### PR TITLE
IDMP-298 - Rename IngredientRole to Ingredient, including its subclasses

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -284,7 +284,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<rdfs:label>Amlodipine EMC constituency</rdfs:label>
-		<idmp-mprd:hasActiveIngredientRole rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateAsActiveIngredientInAmlodipineEMC"/>
+		<idmp-mprd:hasActiveIngredient rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateAsActiveIngredientInAmlodipineEMC"/>
 		<cmns-dsg:defines rdf:resource="&idmp-amp;AmlodipineEMC"/>
 	</owl:NamedIndividual>
 	
@@ -464,7 +464,7 @@
 		<rdfs:label>Norvasc constituency</rdfs:label>
 		<skos:definition>constituency of the pharmaceutical product that is a besylate salt of amlodipine</skos:definition>
 		<skos:note>NORVASC (amlodipine besylate) Tablets are formulated as white tablets equivalent to 2.5, 5, and 10 mg of amlodipine for oral administration. In addition to the active ingredient, amlodipine besylate, each tablet contains the following inactive ingredients: microcrystalline cellulose, dibasic calcium phosphate anhydrous, sodium starch glycolate, and magnesium stearate.</skos:note>
-		<idmp-mprd:hasActiveIngredientRole rdf:resource="&idmp-amp;AmlodipineBesylateAsActiveIngredientInNorvasc"/>
+		<idmp-mprd:hasActiveIngredient rdf:resource="&idmp-amp;AmlodipineBesylateAsActiveIngredientInNorvasc"/>
 		<cmns-dsg:defines rdf:resource="&idmp-amp;Norvasc"/>
 	</owl:NamedIndividual>
 	

--- a/EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf
+++ b/EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf
@@ -109,15 +109,15 @@
 		<cmns-col:comprises rdf:resource="&idmp-euctr;Aliskiren"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumHydroxideAsActiveIngredientRole">
+	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumHydroxideAsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
-		<rdfs:label>aluminum hydroxide in a role as an active ingredient</rdfs:label>
+		<rdfs:label>aluminum hydroxide as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/bba69d15-f55c-4f0d-8e24-e61b60f2a115"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumPhosphateAsActiveIngredientRole">
+	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumPhosphateAsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
-		<rdfs:label>Aluminum Phosphate in a role as an active ingredient</rdfs:label>
+		<rdfs:label>Aluminum Phosphate as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/beaecfe8-eccb-44ab-b842-ae2cc60ff3e4"/>
 	</owl:NamedIndividual>
 	
@@ -190,7 +190,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;EngerixBPharmaceuticalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
 		<rdfs:label>Engerix B PP</rdfs:label>
-		<cmns-col:comprises rdf:resource="&idmp-euctr;AluminumHydroxideAsActiveIngredientRole"/>
+		<cmns-col:comprises rdf:resource="&idmp-euctr;AluminumHydroxideAsActiveIngredient"/>
 		<cmns-col:comprises rdf:resource="&idmp-euctr;HepatitisBSurfaceAntigenAsActiveIngredient"/>
 	</owl:NamedIndividual>
 	
@@ -240,7 +240,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;FendrixPharmaceuticalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
 		<rdfs:label>Fendrix suspension For injection in pre-filled syringe PP</rdfs:label>
-		<cmns-col:comprises rdf:resource="&idmp-euctr;AluminumPhosphateAsActiveIngredientRole"/>
+		<cmns-col:comprises rdf:resource="&idmp-euctr;AluminumPhosphateAsActiveIngredient"/>
 		<cmns-col:comprises rdf:resource="&idmp-euctr;HepatitisBSurfaceAntigenAsActiveIngredient"/>
 		<cmns-col:comprises rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/EuropeanUnionClinicalTrialsRegister/MonophosphorylLipidA-1-3-O-desacyl-4&apos;AsActiveIngredient"/>
 	</owl:NamedIndividual>
@@ -258,7 +258,7 @@
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;HepatitisBSurfaceAntigenAsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
-		<rdfs:label>hepatitis B surface antigen in a role as an active ingredient</rdfs:label>
+		<rdfs:label>hepatitis B surface antigen as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/e67c9314-1e17-4876-a745-47f27c2169e6"/>
 	</owl:NamedIndividual>
 	
