### PR TITLE
IDMP-466 - PhP and MI are disjoint classes (WIP)

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -105,7 +105,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230301/Examples/AmlodipineExample/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230401/Examples/AmlodipineExample/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -315,29 +315,37 @@
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC">
+	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-ManufacturedItem">
 		<rdf:type rdf:resource="&idmp-sub;ManufacturedItem"/>
-		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
-		<rdfs:label>Amlodipine EMC</rdfs:label>
-		<skos:definition>long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
+		<rdfs:label>Amlodipine EMC - manufactured item</rdfs:label>
+		<skos:definition>manufactured item that is a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
 		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrate"/>
-		<cmns-col:isIncludedIn rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&idmp-amp;AmlodipineEMCComposition"/>
 		<cmns-prd:isProducedBy rdf:resource="&idmp-amp;KentPharmaAsManufacturer"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct">
+		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
+		<rdfs:label>Amlodipine EMC - pharmaceutical product</rdfs:label>
+		<skos:definition>pharmaceutical product that is a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
+		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrate"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-amp;AmlodipineEMCComposition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCComposition">
 		<rdf:type rdf:resource="&idmp-mprd;ProductComposition"/>
 		<rdfs:label>Amlodipine EMC composition</rdfs:label>
 		<idmp-mprd:hasActiveIngredient rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateAsActiveIngredientInAmlodipineEMC"/>
-		<cmns-dsg:defines rdf:resource="&idmp-amp;AmlodipineEMC"/>
+		<cmns-dsg:defines rdf:resource="&idmp-amp;AmlodipineEMC-ManufacturedItem"/>
+		<cmns-dsg:defines rdf:resource="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;MedicinalProduct"/>
 		<rdfs:label>Amlodipine EMC medicinal product</rdfs:label>
-		<skos:definition>long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
-		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineEMC"/>
+		<skos:definition>medicinal product that is a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
+		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineEMC-ManufacturedItem"/>
+		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct"/>
 		<cmns-prd:isProducedBy rdf:resource="&idmp-amp;KentPharmaAsManufacturer"/>
 	</owl:NamedIndividual>
 	
@@ -562,15 +570,21 @@
 		<cmns-txt:hasTextValue>EMEA/H/A-30/1288</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-amp;Norvasc">
+	<owl:NamedIndividual rdf:about="&idmp-amp;Norvasc-ManufacturedItem">
 		<rdf:type rdf:resource="&idmp-sub;ManufacturedItem"/>
-		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
-		<rdfs:label>Norvasc</rdfs:label>
-		<skos:definition>pharmaceutical product that is a besylate salt of amlodipine, a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
+		<rdfs:label>Norvasc - manufactured item</rdfs:label>
+		<skos:definition>manufactured item that is a besylate salt of amlodipine, a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
 		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineBesylate"/>
-		<cmns-col:isIncludedIn rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&idmp-amp;NorvascComposition"/>
 		<cmns-prd:isProducedBy rdf:resource="&idmp-amp;PfizerLaboratoriesAsManufacturer"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-amp;Norvasc-PharmaceuticalProduct">
+		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
+		<rdfs:label>Norvasc - pharmaceutical product</rdfs:label>
+		<skos:definition>pharmaceutical product that is a besylate salt of amlodipine, a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
+		<cmns-col:comprises rdf:resource="&idmp-amp;AmlodipineBesylate"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-amp;NorvascComposition"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascAsAuthorizedMedicinalProduct">
@@ -585,20 +599,20 @@
 		<rdf:type rdf:resource="&idmp-sub;StartingMaterialRole"/>
 		<rdfs:label>norvasc tablets as starting material</rdfs:label>
 		<cmns-pts:isManifestedIn rdf:resource="&idmp-amp;NorvascPackageTablets"/>
-		<cmns-pts:isPlayedBy rdf:resource="&idmp-amp;Norvasc"/>
+		<cmns-pts:isPlayedBy rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBlister">
 		<rdf:type rdf:resource="&idmp-mprd;MedicinalProductContainer"/>
 		<rdfs:label>Norvasc blister</rdfs:label>
