### PR TITLE
IDMP-391 - The relationship between structure and structural representation should be better defined

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -105,7 +105,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20220901/Examples/AmlodipineExample/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20221201/Examples/AmlodipineExample/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -137,10 +137,15 @@
 		<dct:source rdf:resource="https://www.ebi.ac.uk/chebi/chebiOntology.do?chebiId=CHEBI:2668"/>
 		<skos:definition>fully substituted dialkyl 1,4-dihydropyridine-3,5-dicarboxylate derivative, which is used for the treatment of hypertension, chronic stable angina and confirmed or suspected vasospastic angina</skos:definition>
 		<skos:note>It is a long-acting dihydropyridine calcium channel blocker effective in the treatment of angina pectoris and hypertension.</skos:note>
+		<idmp-sub:hasMolecularFormula>C20H25ClN2O5</idmp-sub:hasMolecularFormula>
+		<idmp-sub:hasMolecularFormulaByMoiety>C20H25ClN2O5</idmp-sub:hasMolecularFormulaByMoiety>
+		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-amp;AmlodipineMolecularWeight"/>
 		<idmp-sub:hasNumberOfMoieties rdf:datatype="&xsd;integer">1</idmp-sub:hasNumberOfMoieties>
+		<idmp-sub:hasStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
 		<idmp-sub:hasStructure rdf:resource="&idmp-amp;AmlodipineMolecularStructure"/>
 		<idmp-sub:isActiveMoietyOf rdf:resource="&idmp-amp;AmlodipineBesylate"/>
 		<idmp-sub:isActiveMoietyOf rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrate"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&idmp-sub;OpticalActivity-EitherDirection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineAsActiveMoiety">
@@ -176,8 +181,13 @@
 		<skos:definition>besylate salt of amlodipine, a long-acting calcium channel blocker</skos:definition>
 		<skos:note>Amlodipine besylate is chemically described as 3-Ethyl-5-methyl (±)-2-[(2-aminoethoxy)methyl]-4-(2-chlorophenyl)-1,4-dihydro-6-methyl-3,5-pyridinedicarboxylate, monobenzenesulphonate. Amlodipine besylate is a white crystalline powder with a molecular weight of 567.1. It is slightly soluble in water and sparingly soluble in ethanol.</skos:note>
 		<idmp-sub:hasActiveMoiety rdf:resource="&idmp-amp;Amlodipine"/>
+		<idmp-sub:hasMolecularFormula>C20H25CIN2O5.C6H6O3S</idmp-sub:hasMolecularFormula>
+		<idmp-sub:hasMolecularFormulaByMoiety>C20H25CIN2O5.C6H6O3S</idmp-sub:hasMolecularFormulaByMoiety>
+		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-amp;AmlodipineBesylateMolecularWeight"/>
 		<idmp-sub:hasNumberOfMoieties rdf:datatype="&xsd;integer">2</idmp-sub:hasNumberOfMoieties>
+		<idmp-sub:hasStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
 		<idmp-sub:hasStructure rdf:resource="&idmp-amp;AmlodipineBesylateMolecularStructure"/>
+		<cmns-cls:isClassifiedBy rdf:resource="&idmp-sub;OpticalActivity-EitherDirection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateAsActiveIngredientInNorvasc">
@@ -210,12 +220,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateMolecularStructure">
 		<rdf:type rdf:resource="&idmp-sub;MolecularStructure"/>
 		<rdfs:label>amlodipine besylate molecular structure</rdfs:label>
-		<idmp-sub:hasMolecularFormula>C20H25CIN2O5.C6H6O3S</idmp-sub:hasMolecularFormula>
-		<idmp-sub:hasMolecularFormulaByMoiety>C20H25CIN2O5.C6H6O3S</idmp-sub:hasMolecularFormulaByMoiety>
-		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-amp;AmlodipineBesylateMolecularWeight"/>
 		<idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification>OS(=O)(=O)C1=CC=CC=C1.CCOC(=O)C2=C(COCCN)NC(C)=C(C2C3=C(Cl)C=CC=C3)C(=O)OC</idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification>