@@ -292,7 +292,7 @@
 	
 	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/EuropeanUnionClinicalTrialsRegister/MonophosphorylLipidA-1-3-O-desacyl-4&apos;AsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
-		<rdfs:label>1-3-O-desacyl-4&apos; monophosphoryl lipid A in a role as an active ingredient</rdfs:label>
+		<rdfs:label>1-3-O-desacyl-4&apos; monophosphoryl lipid A as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/c9925b82-5d36-4e00-b54d-d3b7189625de"/>
 	</owl:NamedIndividual>
 	

--- a/EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf
+++ b/EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf
@@ -66,7 +66,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20220901/Examples/EuropeanUnionClinicalTrialsRegister/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20221101/Examples/EuropeanUnionClinicalTrialsRegister/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -110,13 +110,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumHydroxideAsActiveIngredientRole">
-		<rdf:type rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>aluminum hydroxide in a role as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/bba69d15-f55c-4f0d-8e24-e61b60f2a115"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumPhosphateAsActiveIngredientRole">
-		<rdf:type rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>Aluminum Phosphate in a role as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/beaecfe8-eccb-44ab-b842-ae2cc60ff3e4"/>
 	</owl:NamedIndividual>
@@ -257,7 +257,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;HepatitisBSurfaceAntigenAsActiveIngredient">
-		<rdf:type rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>hepatitis B surface antigen in a role as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/e67c9314-1e17-4876-a745-47f27c2169e6"/>
 	</owl:NamedIndividual>
@@ -291,7 +291,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/EuropeanUnionClinicalTrialsRegister/MonophosphorylLipidA-1-3-O-desacyl-4&apos;AsActiveIngredient">
-		<rdf:type rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>1-3-O-desacyl-4&apos; monophosphoryl lipid A in a role as an active ingredient</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/c9925b82-5d36-4e00-b54d-d3b7189625de"/>
 	</owl:NamedIndividual>

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -93,7 +93,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20220901/Examples/TerlipressinExample/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20221101/Examples/TerlipressinExample/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -145,7 +145,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateAsActiveIngredientInTerlipressinAcetateSUN">
-		<rdf:type rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>terlipressin acetate as active ingredient in terlipressin acetate SUN</rdfs:label>
 		<skos:definition>terlipressin acetate in the role of an active ingredient in terlipressin acetate SUN solution for injection</skos:definition>
 		<idmp-mprd:hasBasisOfStrengthAsManufactured rdf:resource="&idmp-trlp;TerlipressinAcetateStrengthAsManufacturedInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -271,7 +271,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjectionConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<rdfs:label>terlipressin acetate SUN 0.12 mg/ml solution for injection constituency</rdfs:label>
-		<idmp-mprd:hasIngredientRole rdf:resource="&idmp-trlp;TerlipressinAsReferenceStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
+		<idmp-mprd:hasIngredient rdf:resource="&idmp-trlp;TerlipressinAsReferenceStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
 		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjection"/>
 		<cmns-rga:isApplicableInJurisdiction rdf:resource="&lcc-3166-1;UnitedKingdomOfGreatBritainAndNorthernIreland"/>
 	</owl:NamedIndividual>
@@ -279,7 +279,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSUNConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<rdfs:label>terlipressin acetate SUN constituency</rdfs:label>
-		<idmp-mprd:hasActiveIngredientRole rdf:resource="&idmp-trlp;TerlipressinAcetateAsActiveIngredientInTerlipressinAcetateSUN"/>
+		<idmp-mprd:hasActiveIngredient rdf:resource="&idmp-trlp;TerlipressinAcetateAsActiveIngredientInTerlipressinAcetateSUN"/>
 		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinAcetateSUN"/>
 	</owl:NamedIndividual>
 	