-		<idmp-mprd:contains rdf:resource="&idmp-amp;Norvasc"/>
+		<idmp-mprd:contains rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
 		<cmns-col:comprises rdf:resource="&idmp-amp;PolyvinylChloride"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBlisterAsImmediateContainer">
 		<rdf:type rdf:resource="&idmp-mprd;ImmediateContainer"/>
 		<rdfs:label>Norvasc blister As Immediate Container</rdfs:label>
-		<idmp-mprd:immediatelyContains rdf:resource="&idmp-amp;Norvasc"/>
+		<idmp-mprd:immediatelyContains rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
 		<cmns-pts:isPlayedBy rdf:resource="&idmp-amp;NorvascBlister"/>
 	</owl:NamedIndividual>
 	
@@ -642,7 +656,8 @@
 		<skos:definition>composition of the pharmaceutical product, Norvasc, that is a besylate salt of amlodipine</skos:definition>
 		<skos:note>NORVASC (amlodipine besylate) Tablets are formulated as white tablets equivalent to 2.5, 5, and 10 mg of amlodipine for oral administration. In addition to the active ingredient, amlodipine besylate, each tablet contains the following inactive ingredients: microcrystalline cellulose, dibasic calcium phosphate anhydrous, sodium starch glycolate, and magnesium stearate.</skos:note>
 		<idmp-mprd:hasActiveIngredient rdf:resource="&idmp-amp;AmlodipineBesylateAsActiveIngredientInNorvasc"/>
-		<cmns-dsg:defines rdf:resource="&idmp-amp;Norvasc"/>
+		<cmns-dsg:defines rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
+		<cmns-dsg:defines rdf:resource="&idmp-amp;Norvasc-PharmaceuticalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascIntermediatePackaging">
@@ -668,7 +683,8 @@
 		<dct:source rdf:resource="https://www.dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=abd6a2ca-40c2-485c-bc53-db1c652505ed"/>
 		<skos:definition>pharmaceutical and medicinal product that is a besylate salt of amlodipine, a long-acting long-acting calcium channel blocker (CCB), used to treat high blood pressure (hypertension) and a type of chest pain called angina</skos:definition>
 		<skos:note>NORVASC (amlodipine besylate) Tablets are formulated as white tablets equivalent to 2.5, 5, and 10 mg of amlodipine for oral administration. In addition to the active ingredient, amlodipine besylate, each tablet contains the following inactive ingredients: microcrystalline cellulose, dibasic calcium phosphate anhydrous, sodium starch glycolate, and magnesium stearate.</skos:note>
-		<cmns-col:comprises rdf:resource="&idmp-amp;Norvasc"/>
+		<cmns-col:comprises rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
+		<cmns-col:comprises rdf:resource="&idmp-amp;Norvasc-PharmaceuticalProduct"/>
 		<cmns-prd:isProducedBy rdf:resource="&idmp-amp;PfizerLaboratoriesAsManufacturer"/>
 	</owl:NamedIndividual>
 	
@@ -732,7 +748,7 @@
 		<rdf:type rdf:resource="&idmp-sub;Manufacturer"/>
 		<rdfs:label>Pfizer Laboratories as manufacturer</rdfs:label>
 		<cmns-pts:isPlayedBy rdf:resource="&idmp-amp;PfizerInc"/>
-		<cmns-prd:produces rdf:resource="&idmp-amp;Norvasc"/>
+		<cmns-prd:produces rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;PolyvinalChlorideCommonName">

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -105,7 +105,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230301/Examples/TerlipressinExample/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230401/Examples/TerlipressinExample/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -295,10 +295,20 @@
 		<cmns-qtu:hasNumerator rdf:resource="&idmp-trlp;TerlipressinAcetateNumeratorInTerlipressinSUN1MgSolutionForInjectionPresentationStrength"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSUN">
+	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSUN-ManufacturedItem">
 		<rdf:type rdf:resource="&idmp-sub;ManufacturedItem"/>
+		<rdfs:label>terlipressin acetate SUN - manufactured item</rdfs:label>
+		<skos:definition>manufactured item that is terlipressin acetate solution for injection</skos:definition>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
+		<cmns-col:isIncludedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjection"/>
+		<cmns-col:isIncludedIn rdf:resource="&idmp-trlp;TerlipressinSUN0.1MgPerMlSolutionForInjection"/>
+		<cmns-col:isIncludedIn rdf:resource="&idmp-trlp;TerlipressinSUN1MgSolutionForInjection"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUNComposition"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSUN-PharmaceuticalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
-		<rdfs:label>terlipressin acetate SUN</rdfs:label>
+		<rdfs:label>terlipressin acetate SUN - pharmaceutical product</rdfs:label>
 		<skos:definition>pharmaceutical product that is terlipressin acetate solution for injection</skos:definition>
 		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
 		<cmns-col:isIncludedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjection"/>
