### PR TITLE
IDMP-390 - Add annotations to suggest changes to definitions that are needed in the IDMP standard

### DIFF
--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -133,7 +133,7 @@
 		<rdfs:seeAlso rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C2140"/>
 		<skos:definition>pharmacological role of a component that potentiates the immune response to an antigen and/or modulates it towards the desired immune response</skos:definition>
 		<skos:note>An adjuvant is an agent that enhances the activity or therapeutic effect of another pharmacologic substance without having much, if any, therapeutic impact by itself.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NamingConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
 		<cmns-av:explanatoryNote>An adjuvant is defined as a component of a mixture in the ISO 11238 standard rather than as a role that such a component plays, thus this definition is non-conformant.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -252,7 +252,7 @@
 		<rdfs:label>excipient</rdfs:label>
 		<dct:source>Chemical Entities of Biological Interest Ontology, see http://purl.obolibrary.org/obo/CHEBI_75324</dct:source>
 		<skos:definition>pharmacological role of a generally pharmacologically inactive substance that is formulated with the active ingredient of a medication</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;DefinitionallyConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:explanatoryNote>An excipient is not explicitly defined in the ISO 11238 standard (although clause 8.5 states that an excipient is a non-active ingredient intended to be used in the medicinal product), which this definition conforms with although it is modeled as a role in this ontology.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>bulking agent</cmns-av:synonym>
 		<cmns-av:synonym>filler</cmns-av:synonym>
@@ -323,9 +323,9 @@
 		</rdfs:subClassOf>
 		<rdfs:label>ingredient</rdfs:label>
 		<skos:definition>substance role that is specifically part of or used in the preparation of some manufactured item, pharmaceutical product, medication, or drug</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NamingConformant"/>
-		<cmns-av:explanatoryNote>An ingredient is defined as a material in the ISO 11238 standard rather than as a role, thus this definition is non-conformant.</cmns-av:explanatoryNote>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
 		<cmns-av:synonym>pharmacological role</cmns-av:synonym>
+		<cmns-av:usageNote>An ingredient is defined as a material in the ISO 11238 standard rather than as a role, which would make the model inconsistent. Thus this concept is consistent in terms of its name but not in terms of its definition.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;IngredientRole">
@@ -402,7 +402,7 @@
 	<owl:Class rdf:about="&idmp-sub;Matter">
 		<rdfs:label>matter</rdfs:label>
 		<skos:definition>something that has mass and occupies space by virtue of having volume</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NonConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.41</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Note that the concept of &apos;matter&apos; is used in the definition of substance but not explicitly defined in the IDMP standards. The definition of &apos;material&apos; is close, but adds the notion of consisting of one or more substances, thus this term generalizes both material and substance.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -1114,9 +1114,10 @@
 		<rdfs:label>structure</rdfs:label>
 		<skos:definition>arrangement and organization of interrelated elements in a material object or system</skos:definition>
 		<skos:note>Material structures include man-made objects such as buildings and machines and natural objects such as biological organisms, minerals and chemicals.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NonConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clauses 3.49, 7.2.1</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>Note that the term &apos;structure&apos; is not explicitly defined in the standard, but molecular structure is defined using this concept.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>Note that the term &apos;structure&apos; is not explicitly defined in the standard, but molecular structure is defined using this concept, and the concept appears in various UML diagrams in the standard.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Substance">
@@ -1146,9 +1147,9 @@
 		<skos:note>A substance can be a moiety. A moiety is an entity within a substance that has a complete and continuous molecular structure. The strength of a pharmaceutical product is often based on what is referred to as the active moiety of the molecule, responsible for the physiological or pharmacological action of the drug substance. Chemically, the active moiety of a stoichiometric or non-stoichoimetrical substance molecule is considered that part of the molecule that is the base, free acid or ion molecular part of a salt, solvate, chelate, clathrate, molecular complex or ester.</skos:note>
 		<skos:note>Discrete existence refers to the ability of a substance to exist independently of any other substance. Substances can either be well-defined entities containing definite chemical structures, synthetic (e.g. isomeric mixtures) or naturally-occurring (e.g. conjugated oestrogens) mixtures of chemicals containing definite molecular structures, or materials derived from plants, animals, microorganisms or inorganic matrices for which the chemical structure may be unknown or difficult to define.</skos:note>
 		<skos:note>Substances are further described as single substances, mixture substances or one of a group of specified substances. Single substances are defined using a minimally sufficient set of data elements divided into five types: chemical, protein, nucleic acid, polymer and structurally diverse. Substances may be salts, solvates, free acids, free bases or mixtures of related compounds that are either isolated or synthesized together. Pharmacopoeial terminology and defining characteristics will be used when available and appropriate. Defining elements are dependent on the type of substance.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NameAndAnnotationConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.84</cmns-av:directSource>