@@ -418,7 +418,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinSUN0.1MgPerMlSolutionForInjectionConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<rdfs:label>terlipressin SUN 0.1 mg/ml solution for injection constituency</rdfs:label>
-		<idmp-mprd:hasIngredientRole rdf:resource="&idmp-trlp;TerlipressinAsReferenceStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
+		<idmp-mprd:hasIngredient rdf:resource="&idmp-trlp;TerlipressinAsReferenceStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
 		<idmp-mprd:hasReferenceSubstance rdf:resource="&idmp-trlp;Terlipressin"/>
 		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinSUN0.1MgPerMlSolutionForInjection"/>
 		<cmns-rga:isApplicableInJurisdiction rdf:resource="&lcc-3166-1;Netherlands"/>
@@ -435,7 +435,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinSUN1MgSolutionForInjectionConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<rdfs:label>terlipressin SUN 1 mg solution for injection constituency</rdfs:label>
-		<idmp-mprd:hasIngredientRole rdf:resource="&idmp-trlp;TerlipressinAsReferenceStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
+		<idmp-mprd:hasIngredient rdf:resource="&idmp-trlp;TerlipressinAsReferenceStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
 		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinSUN1MgSolutionForInjection"/>
 		<cmns-rga:isApplicableInJurisdiction rdf:resource="&lcc-3166-1;Sweden"/>
 	</owl:NamedIndividual>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -85,7 +85,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11238-Substances/"/>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-Substances.rdf version of this ontology was modified to rename &apos;ingredient role&apos; to ingredient for clarification per discussion at the Pistoia Alliance Conference on 3 November 2022.</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-Substances.rdf version of this ontology was modified to rename &apos;ingredient role&apos; to ingredient for clarification per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -102,12 +102,17 @@
 		<skos:note>An acid is also defined in CHEBI as a molecular entity capable of donating a hydron (Bronsted acid) or capable of forming a covalent bond with an electron pair (Lewis acid).</skos:note>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;ActiveIngredientRole">
+	<owl:Class rdf:about="&idmp-sub;ActiveIngredient">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Ingredient"/>
-		<rdfs:label>active ingredient role</rdfs:label>
+		<rdfs:label>active ingredient</rdfs:label>
 		<skos:definition>role of a substance present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients</skos:definition>
 		<cmns-av:adaptedFrom>Inxight Drugs, Natonal Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
-		<cmns-av:synonym>active pharmacological ingredient [role]</cmns-av:synonym>
+		<cmns-av:synonym>active pharmacological ingredient</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;ActiveIngredientRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-sub;ActiveIngredient"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ActiveMoietyRole">
@@ -120,13 +125,20 @@
 		<cmns-av:adaptedFrom>Inxight Drugs, Natonal Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;AdjuvantRole">
+	<owl:Class rdf:about="&idmp-sub;Adjuvant">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Ingredient"/>
-		<rdfs:label>adjuvant role</rdfs:label>
+		<rdfs:label>adjuvant</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1</dct:source>
 		<rdfs:seeAlso rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C2140"/>
 		<skos:definition>pharmacological role of a component that potentiates the immune response to an antigen and/or modulates it towards the desired immune response</skos:definition>
 		<skos:note>An adjuvant is an agent that enhances the activity or therapeutic effect of another pharmacologic substance without having much, if any, therapeutic impact by itself.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NamingConformant"/>
+		<cmns-av:explanatoryNote>An adjuvant is defined as a component of a mixture in the ISO 11238 standard rather than as a role that such a component plays, thus this definition is non-conformant.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;AdjuvantRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-sub;Adjuvant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Base">
@@ -234,13 +246,20 @@
 		<skos:note>Esters are compounds derived from organic or inorganic acids in which at least one hydroxyl group is replaced by an -O-alkyl or another organic group. They can be represented by the structure formula RCOOR&apos; and are usually formed by the reaction between an acid and an alcohol with elimination of water.</skos:note>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;ExcipientRole">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;InactiveIngredientRole"/>
-		<rdfs:label>excipient role</rdfs:label>
+	<owl:Class rdf:about="&idmp-sub;Excipient">
+		<rdfs:subClassOf rdf:resource="&idmp-sub;InactiveIngredient"/>
+		<rdfs:label>excipient</rdfs:label>
 		<dct:source>Chemical Entities of Biological Interest Ontology, see http://purl.obolibrary.org/obo/CHEBI_75324</dct:source>
 		<skos:definition>pharmacological role of a generally pharmacologically inactive substance that is formulated with the active ingredient of a medication</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;DefinitionallyConformant"/>
