### PR TITLE
IDMP-GitHub-249 - Wrong versionIRI in ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities.rdf

### DIFF
--- a/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities.rdf
+++ b/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities.rdf
@@ -66,7 +66,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/EuropeanJurisdiction/EuropeanRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/EuropeanJurisdiction/EuropeanRegistrationAuthorities/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>


### PR DESCRIPTION
Description: Corrected versionIRI on European Registration Authorities ontology

Signed-off-by: Elisa Kendall <ekendall@thematix.com>