-		<idmp-sub:hasStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
-		<cmns-cls:isClassifiedBy rdf:resource="&idmp-sub;OpticalActivity-EitherDirection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateMolecularWeight">
@@ -319,9 +324,14 @@
 		<skos:definition>mesylate salt of amlodipine, a long-acting calcium channel blocker</skos:definition>
 		<skos:note>Amlodipine mesylate monohydrate is chemically described as 3,5-Pyridinedicarboxylic acid, 2-((2-aminoethoxy)methyl)-4-(2-chlorophenyl)-1,4-dihydro-6-methyl-, 3-ethyl 5-methyl ester, monomethanesulfonate, monohydrate.</skos:note>
 		<idmp-sub:hasActiveMoiety rdf:resource="&idmp-amp;Amlodipine"/>
+		<idmp-sub:hasMolecularFormula>C21H31ClN2O9S</idmp-sub:hasMolecularFormula>
+		<idmp-sub:hasMolecularFormulaByMoiety>C20H25ClN2O5.CH4O3S.H2O</idmp-sub:hasMolecularFormulaByMoiety>
+		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateMolecularWeight"/>
 		<idmp-sub:hasNumberOfMoieties rdf:datatype="&xsd;integer">3</idmp-sub:hasNumberOfMoieties>
+		<idmp-sub:hasStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
 		<idmp-sub:hasStructure rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateMolecularStructure"/>
 		<cmns-av:synonym>amlodipine mesilate monohydrate</cmns-av:synonym>
+		<cmns-cls:isClassifiedBy rdf:resource="&idmp-sub;OpticalActivity-EitherDirection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateAsActiveIngredientInAmlodipineEMC">
@@ -361,12 +371,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateMolecularStructure">
 		<rdf:type rdf:resource="&idmp-sub;MolecularStructure"/>
 		<rdfs:label>amlodipine mesylate monohydrate molecular structure</rdfs:label>
-		<idmp-sub:hasMolecularFormula>C21H31ClN2O9S</idmp-sub:hasMolecularFormula>
-		<idmp-sub:hasMolecularFormulaByMoiety>C20H25ClN2O5.CH4O3S.H2O</idmp-sub:hasMolecularFormulaByMoiety>
-		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateMolecularWeight"/>
 		<idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification>O.CS(O)(=O)=O.CCOC(=O)C1=C(COCCN)NC(C)=C(C1C1=C(Cl)C=CC=C1)C(=O)OC</idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification>
-		<idmp-sub:hasStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
-		<cmns-cls:isClassifiedBy rdf:resource="&idmp-sub;OpticalActivity-EitherDirection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateMolecularWeight">
@@ -404,11 +409,6 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMolecularStructure">
 		<rdf:type rdf:resource="&idmp-sub;MolecularStructure"/>
 		<rdfs:label>amlodipine molecular structure</rdfs:label>
-		<idmp-sub:hasMolecularFormula>C20H25ClN2O5</idmp-sub:hasMolecularFormula>
-		<idmp-sub:hasMolecularFormulaByMoiety>C20H25ClN2O5</idmp-sub:hasMolecularFormulaByMoiety>
-		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-amp;AmlodipineMolecularWeight"/>
-		<idmp-sub:hasStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
-		<cmns-cls:isClassifiedBy rdf:resource="&idmp-sub;OpticalActivity-EitherDirection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMolecularWeight">

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -105,7 +105,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20221101/Examples/TerlipressinExample/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20221201/Examples/TerlipressinExample/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -143,6 +143,9 @@
 		<skos:definition>protein that is an analogue of vasopressin used as a vasoactive drug in the management of low blood pressure</skos:definition>
 		<skos:note>It has been found to be effective when norepinephrine does not help. Indications for use include norepinephrine-resistant septic shock and hepatorenal syndrome. In addition, it is used to treat bleeding esophageal varices.</skos:note>
 		<skos:note>Terlipressin is currently not available in the United States, or Canada, but it is available in New Zealand, Australia, much of Europe, India, Pakistan and UAE.</skos:note>
+		<idmp-sub:hasMolecularFormula>C52H75O15N16S2</idmp-sub:hasMolecularFormula>
+		<idmp-sub:hasMolecularFormulaByMoiety>C52H75O15N16S2</idmp-sub:hasMolecularFormulaByMoiety>
+		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-trlp;TerlipressinMolecularWeight"/>
 		<idmp-sub:hasStructure rdf:resource="&idmp-trlp;TerlipressinMolecularStructure"/>
 		<idmp-sub:isActiveMoietyOf rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
 	</owl:NamedIndividual>