+		<cmns-av:explanatoryNote>An excipient is not explicitly defined in the ISO 11238 standard (although clause 8.5 states that an excipient is a non-active ingredient intended to be used in the medicinal product), which this definition conforms with although it is modeled as a role in this ontology.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>bulking agent</cmns-av:synonym>
 		<cmns-av:synonym>filler</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;ExcipientRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-sub;Excipient"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Hydrate">
@@ -264,12 +283,17 @@
 		<skos:definition>set of controlled vocabularies and codes for reporting of substance-related information specified in the ISO/TS 19844 guidelines</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&idmp-sub;InactiveIngredientRole">
+	<owl:Class rdf:about="&idmp-sub;InactiveIngredient">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Ingredient"/>
-		<rdfs:label>inactive ingredient role</rdfs:label>
+		<rdfs:label>inactive ingredient</rdfs:label>
 		<skos:definition>role of an ingredient of a given formulation (most frequently, an excipient) that does not exhibit pharmacological activity</skos:definition>
 		<cmns-av:adaptedFrom>Inxight Drugs, Natonal Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Substances are classified based on their effect on disease progression for a specific disease or condition. In this case, a condition is only related to such compound via the formulation used to affect (treat or diagnose) this condition.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;InactiveIngredientRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-sub;InactiveIngredient"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;InactiveMoietyRole">
@@ -298,8 +322,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>ingredient</rdfs:label>
 		<skos:definition>substance role that is specifically part of or used in the preparation of some manufactured item, pharmaceutical product, medication, or drug</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NonConformant"/>
-		<cmns-av:explantoryNote>An ingredient is defined as a material in the ISO 11238 standard rather than as a role, thus this definition is non-conformant.</cmns-av:explantoryNote>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NamingConformant"/>
+		<cmns-av:explanatoryNote>An ingredient is defined as a material in the ISO 11238 standard rather than as a role, thus this definition is non-conformant.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>pharmacological role</cmns-av:synonym>
 	</owl:Class>
 	

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -17,6 +17,7 @@
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
+	<!ENTITY idmp-cmpl "https://spec.pistoiaalliance.org/idmp/ontology/META/ISOConformanceAnnotations/">
 	<!ENTITY idmp-dtp "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/">
 	<!ENTITY idmp-sub "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/">
 	<!ENTITY idmp-uom "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/">
@@ -46,6 +47,7 @@
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
+	xmlns:idmp-cmpl="https://spec.pistoiaalliance.org/idmp/ontology/META/ISOConformanceAnnotations/"
 	xmlns:idmp-dtp="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"
 	xmlns:idmp-sub="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/"
 	xmlns:idmp-uom="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/"
@@ -64,6 +66,7 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
+		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ISOConformanceAnnotations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
@@ -81,7 +84,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-Substances/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11238-Substances/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-Substances.rdf version of this ontology was modified to rename &apos;ingredient role&apos; to ingredient for clarification per discussion at the Pistoia Alliance Conference on 3 November 2022.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -99,7 +103,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ActiveIngredientRole">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;IngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;Ingredient"/>
 		<rdfs:label>active ingredient role</rdfs:label>
 		<skos:definition>role of a substance present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients</skos:definition>
 		<cmns-av:adaptedFrom>Inxight Drugs, Natonal Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
@@ -117,7 +121,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;AdjuvantRole">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;IngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;Ingredient"/>
 		<rdfs:label>adjuvant role</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1</dct:source>
 		<rdfs:seeAlso rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C2140"/>
@@ -261,7 +265,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;InactiveIngredientRole">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;IngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;Ingredient"/>
 		<rdfs:label>inactive ingredient role</rdfs:label>
 		<skos:definition>role of an ingredient of a given formulation (most frequently, an excipient) that does not exhibit pharmacological activity</skos:definition>
 		<cmns-av:adaptedFrom>Inxight Drugs, Natonal Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