-		<cmns-av:explanatoryNote>Note that while the IDMP standards require a substance name for all substances, the ontology deviates from this by making the name optional in the restriction on substance. This is to enable mapping to various source repositories for substance information that do not necessarily provide names but that define a substance based on its molecular structure, which is far more accurate.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that while the IDMP standards require a substance name for all substances, the ontology deviates from this by making the name optional in the restriction on substance. This is to enable mapping to various source repositories for substance information that do not necessarily provide names but that define a substance based on its molecular structure, which is typically more accurate.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceCode">
@@ -1711,8 +1712,8 @@
 		<idmp-sub:hasBusinessRules>Mandatory all substances shall have at least one name or company code (also considered to be a Substance Name) associated with the substance.</idmp-sub:hasBusinessRules>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
 		<idmp-sub:hasValuesAllowed>Free text, multiple names allowed, each in its own element.</idmp-sub:hasValuesAllowed>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NameAndAnnotationConformant"/>
-		<cmns-av:explanatoryNote>Note that while the IDMP standards require a substance name for all substances, the ontology deviates from this by making the name optional in the restriction on substance. This is to enable mapping to various source repositories for substance information that do not necessarily provide names but that define a substance based on its molecular structure, which is far more accurate.</cmns-av:explanatoryNote>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
+		<cmns-av:explanatoryNote>Note that while the IDMP standards require a substance name for all substances, the ontology deviates from this by making the name optional in the restriction on substance. This is to enable mapping to various source repositories for substance information that do not necessarily provide names but that define a substance based on its molecular structure, which is typically more accurate.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasSubstanceNameType">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -451,10 +451,10 @@
 	<owl:Class rdf:about="&idmp-mprd;Container">
 		<rdfs:label>container</rdfs:label>
 		<skos:definition>object that can be used to hold things</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;NamingConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.16</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>https://ncithesaurus.nci.nih.gov/ncitbrowser/pages/home.jsf</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>The ISO 11615 definition for &apos;container&apos; is too specific to be a generalization of some of its subordinate concepts, such as intermediate container and other packaging related concepts.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>The ISO 11615 definition for &apos;container&apos; is too specific to be a generalization of some of its subordinate concepts, such as intermediate container and other packaging related concepts.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-mprd;ISO20443-CodeSet">
@@ -830,9 +830,10 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>medicinal product container</rdfs:label>
-		<skos:definition>medicinal product container that is part of a medicinal product and is used for storage, identification and/or transport of the components of the medicinal product</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;DefinitionallyConformant"/>
+		<skos:definition>container that is part of a medicinal product and is used for storage, identification and/or transport of the components of the medicinal product</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.16</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>In the ISO 11615 standard, the term container was used more generally and in some cases more specifically. This concept, medicinal product container, was added with the original definition for container in the IDMP standard in order to differentiate the two concepts and enable proper representation of some of the more specific kinds of containers included in the standard.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicinalProductIdentifier">