@@ -154,6 +157,9 @@
 		<skos:definition>analogue of vasopressin used as a vasoactive for proteomics research</skos:definition>
 		<skos:note>Synonyms for terlipressin acetate include Gly-Gly-Gly-Cys-Tyr-Phe-Gln-Asn-Cys-Pro-Lys-Gly-Nh2 (4-9 Disulfide) Acetate, and as N-(N-(N-Glycylglycyl)Glycyl)-8-L-Lysinevasopressin Acetate.</skos:note>
 		<idmp-sub:hasActiveMoiety rdf:resource="&idmp-trlp;Terlipressin"/>
+		<idmp-sub:hasMolecularFormula>C56H92N16O24S2</idmp-sub:hasMolecularFormula>
+		<idmp-sub:hasMolecularFormulaByMoiety>C52H74N16O15S2.2C2H4O2.5H2O</idmp-sub:hasMolecularFormulaByMoiety>
+		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-trlp;TerlipressinAcetateMolecularWeight"/>
 		<idmp-sub:hasStructure rdf:resource="&idmp-trlp;TerlipressinAcetateMolecularStructure"/>
 	</owl:NamedIndividual>
 	
@@ -217,9 +223,6 @@
 		<rdf:type rdf:resource="&idmp-sub;MolecularStructure"/>
 		<rdfs:label>terlipressin acetate molecular structure</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://go.drugbank.com/salts/DBSALT002332"/>
-		<idmp-sub:hasMolecularFormula>C56H92N16O24S2</idmp-sub:hasMolecularFormula>
-		<idmp-sub:hasMolecularFormulaByMoiety>C52H74N16O15S2.2C2H4O2.5H2O</idmp-sub:hasMolecularFormulaByMoiety>
-		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-trlp;TerlipressinAcetateMolecularWeight"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateMolecularWeight">
@@ -376,9 +379,6 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinMolecularStructure">
 		<rdf:type rdf:resource="&idmp-sub;MolecularStructure"/>
 		<rdfs:label>terlipressin molecular structure</rdfs:label>
-		<idmp-sub:hasMolecularFormula>C52H75O15N16S2</idmp-sub:hasMolecularFormula>
-		<idmp-sub:hasMolecularFormulaByMoiety>C52H75O15N16S2</idmp-sub:hasMolecularFormulaByMoiety>
-		<idmp-sub:hasMolecularWeight rdf:resource="&idmp-trlp;TerlipressinMolecularWeight"/>
 		<idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification>O=C(N)CNC(=O)[C@@H](NC(=O)[C@H]4N(C(=O)[C@H]1NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)CNC(=O)CNC(=O)CN)CSSC1)Cc2ccc(O)cc2)Cc3ccccc3)CCC(=O)N)CC(=O)N)CCC4)CCCCN</idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification>
 	</owl:NamedIndividual>
 	

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -209,6 +209,7 @@
 		<owl:disjointWith rdf:resource="&idmp-sub;StructurallyDiverseSubstance"/>
 		<skos:definition>single substance that can be described as a stoichiometric or non-stoichiometric single molecular entity and is not a protein, nucleic acid or polymer substance</skos:definition>
 		<skos:note>Chemical substances are generally considered &apos;small&apos; molecules which have associated salts, solvates or ions and may be described using a single definitive or representative structure.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.11</cmns-av:directSource>
 	</owl:Class>
 	