@@ -277,7 +281,7 @@
 		<cmns-av:adaptedFrom>Inxight Drugs, Natonal Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;IngredientRole">
+	<owl:Class rdf:about="&idmp-sub;Ingredient">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;SubstanceRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -292,9 +296,16 @@
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>ingredient role</rdfs:label>
-		<skos:definition>role played by a substance that is specifically part of or used in the preparation of some manufactured item, or pharmaceutical product, medication, or drug</skos:definition>
+		<rdfs:label>ingredient</rdfs:label>
+		<skos:definition>substance role that is specifically part of or used in the preparation of some manufactured item, pharmaceutical product, medication, or drug</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NonConformant"/>
+		<cmns-av:explantoryNote>An ingredient is defined as a material in the ISO 11238 standard rather than as a role, thus this definition is non-conformant.</cmns-av:explantoryNote>
 		<cmns-av:synonym>pharmacological role</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;IngredientRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-sub;Ingredient"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ManufacturedItem">
@@ -1147,7 +1158,7 @@
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&idmp-sub;IngredientRole">
+							<rdf:Description rdf:about="&idmp-sub;Ingredient">
 							</rdf:Description>
 							<rdf:Description rdf:about="&idmp-sub;MoietyRole">
 							</rdf:Description>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -987,11 +987,16 @@
 		<skos:definition>assesses the nature, quality, or ability of someone or something</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&idmp-mprd;hasActiveIngredientRole">
-		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasIngredientRole"/>
-		<rdfs:label>has active ingredient role</rdfs:label>
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasActiveIngredient">
+		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasIngredient"/>
+		<rdfs:label>has active ingredient</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-sub;ActiveIngredient"/>
-		<skos:definition>relates the constituency representing the contituents of a pharmaceutical or medicinal product to something in the role of an active ingredient</skos:definition>
+		<skos:definition>relates something representing the contituents of a pharmaceutical or medicinal product to something in the role of an active ingredient</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasActiveIngredientRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasActiveIngredient"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasAuthorization">
@@ -1025,16 +1030,21 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasBasisOfStrengthAsManufactured">
-		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasActiveIngredientRole"/>
+		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasActiveIngredient"/>
 		<rdfs:label>has basis of strength as manufactured</rdfs:label>
 		<skos:definition>indicates the role of an active ingredient as the basis of strength of any substance or pharmaceutical product as manufactured</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredient">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasRole"/>
-		<rdfs:label>has ingredient role</rdfs:label>
+		<rdfs:label>has ingredient</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-sub;Ingredient"/>
-		<skos:definition>relates the constituency representing the contituents of a pharmaceutical or medicinal product to something in the role of an ingredient</skos:definition>
+		<skos:definition>relates something representing the contituents of a pharmaceutical or medicinal product to something in the role of an ingredient</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasIngredient"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasReferenceStrength">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -82,13 +82,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11615-MedicinalProducts/"/>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference on 3 November 2022.</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&idmp-sub;ActiveIngredientRole">
+	<owl:Class rdf:about="&idmp-sub;ActiveIngredient">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasReferenceSubstance"/>
@@ -109,7 +109,7 @@
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.80</dct:source>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;AdjuvantRole">
+	<owl:Class rdf:about="&idmp-sub;Adjuvant">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
@@ -119,7 +119,7 @@
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.1</dct:source>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;InactiveIngredientRole">
+	<owl:Class rdf:about="&idmp-sub;InactiveIngredient">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
@@ -217,7 +217,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActiveIngredientActiveMoietyBasisOfStrength">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveMoietyRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -239,7 +239,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActiveIngredientEntireSubstanceBasisOfStrength">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
@@ -259,7 +259,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActiveIngredientReferenceSubstanceBasisOfStrength">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
@@ -285,7 +285,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActiveIngredientWithoutBasisOfStrength">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
@@ -990,7 +990,7 @@
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasActiveIngredientRole">
 		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasIngredientRole"/>
 		<rdfs:label>has active ingredient role</rdfs:label>