--- a/META/ISOConformanceAnnotations.rdf
+++ b/META/ISOConformanceAnnotations.rdf
@@ -31,8 +31,8 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/20221101/ISOConformanceAnnotations/"/>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISOConformanceAnnotations.rdf version of this ontology was modified to add a distinct conformance level for name and annotations, including the definition, in contrast with naming conformance, which means that the concept has the same name as something in an ISO standard but not the same meaning.</skos:changeNote>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/20221201/ISOConformanceAnnotations/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISOConformanceAnnotations.rdf version of this ontology was modified to add a distinct conformance level for name and annotations, including the definition, in contrast with naming conformance, which means that the concept has the same name as something in an ISO standard but not the same meaning. Two additional annotations were also included, one to say that while the ontology conforms with the definition in the standard, that definition needs clarification, and a second one to identify elements that have been added as extensions that are needed to fill gaps in the standard. These additions are not necessarily non-conformant but should be considered as additions when the standard is revised. We also changed the names of the individuals to include the class name, ConformanceToISOLevel, as a prefix in the individual name to ensure uniqueness.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -44,45 +44,58 @@
 		<skos:definition>classifier used to indicate the representational conformance of element with respect to the ISO IDMP standard(s) it is derived from</skos:definition>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&idmp-cmpl;Conformant">
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-Conformant">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
-		<rdfs:label>conformant</rdfs:label>
+		<rdfs:label>conformance to ISO level - conformant</rdfs:label>
 		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual, including but not limited to the way it is modeled, its naming, annotations, and relationships</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-cmpl;DefinitionallyConformant">
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
-		<rdfs:label>definitionally conformant</rdfs:label>
+		<rdfs:label>conformance to ISO level - definitionally conformant</rdfs:label>
 		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to its definition and other annotations, but may not be conformant with respect to how it is named or otherwise modeled</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">Definitionally conformant elements will have annotations corresponding to what is in the ISO IDMP standard but be named and modeled differently. Examples include elements that are modeled as classes in the IDMP standard but as properties in the ontology, so the name has been rephrased as a verb or verb phrase.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-cmpl;ModelConformant">
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-Extension">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
-		<rdfs:label>model conformant</rdfs:label>
+		<rdfs:label>conformance to ISO level - extension</rdfs:label>
+		<skos:definition xml:lang="en">compliance level indicating that the ontology element extends the existing ISO standard with a concept that is either implied by the specification or fills a gap that was not addressed in the standard</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-ModelConformant">
+		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
+		<rdfs:label>conformance to ISO level - model conformant</rdfs:label>
 		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to how it is modeled, but not necessarily with respect to all of its relationships</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">There are various cases in the ontologies where a given element will be modeled as a text value with some ISO 21090 Harmonized Datatype encoding, whereas we have modeled it as a named individual with additional semantics in the ontology. A class that in other aspects is modeled as defined in the relevant ISO IDMP specifications that has a relationships with this individual rather than having a text attribute for it would be considered model conformant.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-cmpl;NameAndAnnotationConformant">
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
-		<rdfs:label>name and annotation conformant</rdfs:label>
+		<rdfs:label>conformance to ISO level - name and annotation conformant</rdfs:label>
 		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to its name, definition and other annotations, but may not be conformant with respect to how it is modeled</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">There are various cases in the ontologies where a given element will be modeled as a class, similarly to what is in the ISO IDMP standard, but whose relationships are specified differently. This may be because of inheritance via the patterns we have implemented, the use of restrictions, or other variations with respect to the modeling approach taken. Other cases include concepts that are modeled as roles in the ontology but as classes or properties in the IDMP standard.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-cmpl;NamingConformant">
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-NamingConformant">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
-		<rdfs:label>naming conformant</rdfs:label>
+		<rdfs:label>conformance to ISO level - naming conformant</rdfs:label>
 		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the corresponding ISO class, property, datatype, or other individual with respect to its name, and possibly other annotations, but not in terms of its definition or with respect to how it is modeled</skos:definition>
 		<cmns-av:explanatoryNote xml:lang="en">One such case identified shortly after the initial 0.1 version of the ontology was released is the concept &apos;ingredient&apos;, which is modeled as a role rather than as a subclass of material and where the definition in ISO 11238 is distinct from the definition in the ontology.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-cmpl;NonConformant">
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-NeedsClarification">
 		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
-		<rdfs:label>non-conformant</rdfs:label>
+		<rdfs:label>conformance to ISO level - needs clarification</rdfs:label>
+		<skos:definition xml:lang="en">compliance level indicating that the ontology element is conformant with the ISO standard but indicates that the standard should be revised in some fashion for clarification purposes</skos:definition>
+		<cmns-av:explanatoryNote xml:lang="en">In this case, a usage note should accompany this annotation to say what exactly needs clarification.</cmns-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-cmpl;ConformanceToISOLevel-NonConformant">
+		<rdf:type rdf:resource="&idmp-cmpl;ConformanceToISOLevel"/>
+		<rdfs:label>conformance to ISO level - non-conformant</rdfs:label>
 		<skos:definition xml:lang="en">compliance level indicating that the ontology element is not conformant with the corresponding ISO class, property, datatype, or other individual</skos:definition>
-		<cmns-av:explanatoryNote xml:lang="en">Non-conformant elements include those that are introduced to fill gaps in the model that are needed in the ontology, and that may be candidates for addition to the IDMP standard at some point.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote xml:lang="en">This annotation should be used when the ontology necessarily differs from the standard in some way due to an inconsistency that would be introduced if it was modeled explicitly as indicated in the UML model, for example. In this case a usage note should be included to state why we believe that the element should be modeled differently.</cmns-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:AnnotationProperty rdf:about="&idmp-cmpl;hasConformanceToISOLevel">


### PR DESCRIPTION
Description: 
(1) augmented the conformance annotations to include extension and needs clarification as triggers for reviewers of the IDMP ISO standards to consider as part of their review process; 
(2) revised the names of the individuals to include the prefix that distinguishes these from other concepts of conformance in the IDMP standards; 
(3) updated the ISO ontologies as appropriate to reflect these changes

Signed-off-by: Elisa Kendall <ekendall@thematix.com>