@@ -510,6 +511,7 @@
 		<skos:example>The strength of a medicinal product is often based on what is referred to as the active moiety of the molecule, responsible for the physiological or pharmacological action of the drug substance. To avoid ambiguity, the free acid and/or free base should be used as the moiety upon which strength is based.</skos:example>
 		<skos:note>The active moiety of a stoichiometric or non-stoichiometrical substance molecule is considered that part of the molecule that is the base, free acid or ion molecular part of a salt, solvate, chelate, clathrate, molecular complex or ester.</skos:note>
 		<skos:note>The moiety subclause serves for the description of both the moiety and the other fragment constituting the substance. The Element Group Moiety is attached to the element class Chemical in order to describe a salt, solvate and co-crystal relationship to the active moiety in an unambiguous way with respect to the description of the molecular formula and sometimes the official names. The Element Group Amount is attached to Moiety. This will help to describe salts, solvates, hydrated substances and co-crystallising agents in a more unambiguous way with respect to the description of the molecular formula and sometimes official names. Each moiety within the chemical substance is to be identified and the composition range of the moieties when known is to be provided by means of the following data elements: If the numeric value of the element &apos;Number of Moieties&apos; is equal to 1, the class Moiety should not be used; otherwise the class shall always be mandatory.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.45</cmns-av:directSource>
 	</owl:Class>
 	

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -85,7 +85,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11238-Substances/"/>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-Substances.rdf version of this ontology was modified to rename &apos;ingredient role&apos; to ingredient for clarification per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also modified to add the concept of matter and to add a specific hasSubstanceName property rather than the more general hasName property in order to accommodate additional semantics.</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-Substances.rdf version of this ontology was modified to rename &apos;ingredient role&apos; to ingredient for clarification per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also modified to add the concept of matter and to add a specific hasSubstanceName property rather than the more general hasName property in order to accommodate additional semantics. The relationship between a moiety or substance and some of its characteristics was also revised, including the relationship between a structure and its corresponding representation.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11238-Substances.rdf version of this ontology was modified to relax the restriction on the property isStoichiometric with respect to chemical substances to optional from required (IDMP-380), and then reversed per the SME team and to conform with the IDMP standard.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
@@ -153,6 +153,34 @@
 	
 	<owl:Class rdf:about="&idmp-sub;ChemicalSubstance">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;SingleSubstance"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;OpticalActivity"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasStereochemistry"/>
+				<owl:onClass rdf:resource="&idmp-sub;Stereochemistry"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularFormula"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularFormulaByMoiety"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
@@ -438,6 +466,41 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;OpticalActivity"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasStereochemistry"/>
+				<owl:onClass rdf:resource="&idmp-sub;Stereochemistry"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularFormula"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularFormulaByMoiety"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularWeight"/>
+				<owl:onClass rdf:resource="&idmp-sub;MolecularWeight"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-sub;isMoietyOf"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Substance"/>
 			</owl:Restriction>
@@ -512,6 +575,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>molecular graph</rdfs:label>
 		<skos:definition>single chemical structure that is an unambiguous representation of the arrangement of atoms, normalized to conform with the International Union of Pure and Applied Chemistry (IUPAC) specification for drawing chemical structures to the degree possible</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MolecularGraphIdentifier">
@@ -524,43 +588,16 @@
 		</rdfs:subClassOf>
 		<rdfs:label>molecular graph identifier</rdfs:label>
 		<skos:definition>unique identifier for a molecular graph representing a single chemical structure</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MolecularStructure">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Structure"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&idmp-sub;OpticalActivity"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-sub;hasStereochemistry"/>
-				<owl:onClass rdf:resource="&idmp-sub;Stereochemistry"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;hasArrangement"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDescribedBy"/>
 				<owl:onClass rdf:resource="&idmp-sub;StructuralRepresentation"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularFormula"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularFormulaByMoiety"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -570,20 +607,15 @@
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularWeight"/>
-				<owl:onClass rdf:resource="&idmp-sub;MolecularWeight"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>molecular structure</rdfs:label>
 		<skos:definition>unambiguous representation of the arrangement of atoms</skos:definition>
 		<skos:note>For the purposes of defining substances, the three-dimensional conformations are not captured. Individual conformations or conformers of substances would only be captured in either a general sense for proteins (i.e. denatured) or when a given rotation about a single bond is restricted in such a way that the two different conformers are isolatable from each other and do not interconvert at room temperature (e.g. substituted biphenyls).</skos:note>
 		<skos:note>Structural representations shall include the complete molecular structure with all known stereochemistry indicated. Molecular fragments and moieties shall also contain structural representations. The structure is a defining element for chemicals, polymers and structural modifications. It should be defined in a consistent and unambiguous manner. The Structural Representation can cover complex substances like proteins and nucleic acid by graphical representation.</skos:note>
 		<skos:note>The structure shall contain a sufficient amount of graphical and textual information to define the underlying atoms and the connectivity between atoms as well as the composition ratio of moieties.</skos:note>
 		<skos:note>This representation should be generally translatable into a graphical representation.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clauses 3.49, 7.2.1</cmns-av:directSource>