-		<rdfs:range rdf:resource="&idmp-sub;ActiveIngredientRole"/>
+		<rdfs:range rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<skos:definition>relates the constituency representing the contituents of a pharmaceutical or medicinal product to something in the role of an active ingredient</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -81,7 +81,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11615-MedicinalProducts/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference on 3 November 2022.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -127,24 +128,18 @@
 		</rdfs:subClassOf>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;IngredientRole">
+	<owl:Class rdf:about="&idmp-sub;Ingredient">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasStrength"/>
-				<owl:onClass rdf:resource="&idmp-mprd;Strength"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onProperty rdf:resource="&cmns-pts;isManifestedIn"/>
+				<owl:onClass rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-pts;isPlayedBy"/>
-				<owl:onClass>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-col;isIncludedIn"/>
-						<owl:onClass rdf:resource="&idmp-sub;ManufacturedItem"/>
-						<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-					</owl:Restriction>
-				</owl:onClass>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasStrength"/>
+				<owl:onClass rdf:resource="&idmp-mprd;Strength"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -166,6 +161,12 @@
 				<owl:onProperty rdf:resource="&idmp-mprd;isAllergenic"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-pts;isManifestedIn"/>
+				<owl:someValuesFrom rdf:resource="&idmp-sub;ManufacturedItem"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clauses 3.1.28 and 9.7, Figure 12</dct:source>
@@ -583,7 +584,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;IngredientRole"/>
+				<owl:someValuesFrom rdf:resource="&idmp-sub;Ingredient"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>ingredient role code</rdfs:label>
@@ -848,7 +849,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-pts;hasRole"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;IngredientRole"/>
+				<owl:someValuesFrom rdf:resource="&idmp-sub;Ingredient"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product constituency</rdfs:label>
@@ -1032,7 +1033,7 @@
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasRole"/>
 		<rdfs:label>has ingredient role</rdfs:label>
-		<rdfs:range rdf:resource="&idmp-sub;IngredientRole"/>
+		<rdfs:range rdf:resource="&idmp-sub;Ingredient"/>
 		<skos:definition>relates the constituency representing the contituents of a pharmaceutical or medicinal product to something in the role of an ingredient</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/ISO/ISO11616-PharmaceuticalProducts.rdf
+++ b/ISO/ISO11616-PharmaceuticalProducts.rdf
@@ -63,13 +63,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20220801/ISO11616-PharmaceuticalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11616-PharmaceuticalProducts/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11616-PharmaceuticalProducts.rdf version of this ontology was modified to rename &apos;adjuvant role&apos;s to adjuvant for clarification per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Preliminary"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&idmp-sub;AdjuvantRole">
+	<owl:Class rdf:about="&idmp-sub;Adjuvant">
 		<dct:source>ISO 11616:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated pharmaceutical product information, clause 3.1.1</dct:source>
 	</owl:Class>
 	

--- a/META/ISOConformanceAnnotations.rdf
+++ b/META/ISOConformanceAnnotations.rdf
@@ -31,7 +31,8 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/20221001/ISOConformanceAnnotations/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/20221101/ISOConformanceAnnotations/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISOConformanceAnnotations.rdf version of this ontology was modified to add a distinct conformance level for name and annotations, including the definition, in contrast with naming conformance, which means that the concept has the same name as something in an ISO standard but not the same meaning.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -63,11 +64,18 @@
 		<cmns-av:explanatoryNote xml:lang="en">There are various cases in the ontologies where a given element will be modeled as a text value with some ISO 21090 Harmonized Datatype encoding, whereas we have modeled it as a named individual with additional semantics in the ontology. A class that in other aspects is modeled as defined in the relevant ISO IDMP specifications that has a relationships with this individual rather than having a text attribute for it would be considered model conformant.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;NameAndAnnotationConformant">
+		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
+		<rdfs:label>name and annotation conformant</rdfs:label>
+		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to its name, definition and other annotations, but may not be conformant with respect to how it is modeled</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">There are various cases in the ontologies where a given element will be modeled as a class, similarly to what is in the ISO IDMP standard, but whose relationships are specified differently. This may be because of inheritance via the patterns we have implemented, the use of restrictions, or other variations with respect to the modeling approach taken. Other cases include concepts that are modeled as roles in the ontology but as classes or properties in the IDMP standard.</cmns-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-cmpl;NamingConformant">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
 		<rdfs:label>naming conformant</rdfs:label>
