### PR TITLE
IDMP-549 - Augment the definition of pharmaceutical dose form with two additional properties

### DIFF
--- a/ISO/ISO11239-PharmaceuticalDoseForms.rdf
+++ b/ISO/ISO11239-PharmaceuticalDoseForms.rdf
@@ -126,6 +126,15 @@
 		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clause 3.1.3</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-phdf;hasBasicDoseForm">
+		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasDoseForm"/>
+		<rdfs:label>has basic dose form</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;PharmaceuticalDoseForm"/>
+		<rdfs:range rdf:resource="&idmp-phdf;BasicDoseForm"/>
+		<skos:definition>specifies the generalized dose form associated with the pharmaceutical dose form</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.4</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-phdf;hasIntendedSite">
 		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-prd;isSituatedAt"/>
@@ -133,6 +142,14 @@
 		<rdfs:range rdf:resource="&idmp-phdf;IntendedSite"/>
 		<skos:definition>specifies a general body site at which a pharmaceutical product is intended to be administered</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clause 3.1.13</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-phdf;hasReleaseCharacteristic">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isCharacterizedBy"/>
+		<rdfs:label>has release characteristic</rdfs:label>
+		<rdfs:range rdf:resource="&idmp-phdf;ReleaseCharacteristic"/>
+		<skos:definition>specifies the description of the modified timing by which an active ingredient is made available in the body after administration of the pharmaceutical product</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clause 3.1.23</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&idmp-mprd;AdministrableDoseForm">
@@ -185,14 +202,14 @@
 	<owl:Class rdf:about="&idmp-mprd;PharmaceuticalDoseForm">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasDoseForm"/>
+				<owl:onProperty rdf:resource="&idmp-phdf;hasBasicDoseForm"/>
 				<owl:onClass rdf:resource="&idmp-phdf;BasicDoseForm"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:onProperty rdf:resource="&idmp-phdf;hasReleaseCharacteristic"/>
 				<owl:onClass rdf:resource="&idmp-phdf;ReleaseCharacteristic"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>


### PR DESCRIPTION
Description: Added two properties - hasReleaseCharactic and hasBasicDoseForm to support the WHO demonstration

Signed-off-by: Elisa Kendall [ekendall@thematix.com](mailto:ekendall@thematix.com)