+		<cmns-av:usageNote>While certain diagrams, such as Figure 14 in the ISO 11238:2018 show attributes such as stereochemistry, optical activity, and molecular formulas as characteristics of structure, from an ontological perspective these characteristics are actually characteristics of a moiety or chemical substance and are modeled as such herein.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MolecularStructureIdentifier">
@@ -596,6 +628,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>molecular structure identifier</rdfs:label>
 		<skos:definition>unique identifier for the unambiguous representation of the arrangement of atoms for a given substance</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MolecularWeight">
@@ -1092,7 +1125,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;StructuralRepresentation">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;Structure"/>
+		<rdfs:subClassOf rdf:resource="&cmns-dsg;Designation"/>
 		<rdfs:label>structural representation</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.6</dct:source>
@@ -1115,13 +1148,19 @@
 		<skos:definition>arrangement and organization of interrelated elements in a material object or system</skos:definition>
 		<skos:note>Material structures include man-made objects such as buildings and machines and natural objects such as biological organisms, minerals and chemicals.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clauses 3.49, 7.2.1</cmns-av:adaptedFrom>
 		<cmns-av:usageNote>Note that the term &apos;structure&apos; is not explicitly defined in the standard, but molecular structure is defined using this concept, and the concept appears in various UML diagrams in the standard.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Substance">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Matter"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasMolecularWeight"/>
+				<owl:onClass rdf:resource="&idmp-sub;MolecularWeight"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-sub;isRelatedSubstanceTo"/>
@@ -1600,7 +1639,6 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
 		<rdfs:label>has molecular formula</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.3</dct:source>
-		<rdfs:domain rdf:resource="&idmp-sub;MolecularStructure"/>
 		<skos:definition>relates a single substance to a formal definition for its molecular formula</skos:definition>
 		<skos:note>Molecular formula is written as a sequence of pairs of atom symbol and stoichiometric number (see example below). This formal notation is essentially a code system. Specified according to the Hill system, i.e. first C, then H, then alphabetical.</skos:note>
 		<skos:note>The messaging requirements can dictate a specific electronic format for the molecular formula and the molecular formula by moiety.</skos:note>
@@ -1614,7 +1652,6 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
 		<rdfs:label>has molecular formula by moiety</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.4</dct:source>
-		<rdfs:domain rdf:resource="&idmp-sub;MolecularStructure"/>
 		<skos:definition>way of describing of the molecular formula of a stoichiometric or non-stoichiometric substance existing of two or more moieties, the molecular formula of each moiety shall be described separated by a dot</skos:definition>
 		<skos:note>In non-cyclic linear structures like sodium nitroprusside: Na2[Fe(CN)5(NO)].2H2O, a non-cyclic structure is constructed in the following order: a) symbol of the central atom placed on the left; b) ionic ligands with cations first then anions; c) neutral ligands.</skos:note>
 		<skos:note>The messaging requirements can dictate a specific electronic format for the molecular formula and the molecular formula by moiety.</skos:note>
@@ -1631,7 +1668,7 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.5, Figure 10</dct:source>
 		<rdfs:range rdf:resource="&idmp-sub;MolecularWeight"/>
-		<skos:definition>relates a substance or its structure to its molecular weight</skos:definition>
+		<skos:definition>relates a substance to its molecular weight</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&idmp-sub;hasNumberOfMoieties">
@@ -1683,7 +1720,6 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has stereochemistry</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.2 Figure 14</dct:source>
-		<rdfs:domain rdf:resource="&idmp-sub;MolecularStructure"/>
 		<rdfs:range rdf:resource="&idmp-sub;Stereochemistry"/>
 		<skos:definition>is classified by the relative spatial arrangement of atoms within molecules</skos:definition>
 		<idmp-sub:hasBusinessRules>When the substance type, as defined in is either chemical or polymer, this class is MANDATORY; for all other cases this class is CONDITIONAL.</idmp-sub:hasBusinessRules>


### PR DESCRIPTION
Description: This resolution moves certain characteristics of a substance that were originally modeled as properties of molecular structure to being properties of the moiety or chemical substance directly and revised examples accordingly, and adds conformance updates to moiety and chemical substance, as the model no longer conforms to the ISO standard precisely. It also changes the class hierarchy with respect to structural representation, making it a subclass of designation, which is a better fit, and which at least partially addresses issues #241, 243, and 266.

Signed-off-by: Elisa Kendall <ekendall@thematix.com>