-		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to its name, definition and other annotations, but may not be conformant with respect to how it is modeled</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">There are various cases in the ontologies where a given element will be modeled as a class, similarly to what is in the ISO IDMP standard, but whose relationships are specified differently. This may be because of inheritance via the patterns we have implemented, the use of restrictions, or other variations with respect to the modeling approach taken. Other cases include concepts that are modeled as roles in the ontology but as classes or properties in the IDMP standard.</cmns-av:explanatoryNote>
+		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to its name, and possibly other annotations, but not in terms of its definition or with respect to how it is modeled</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">One such case identified shortly after the initial 0.1 version of the ontology was released is the concept &apos;ingredient&apos;, which is modeled as a role rather than as a subclass of material and where the definition in ISO 11238 is distinct from the definition in the ontology.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-cmpl;NonConformant">

--- a/etc/CQ/Example/cq7.sparql
+++ b/etc/CQ/Example/cq7.sparql
@@ -24,7 +24,7 @@ WHERE {
   
   	# product constituency link substance in ingredient roles to the pharmaceutical product
   	?productConstituency cmns-dsg:defines ?pharmaceuticalProduct .
-  	?productConstituency idmp-mprd:hasActiveIngredientRole ?substanceInActiveIngredientRole .
+  	?productConstituency idmp-mprd:hasActiveIngredient ?substanceInActiveIngredientRole .
   	
   	# Substance in that Role of active ingredient
   	?substanceInActiveIngredientRole cmns-pts:isPlayedBy ?substance .

--- a/etc/CQ/Example/cq7.sparql
+++ b/etc/CQ/Example/cq7.sparql
@@ -22,11 +22,11 @@ WHERE {
   	# Find the pharmaceutical products that comprise the manufactured item
 	?manufacturedItem cmns-col:comprises ?pharmaceuticalProduct .
   
-  	# product constituency link substance in ingredient roles to the pharmaceutical product
+  	# product constituency link substance as an ingredient to the pharmaceutical product
   	?productConstituency cmns-dsg:defines ?pharmaceuticalProduct .
-  	?productConstituency idmp-mprd:hasActiveIngredient ?substanceInActiveIngredientRole .
+  	?productConstituency idmp-mprd:hasActiveIngredient ?substanceInActiveIngredient .
   	
-  	# Substance in that Role of active ingredient
-  	?substanceInActiveIngredientRole cmns-pts:isPlayedBy ?substance .
+  	# Substance as an active ingredient
+  	?substanceInActiveIngredient cmns-pts:isPlayedBy ?substance .
   	?substance rdfs:label  ?substanceLabel .
 }

--- a/etc/CQ/cq7.sparql
+++ b/etc/CQ/cq7.sparql
@@ -23,7 +23,7 @@ WHERE {
   
   	# product constituency link substance in ingredient roles to the pharmaceutical product
   	?productConstituency cmns-dsg:defines ?pharmaceuticalProduct .
-  	?productConstituency idmp-mprd:hasActiveIngredientRole ?substanceInActiveIngredientRole .
+  	?productConstituency idmp-mprd:hasActiveIngredient ?substanceInActiveIngredientRole .
   	
   	# Substance in that Role of active ingredient
   	?substanceInActiveIngredientRole cmns-pts:isPlayedBy ?substance .


### PR DESCRIPTION
This resolution makes the following updates to the released, provisional, and informative ontologies:

1. Adds a distinct conformance level for name and annotations, including the definition, in contrast with naming conformance, which means that the concept has the same name as something in an ISO standard but not the same meaning.
2. Renames IngredientRole to Ingredient, including its subclasses ('active ingredient role' --> 'active ingredient', 'inactive ingredient role' --> 'inactive ingredient', 'adjuvant role' --> adjuvant, 'excipient role' --> excipient) and deprecates the original classes, making them equivalent to the new ones
3. Updates the examples that were impacted accordingly