### PR TITLE
IDMP-541 - Connect Manufactured Item and Pharmaceutical Product via Transformation

### DIFF
--- a/ISO/ISO11239-PharmaceuticalDoseForms.rdf
+++ b/ISO/ISO11239-PharmaceuticalDoseForms.rdf
@@ -228,6 +228,13 @@
 	<owl:Class rdf:about="&idmp-mprd;PharmaceuticalDoseForm">
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-phdf;hasTransformationProcedure"/>
+				<owl:onClass rdf:resource="&idmp-phdf;Transformation"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-phdf;hasBasicDoseForm"/>
 				<owl:onClass rdf:resource="&idmp-phdf;BasicDoseForm"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>

--- a/ISO/ISO11239-PharmaceuticalDoseForms.rdf
+++ b/ISO/ISO11239-PharmaceuticalDoseForms.rdf
@@ -131,7 +131,7 @@
 		<dct:source>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clauses 3.1.26, 5.3.2.6</dct:source>
 		<skos:definition>procedure that is carried out in order to convert a manufactured item that requires such a procedure into a pharmaceutical product, i.e. from its manufactured dose form to its administrable dose form</skos:definition>
 		<skos:example>dilution, dissolution, suspension</skos:example>
-		<skos:note>A transformation is not required when the manufactured item is equal to the pharmaceutical product.</skos:note>
+		<skos:note>No transformation is needed if the dose forms of the manufactured item and the pharmaceutical product are equal.</skos:note>
 		<skos:note>Where there is no transformation, the class has an appropriate null value. A transformation is associated with zero to many pharmaceutical dose forms.</skos:note>
 		<cmns-av:explanatoryNote>See also Annex A (Table A.3) for controlled vocabulary examples, and Annex B for medicinal product examples.</cmns-av:explanatoryNote>
 	</owl:Class>

--- a/ISO/ISO11239-PharmaceuticalDoseForms.rdf
+++ b/ISO/ISO11239-PharmaceuticalDoseForms.rdf
@@ -118,6 +118,24 @@
 		<skos:example>delayed, extended, none</skos:example>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-phdf;Transformation">
+		<rdfs:subClassOf rdf:resource="&idmp-mprd;ProcessSpecification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
+				<owl:onClass rdf:resource="&idmp-mprd;PharmaceuticalDoseForm"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transformation</rdfs:label>
+		<dct:source>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clauses 3.1.26, 5.3.2.6</dct:source>
+		<skos:definition>procedure that is carried out in order to convert a manufactured item that requires such a procedure into a pharmaceutical product, i.e. from its manufactured dose form to its administrable dose form</skos:definition>
+		<skos:example>dilution, dissolution, suspension</skos:example>
+		<skos:note>A transformation is not required when the manufactured item is equal to the pharmaceutical product.</skos:note>
+		<skos:note>Where there is no transformation, the class has an appropriate null value. A transformation is associated with zero to many pharmaceutical dose forms.</skos:note>
+		<cmns-av:explanatoryNote>See also Annex A (Table A.3) for controlled vocabulary examples, and Annex B for medicinal product examples.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:ObjectProperty rdf:about="&idmp-phdf;hasAdministrationMethod">
 		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
 		<rdfs:label>has administration method</rdfs:label>
@@ -150,6 +168,14 @@
 		<rdfs:range rdf:resource="&idmp-phdf;ReleaseCharacteristic"/>
 		<skos:definition>specifies the description of the modified timing by which an active ingredient is made available in the body after administration of the pharmaceutical product</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clause 3.1.23</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-phdf;hasTransformationProcedure">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
+		<rdfs:label>has transformation procedure</rdfs:label>
+		<rdfs:range rdf:resource="&idmp-phdf;Transformation"/>
+		<skos:definition>specifies a procedure that is carried out in order to convert a manufactured item that requires such a procedure into a pharmaceutical product, i.e. from its manufactured dose form to its administrable dose form</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packaging, clause 3.1.26</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&idmp-mprd;AdministrableDoseForm">


### PR DESCRIPTION
Description: 

1. Augmented the pharmaceutical dose forms ontology to include transformation and the property, hasTransformationProcedure to support  the WHO demo
2. Added a restriction to connect a pharmaceutical dose form to a relevant transformation

Signed-off-by: Elisa Kendall [ekendall@thematix.com](mailto:ekendall@thematix.com)