@@ -311,7 +321,8 @@
 		<rdf:type rdf:resource="&idmp-mprd;MedicinalProduct"/>
 		<rdfs:label>terlipressin acetate SUN 0.12 mg/ml solution for injection</rdfs:label>
 		<skos:definition>terlipressin acetate as marketed in the United Kingdom</skos:definition>
-		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN"/>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-ManufacturedItem"/>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-PharmaceuticalProduct"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjectionComposition"/>
 	</owl:NamedIndividual>
 	
@@ -327,7 +338,8 @@
 		<rdf:type rdf:resource="&idmp-mprd;ProductComposition"/>
 		<rdfs:label>terlipressin acetate SUN composition</rdfs:label>
 		<idmp-mprd:hasActiveIngredient rdf:resource="&idmp-trlp;TerlipressinAcetateAsActiveIngredientInTerlipressinAcetateSUN"/>
-		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinAcetateSUN"/>
+		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-ManufacturedItem"/>
+		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-PharmaceuticalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSimplifiedMolecularInputLineEntry">
@@ -477,7 +489,8 @@
 		<rdf:type rdf:resource="&idmp-mprd;MedicinalProduct"/>
 		<rdfs:label>terlipressin SUN 0.1 mg/ml solution for injection</rdfs:label>
 		<skos:definition>terlipressin as marketed in the Netherlands</skos:definition>
-		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN"/>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-ManufacturedItem"/>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-PharmaceuticalProduct"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&idmp-trlp;TerlipressinSUN0.1MgPerMlSolutionForInjectionComposition"/>
 	</owl:NamedIndividual>
 	
@@ -494,7 +507,8 @@
 		<rdf:type rdf:resource="&idmp-mprd;MedicinalProduct"/>
 		<rdfs:label>terlipressin SUN 1 mg solution for injection</rdfs:label>
 		<skos:definition>terlipressin as marketed in Sweden</skos:definition>
-		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN"/>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-ManufacturedItem"/>
+		<cmns-col:comprises rdf:resource="&idmp-trlp;TerlipressinAcetateSUN-PharmaceuticalProduct"/>
 		<cmns-dsg:isDefinedIn rdf:resource="&idmp-trlp;TerlipressinSUN1MgSolutionForInjectionComposition"/>
 	</owl:NamedIndividual>
 	

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -90,10 +90,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230301/ISO11615-MedicinalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230401/ISO11615-MedicinalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also extended to include concepts such as process, manufacturing process, process identifier, batch, batch identifier, lot, lot number, and others required in support of the regulatory to manufacturing bridge use case.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename product constituency to product composition, which is better understood by the user community, and to move a couple of restrictions from ingredient to substance, including strength and whether or not that substance is potentially allergenic. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate additional manufacturing and packaging details required for UC-2 (IDMP-465)</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230301/ISO11615-MedicinalProducts.rdf version of this ontology was modified to make manufactured item and pharmaceutical product disjoint (IDMP-466)</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -1492,6 +1493,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>pharmaceutical product</rdfs:label>
+		<owl:disjointWith rdf:resource="&idmp-sub;ManufacturedItem"/>
 		<skos:definition>specification for the qualitative and quantitative composition of a medicinal product in the dose form approved for administration in line with the regulated product information</skos:definition>
 		<skos:note>In many instances, the pharmaceutical product is equal to the manufactured item. However, there are instances where the manufactured item shall undergo a transformation before being administered to the patient (as the pharmaceutical product) and the two are not equal.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>


### PR DESCRIPTION
Description: 
1. Revised the definition of pharmaceutical product to be disjoint with manufactured item; 
2. Revised the examples for Amlodipine and Terlipressin to create both pharmaceutical products and manufactured items for each such that the results are logically consistent

Signed-off-by: Elisa Kendall [ekendall@thematix.com](mailto:ekendall@thematix.com)