### PR TITLE
IDMP-561 - Augment the IDMP ontologies to cover therapeutic indications

### DIFF
--- a/AboutIDMPDev-ReferenceIndividuals.rdf
+++ b/AboutIDMPDev-ReferenceIndividuals.rdf
@@ -23,7 +23,7 @@
   		<rdfs:label>About IDMP Development - Reference Individuals</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of IDMP users. It loads all of the very latest IDMP production and development ontologies, including reference data and examples based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that while metadata files and other 'load' files, such as the various subject area specific 'all' files, are intentionally excluded, this version of the 'load' file does include all reference data, such as governments and related jurisdictions required for complete IDMP representation.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-05-17T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>		
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>		
 		
@@ -60,6 +60,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		
@@ -119,7 +120,7 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/QlairaExample/"/>
 
 
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230501/AboutIDMPDev-ReferenceIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230601/AboutIDMPDev-ReferenceIndividuals/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutIDMPDev.rdf
+++ b/AboutIDMPDev.rdf
@@ -23,7 +23,7 @@
   		<rdfs:label>About IDMP Development</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of IDMP users. It loads all of the very latest IDMP production and development ontologies, excluding reference data and examples, based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that metadata files and other 'load' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-05-17T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>		
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>		
 		
@@ -53,6 +53,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		
@@ -92,7 +93,7 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230501/AboutIDMPDev/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230601/AboutIDMPDev/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/AboutIDMPProd-ReferenceIndividuals.rdf
+++ b/AboutIDMPProd-ReferenceIndividuals.rdf
@@ -23,7 +23,7 @@
   		<rdfs:label>About IDMP Production - Reference Individuals</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of IDMP users. It loads the IDMP production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that while metadata files and other 'load' files, such as the various subject area specific 'all' files, are intentionally excluded, this version of the 'load' file does include all reference data, such as governments and related jurisdictions required for complete IDMP representation.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-05-17T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>		
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>		
 		
@@ -60,6 +60,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		
 	<!-- 
@@ -96,7 +97,7 @@
 	<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"/>
 	<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
 	
-	<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230501/AboutIDMPProd-ReferenceIndividuals/"/>
+	<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230601/AboutIDMPProd-ReferenceIndividuals/"/>
 	
   </owl:Ontology>
 

--- a/AboutIDMPProd.rdf
+++ b/AboutIDMPProd.rdf
@@ -23,7 +23,7 @@
   		<rdfs:label>About IDMP Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of IDMP users. It loads the IDMP production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that reference data, metadata files and other 'load' files, such as the various subject area specific 'all' files, are intentionally excluded.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-05-17T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>		
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>		
 		
@@ -53,6 +53,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		
 	<!-- 
@@ -88,7 +89,7 @@
 	<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"/>
 	<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
 	
-	<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230501/AboutIDMPProd/"/>
+	<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230601/AboutIDMPProd/"/>
 	
   </owl:Ontology>
 

--- a/CMNS/AboutCommons-ReferenceIndividuals.rdf
+++ b/CMNS/AboutCommons-ReferenceIndividuals.rdf
@@ -24,7 +24,7 @@
     <owl:Ontology rdf:about="https://www.omg.org/spec/Commons/AboutCommons-ReferenceIndividuals/">
         <rdfs:label>About the Commons Ontology Library</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of Commons users. It can be used to load all of the current Commons ontologies, including reference individuals for governments and jurisdictions, using a relative catalog, as needed in Protege or other tools.</dct:abstract>
-		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
+		<dct:license rdf:resource="https://opensource.org/licenses/MIT"/>
 		<cmns-av:copyright>Copyright (c) 2021-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2021-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2021-2023 Mayo Clinic</cmns-av:copyright>
@@ -67,9 +67,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-        <owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230401/AboutCommons/"/>
+        <owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230601/AboutCommons/"/>
     </owl:Ontology>
 
 </rdf:RDF>

--- a/CMNS/AboutCommons.rdf
+++ b/CMNS/AboutCommons.rdf
@@ -60,9 +60,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-        <owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230401/AboutCommons/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230501/AboutCommons/"/>
     </owl:Ontology>
 
 </rdf:RDF>

--- a/CMNS/MetadataCMNS.rdf
+++ b/CMNS/MetadataCMNS.rdf
@@ -25,11 +25,11 @@
 		<rdfs:label>Metadata for the IDMP Commons Ontology Library</rdfs:label>
 		<dct:abstract>The Commons (CMNS) Ontology Library Module includes ontologies that are defined in the Object Management Group (OMG) Commons Ontology Library standard, as well as others that are planned for inclusion.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2022-11-16T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-04-20T18:00:00</dct:modified>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-06-01T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230401/MetadataCMNS/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230501/MetadataCMNS/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -63,9 +63,10 @@
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:NamedIndividual>

--- a/CMNS/QuantitiesAndUnits.rdf
+++ b/CMNS/QuantitiesAndUnits.rdf
@@ -34,6 +34,9 @@
 		<dct:abstract>This ontology provides a core set of concepts for quantities, units, systems of quantities, and systems of units. The most widely accepted, scrutinized, and globally used system of quantities and system of units are the International System of Quantities (ISQ) and the International System of Units (SI). They are formally standardized through [ISO 31] and [IEC 60027]. The harmonization of these two sets of standards into one new set [ISO/IEC 80000] has been published by ISO in 2009 and 2010. This ontology is based on the QUDV model from the Object Management Group (OMG)&apos;s SysML standard and on ISO/IEC 80000-1:2009, which refers normatively to the ISO/IEC Guide 99:2007. It is compatible with and can be mapped directly to the OMG Date Time Vocabulary (DTV) Quantities Ontology, the de-facto QUDT ontology representing Units of Measure, Quantity Kinds, Dimensions and Data Types (see http://www.qudt.org/), the Units of Measurement Ontology (UO) ontology available from the BioPortal (https://bioportal.bioontology.org/ontologies/UO) and others, as well as the QUDV annex of the SysML specification.</dct:abstract>
 		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Evan Wallace, U.S. National Institute of Standards and Technology (NIST)</dct:contributor>
+		<dct:contributor>Hans Peter de Koenig, DEKonsult</dct:contributor>
+		<dct:contributor>Roger Burkhart, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Stuart Chalk, University of North Florida</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
@@ -41,10 +44,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20220901/QuantitiesAndUnits/"/>
-		<cmns-av:copyright>Copyright (c) 2011-2022 Thematix Partners LLC</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2022 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2015-2022 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230501/QuantitiesAndUnits/"/>
+		<cmns-av:copyright>Copyright (c) 2011-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023 DEKonsult</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023 University of North Florida</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&cmns-qtu;ArbitraryUnit">
@@ -997,6 +1002,14 @@
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether something, such as a measurement scale, includes the absolute minimum permissive value or not</skos:definition>
 	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-qtu;isValueOf">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;appliesTo"/>
+		<rdfs:label>is value of</rdfs:label>
+		<rdfs:domain rdf:resource="&cmns-qtu;QuantityValue"/>
+		<owl:inverseOf rdf:resource="&cmns-qtu;hasQuantityValue"/>
+		<skos:definition>is the measure that the value represents</skos:definition>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-qtu;specializes">
 		<rdfs:label>specializes</rdfs:label>

--- a/CMNS/RegistrationAuthorities.rdf
+++ b/CMNS/RegistrationAuthorities.rdf
@@ -50,6 +50,14 @@
 		<cmns-av:copyright>Copyright (c) 2022 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
+	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities">
+		<rdf:type rdf:resource="&cmns-ra;Registry"/>
+		<rdfs:label>Medical Dictionary for Regulatory Activities</rdfs:label>
+		<skos:definition>The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) developed MedDRA, a rich and highly specific standardised medical terminology to facilitate sharing of regulatory information internationally for medical products used by humans.</skos:definition>
+		<cmns-av:abbreviation>MedDRA</cmns-av:abbreviation>
+		<cmns-av:directSource rdf:resource="https://www.meddra.org/"/>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&cmns-ra;RegisteredIdentifier">
 		<rdfs:subClassOf rdf:resource="&cmns-cxtid;ContextualIdentifier"/>
 		<rdfs:subClassOf>

--- a/CMNS/RegistrationAuthorities.rdf
+++ b/CMNS/RegistrationAuthorities.rdf
@@ -36,7 +36,7 @@
 	<owl:Ontology rdf:about="https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 		<rdfs:label>Commons Registration Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for representation of registration authorities, registrars, registration-specific identifiers and related identification schemes. It was derived from the FIBO Registration Authorities Ontology and ISO 11179-3, and adapted for broader use.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
@@ -45,18 +45,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20221101/RegistrationAuthorities/"/>
-		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2022 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230601/RegistrationAuthorities/"/>
+		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
-	
-	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities">
-		<rdf:type rdf:resource="&cmns-ra;Registry"/>
-		<rdfs:label>Medical Dictionary for Regulatory Activities</rdfs:label>
-		<skos:definition>The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) developed MedDRA, a rich and highly specific standardised medical terminology to facilitate sharing of regulatory information internationally for medical products used by humans.</skos:definition>
-		<cmns-av:abbreviation>MedDRA</cmns-av:abbreviation>
-		<cmns-av:directSource rdf:resource="https://www.meddra.org/"/>
-	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&cmns-ra;RegisteredIdentifier">
 		<rdfs:subClassOf rdf:resource="&cmns-cxtid;ContextualIdentifier"/>

--- a/CMNS/StatisticalMeasures.rdf
+++ b/CMNS/StatisticalMeasures.rdf
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
+	<!ENTITY cmns-prd "https://www.omg.org/spec/Commons/ProductsAndServices/">
+	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
+	<!ENTITY cmns-stat "https://www.omg.org/spec/Commons/StatisticalMeasures/">
+	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://www.omg.org/spec/Commons/StatisticalMeasures/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
+	xmlns:cmns-prd="https://www.omg.org/spec/Commons/ProductsAndServices/"
+	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
+	xmlns:cmns-stat="https://www.omg.org/spec/Commons/StatisticalMeasures/"
+	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://www.omg.org/spec/Commons/StatisticalMeasures/">
+		<rdfs:label>Statistical Measures Ontology</rdfs:label>
+		<dct:abstract>This ontology defines statistical measures, i.e., common mathematical operations on data, including basic measures such as difference, mean, median, standard deviation, and population-related concepts. It does not cover statistical methods, however, for which other ontologies such as STAT-O may be useful.</dct:abstract>
+		<dct:contributor>Dan Gillman, U.S. Department of Labor, Bureau of Labor Statistics (BLS)</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Lucy Abboud, Statistics Canada</dct:contributor>
+		<dct:contributor>Pete Rivett, agnos.ai U.K. Ltd</dct:contributor>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230601/Statistics/"/>
+		<skos:note>This ontology was originally designed for and has been adapted from the Financial Industry Business Ontology (FIBO) Analytics Ontology.</skos:note>
+		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2013-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2021-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
+		<cmns-av:usageNote>Note that this ontology can be mapped to STAT-O, given that there is overlap but not a 1-1 correspondence in terms of coverage. It does not extend STAT-O, however, as STAT-O duplicates terminology from a number of ontologies from the OBO Foundry, some of which are not standardized, and which may be an issue for some use cases.</cmns-av:usageNote>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&cmns-stat;AnnualizedStandardDeviation">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StandardDeviation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasReferencePeriod"/>
+				<owl:onClass rdf:resource="&cmns-stat;ExplicitRecurrenceInterval"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>annualized standard deviation</rdfs:label>
+		<skos:definition>standard deviation for some measure over a specific reference period</skos:definition>
+		<cmns-av:explanatoryNote>Standard deviation applied to the annual rate of return of an investment provides insights on the historical volatility of that investment. The greater the standard deviation of the price of a security, the greater the volatility. Multiplying monthly standard deviation by the square root of twelve (12) is an industry standard method of approximating annualized standard deviations of monthly returns.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;ArithmeticMean">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Mean"/>
+		<rdfs:label>arithmetic mean</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.bls.gov/bls/glossary.htm#average"/>
+		<rdfs:seeAlso rdf:resource="https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm"/>
+		<skos:definition>sum of a collection of numbers dividing the resulting sum by the quantity of numbers summed</skos:definition>
+		<cmns-av:explanatoryNote>While the arithmetic mean is often used to report central tendencies, it is not a robust statistic, meaning that it is greatly influenced by outliers (values that are very much larger or smaller than most of the values). Notably, for skewed distributions, such as the distribution of income for which a few people&apos;s incomes are substantially greater than most people&apos;s, the arithmetic mean may not accord with one&apos;s notion of &apos;middle&apos;, and robust statistics, such as the median, may be a better description of central tendency.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>average</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;AverageAbsoluteDeviation">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&cmns-stat;Mean">
+							</rdf:Description>
+							<rdf:Description rdf:about="&cmns-stat;Median">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>average absolute deviation</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.statisticshowto.com/average-deviation/"/>
+		<skos:definition>average of the absolute deviations from a central point</skos:definition>
+		<cmns-av:abbreviation>AAD</cmns-av:abbreviation>
+		<cmns-av:explanatoryNote>The central point can be the mean, median, mode, or the result of another measure of central tendency. Absolute deviation is the distance between each value in the data set and that data set&apos;s mean or median.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>mean absolute deviation</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;CalculatedDate">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;Date"/>
+		<rdfs:label>calculated date</rdfs:label>
+		<owl:disjointWith rdf:resource="&cmns-dt;ExplicitDate"/>
+		<skos:definition>date that is or will be determined based on some formula</skos:definition>
+		<cmns-av:explanatoryNote>The hasDateValue property of a CalculatedDate is not set until the Date is calculated. Since the calculation may depend upon future events that may or may not ever happen, the hasDateValue property may never be set.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Difference">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasMinuend"/>
+				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasSubtrahend"/>
+				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>difference</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.reference.com/world-view/difference-mean-math-1cee24a1262808c7"/>
+		<skos:definition>quantity by which amounts differ; the remainder left after subtraction of one value from another</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Dispersion">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasCollectionSize"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;FinitePopulation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasObservedValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-col;StructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>dispersion</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm"/>
+		<skos:definition>degree of scatter or variability shown by observations</skos:definition>
+		<skos:example>Common examples of measures of statistical dispersion are the variance, standard deviation, and interquartile range. The collection size argument, above, represents the number of elements in the set, if known. The collection of values under consideration is represented as a structured collection in FIBO, typically a sample set derived from a finite population.</skos:example>
+		<cmns-av:explanatoryNote>A measure of statistical dispersion is a nonnegative real number that is zero if all the data are the same and increases as the data become more diverse.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>It is usually measured as an average deviation about some central value (e.g. mean deviation, standard deviation) or by an order statistic (e.g. quartile deviation, range) but may also be a mean of deviations of values among themselves (e.g. Gini&apos;s mean difference and also standard deviation).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;ExplicitRecurrenceInterval">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;RecurrenceInterval"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasDurationValue"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>explicit recurrence interval</rdfs:label>
+		<skos:definition>recurrence interval defined via an explicit duration</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;FinitePopulation">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:label>finite population</rdfs:label>
+		<skos:definition>population for which it is possible to count its units</skos:definition>
+		<cmns-av:explanatoryNote>In statistics, a population is a set of similar items or events of interest for some question or experiment. In other words, a population is the complete group of units to which survey results are to apply. (These units may be persons, animals, objects, businesses, trips, etc.).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;GeometricMean">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Mean"/>
+		<rdfs:label>geometric mean</rdfs:label>
+		<skos:definition>mean that indicates the central tendency or typical value of a set of numbers by using the product of their values (as opposed to the arithmetic mean which uses their sum)</skos:definition>
+		<cmns-av:explanatoryNote>The geometric mean is defined as the nth root of the product of n numbers. A geometric mean is often used when comparing different items - finding a single &apos;figure of merit&apos; for these items - when each item has multiple properties that have different numeric ranges. For example, the geometric mean can give a meaningful &apos;average&apos; to compare two companies which are each rated at 0 to 5 for their environmental sustainability, and are rated at 0 to 100 for their financial viability. If an arithmetic mean were used instead of a geometric mean, the financial viability is given more weight because its numeric range is larger - so a small percentage change in the financial rating (e.g. going from 80 to 90) makes a much larger difference in the arithmetic mean than a large percentage change in environmental sustainability (e.g. going from 2 to 5).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Mean">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasObservedValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-col;StructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>mean</rdfs:label>
+		<skos:definition>most common measure of central tendency; the average of a set of numbers</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/bls/glossary.htm</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>When unqualified, the mean usually refers to the expectation of a variate, or to the arithmetic mean of a sample used as an estimate of the expectation.</cmns-av:explanatoryNote>
+		<cmns-av:symbol>μ</cmns-av:symbol>
+		<cmns-av:synonym>expected value</cmns-av:synonym>
+		<cmns-av:synonym>first (raw) moment</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Median">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasObservedValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-col;StructuredCollection"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>median</rdfs:label>
+		<skos:definition>value of the variate dividing the total frequency of a data sample, population, or probability distribution, into two halves</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The basic advantage of the median in describing data compared to the mean is that it is not skewed by extremely large or small values, and may provide a better idea of a &apos;typical&apos; value.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This measure represents the middle value (if n is odd) or the average of the two middle values (if n is even) in an ordered list of data values. The median divides the total frequency distribution into two equal parts: one-half of the cases fall below the median and one-half of the cases exceed the median.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>second quartile</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;MedianAbsoluteDeviation">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;Median"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>median absolute deviation</rdfs:label>
+		<skos:definition>median of the absolute deviations of observations from the average which may be the arithmetic mean, the median or the mode</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;NumericIndexValue">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;isValueOf"/>
+				<owl:onClass rdf:resource="&cmns-stat;ScopedMeasure"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasObservedDateTime"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&cmns-dt;CombinedDateTime"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>numeric index value</rdfs:label>
+		<skos:definition>numeric value of some aggregate relative to the value of that aggregate as of some date</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A mathematical device or number which is used to express the observation (e.g., price level, volume of trade, relative amount etc.) of a given period, in comparison with that of a prior period.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Percentage">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;RatioValue"/>
+		<rdfs:label>percentage</rdfs:label>
+		<skos:definition>ratio value expressed as a fraction of 100, i.e., in which the denominator is fixed rather than variable and equal to 100</skos:definition>
+		<cmns-av:explanatoryNote>The percent value is computed by multiplying the numeric value of the ratio by 100.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>While many percentage values are between 0 and 100, there is no mathematical restriction and percentages may take on other values (positive or negative), particularly in the case of comparisons (percent change).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;QualifiedMeasure">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasAnchorDate"/>
+				<owl:onClass rdf:resource="&cmns-dt;ExplicitDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;isCalculatedViaMethodology"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange>
+					<rdfs:Datatype>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&xsd;string">
+							</rdf:Description>
+							<rdf:Description rdf:about="&xsd;anyURI">
+							</rdf:Description>
+						</owl:unionOf>
+					</rdfs:Datatype>
+				</owl:onDataRange>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>qualified measure</rdfs:label>
+		<skos:definition>statistical measure that is constrained by features, quantity kinds or units that refine how it is calculated</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Ratio">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:label>ratio</rdfs:label>
+		<skos:definition>proportional relationship between two different numbers or quantities, or in mathematics a quotient of two numbers or expressions, arrived at by dividing one by the other</skos:definition>
+		<cmns-av:explanatoryNote>A ratio is a quantity measured with respect to some other quantity.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>rate</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;RatioValue">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:onClass rdf:resource="&cmns-qtu;Variable"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>ratio value</rdfs:label>
+		<skos:definition>proportional relationship specifically between two different quantity values that gives rise to a datum of a specific quantity type</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;RecurrenceInterval">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;ProperInterval"/>
+		<rdfs:label>recurrence interval</rdfs:label>
+		<skos:definition>time interval that is consistent between elements of a regular schedule</skos:definition>
+		<cmns-av:synonym>frequency</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;RelativeDate">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;CalculatedDate"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;isRelativeTo"/>
+				<owl:onClass rdf:resource="&cmns-dt;Date"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasRelativeDuration"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>relative date</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://help.oclc.org/Library_Management/WorldShare_Reports/Work_with_reports/20Relative_dates"/>
+		<skos:definition>calculated date that is some duration before or after another date</skos:definition>
+		<skos:example>A settlement date, defined as T+3: three days after the trade date. The &apos;hasRelativeDuration&apos; property is set to &apos;3D&apos;.</skos:example>
+		<cmns-av:explanatoryNote>When the &apos;hasRelativeDuration&apos; property is negative, the RelativeDate is before the &apos;isRelativeTo&apos; Date; otherwise the RelativeDate is after the &apos;isRelativeTo&apos; Date.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Sample">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalPopulation"/>
+		<rdfs:label>sample</rdfs:label>
+		<skos:definition>subset of a population, usually selected randomly and considered representative of the population</skos:definition>
+		<skos:example>For example, the Current Population Survey (CPS) monthly sample size is approximately 60,000 households.</skos:example>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/bls/glossary.htm</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;SamplingVariance">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Variance"/>
+		<rdfs:label>sampling variance</rdfs:label>
+		<skos:definition>measure of the extent to which the estimate of a characteristic from different possible samples of the same size and the same design differ from one another</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>Sampling variation is defined as the average of the squared differences between an estimate and the average of the estimates across all possible samples.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The word &apos;sampling&apos; can usually be omitted, as being defined by the context or otherwise understood. The sampling variance of a statistic is the square of its standard error.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;ScopedMeasure">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;QualifiedMeasure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasPeriodicity"/>
+				<owl:allValuesFrom rdf:resource="&cmns-stat;RecurrenceInterval"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:onClass rdf:resource="&cmns-stat;FinitePopulation"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-loc;hasCoverageArea"/>
+				<owl:onClass rdf:resource="&cmns-stat;StatisticalArea"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>scoped measure</rdfs:label>
+		<skos:definition>qualified measure that is constrained by filters on the statistical population to which it applies</skos:definition>
+		<cmns-av:explanatoryNote>Note that (1) the anchor date reflects the start of the current series, such as 1982-1984 for the CPI, (2) the fixed comparative date might be something like March 2009, if one is comparing a current index against its value at the end of the great recession, (3) the relative comparative date might be something like a month or year ago, depending on the analysis requirements, and (4) the relative comparative period might be a 3 month average prior value, again depending on the analysis requirements.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StandardDeviation">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&cmns-stat;Mean">
+							</rdf:Description>
+							<rdf:Description rdf:about="&cmns-stat;Variance">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>standard deviation</rdfs:label>
+		<skos:definition>square root of variance that measures the spread or dispersion around the mean of a data set</skos:definition>
+		<cmns-av:abbreviation>SD</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The most widely used measure of dispersion of a frequency distribution introduced by K. Pearson (1893). It is equal to the positive square root of the variance. The standard deviation should not be confused with the root mean square deviation.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>While standard deviation is the most widely-used measure of spread, using squared deviations, it may not be the most robust.</cmns-av:explanatoryNote>
+		<cmns-av:symbol>σ</cmns-av:symbol>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StatisticalArea">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalAreaIdentifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical area</rdfs:label>
+		<skos:definition>physical location that is defined per some program for designating geographic regions for the purposes of tabulating and presenting statistical data</skos:definition>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/display/IND/Statistics+Canada+Census+Information</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StatisticalAreaIdentifier">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
+				<owl:onClass rdf:resource="&cmns-stat;StatisticalArea"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical area identifier</rdfs:label>
+		<skos:definition>identifier for a physical location that is defined per a nationally consistent program for designating geographic regions for the purposes of tabulating and presenting statistical data</skos:definition>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/display/IND/Statistics+Canada+Census+Information</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StatisticalMeasure">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Measure"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:onClass rdf:resource="&cmns-cls;Aspect"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;isEstimate"/>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical measure</rdfs:label>
+		<skos:definition>summary (means, mode, total, index, etc.) of the individual quantitative variable values for the statistical units in a specific group (study domain)</skos:definition>
+		<cmns-av:explanatoryNote>Statistical measures may consist of several orthogonal characteristics, including (a) whether they reflect an estimate or variable, (b) the datatype, or from a FIBO perspective, nature of the measure (e.g., index, total, ratio, percent, percent change, mean, others), (c) the population (or the universe that applies to the highest level if defined in general) to which the measure applies, and (d) any relevant aspects used to subset or stratify a measure, (i.e., make them apply to a smaller universe).</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StatisticalPopulation">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;FinitePopulation"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalUniverse"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasPopulationSize"/>
+				<owl:allValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalArea"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical population</rdfs:label>
+		<skos:definition>statistical universe filtered by time and region</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/bls/glossary.htm</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A common aim of statistical analysis is to produce information about some chosen population. In statistical inference, a subset of the population (a statistical sample) is chosen to represent the population in a statistical analysis. If a sample is chosen properly, characteristics of the entire population that the sample is drawn from can be estimated from corresponding characteristics of the sample.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StatisticalProgram">
+		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;Context"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalUniverse"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-loc;hasCoverageArea"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalArea"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;provides"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalMeasure"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical program</rdfs:label>
+		<skos:definition>program that presents a detailed investigation and analysis of a subject or situation involving one or more studies or surveys</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;StatisticalUniverse">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-stat;hasUniverseSize"/>
+				<owl:allValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalProgram"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>statistical universe</rdfs:label>
+		<skos:definition>collection representing the total membership, or &apos;universe&apos;, of people, resources, products, services, events, or entities of interest for some question, experiment, survey or statistical program</skos:definition>
+		<skos:example>A statistical universe can be a group of actually existing objects (e.g. the set of all stars within the Milky Way galaxy) or a hypothetical and potentially infinite group of objects conceived as a generalization from experience (e.g. the set of all possible hands in a game of poker).</skos:example>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/bls/glossary.htm</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Total">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:label>total</rdfs:label>
+		<skos:definition>sum of the values for some characteristic of all units</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.bls.gov/bls/glossary.htm</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;Variance">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;Dispersion"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>
+				<owl:someValuesFrom rdf:resource="&cmns-stat;Mean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>variance</rdfs:label>
+		<skos:definition>measure of spread, calculated as the average squared deviation of each number from the mean of a data set</skos:definition>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm</cmns-av:adaptedFrom>
+		<cmns-av:symbol>μ2</cmns-av:symbol>
+		<cmns-av:symbol>σ2</cmns-av:symbol>
+		<cmns-av:synonym>second moment</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-stat;WeightingFunction">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:label>weighting function</rdfs:label>
+		<skos:definition>expression or function that determines the relative importance or influence of a given element of a set with respect to the whole</skos:definition>
+		<skos:example>Given a sample size of 1000, and a population of 300M, then the chance that any individual is selected is 1 in 300K. In that case, 300K is the weight assigned to each of the elements in the sample.</skos:example>
+		<cmns-av:explanatoryNote>For certain indices, one of the most common weighting factor is by market capitalization. In that case, each of the elements in the basket is multiplied by its market cap to determine its relative importance to the basket overall.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>With respect to discrete calculations, weighting functions are positive functions defined on discrete sets, such as weighted sums and weighted averages.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasAnchorDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasExplicitDate"/>
+		<rdfs:label>has anchor date</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
+		<skos:definition>specifies the base date against which the value of a numeric index for a more recent date is compared (i.e., the starting point from which it stems)</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasCollectionSize">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasCount"/>
+		<rdfs:label>has collection size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in a given collection</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasCount">
+		<rdfs:label>has count</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>specifies the total number of things in a collection, which could be zero</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasFixedComparativeDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasExplicitDate"/>
+		<rdfs:label>has fixed comparative date</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
+		<skos:definition>specifies the a specific date, such as the end of the last recession (e.g., March 2009) against which the scoped measure is compared</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasMeasurementPeriodInMonths">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasCount"/>
+		<rdfs:label>has measurement period in months</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;integer"/>
+		<skos:definition>indicates the coverage period for which the measure is applicable expressed in months</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasMinuend">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasArgument"/>
+		<rdfs:label>has minuend</rdfs:label>
+		<rdfs:domain rdf:resource="&cmns-stat;Difference"/>
+		<skos:definition>specifies the quantity value from which something is subtracted; the value that is diminished</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasNumberOfEntries">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasCount"/>
+		<rdfs:label>has number of entries</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in some document, table, or other resource (e.g., in a report, table)</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasObservedValue">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasArgument"/>
+		<rdfs:label>has observed value</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-col;StructuredCollection"/>
+		<skos:definition>specifies a collection of values over which some analysis is performed</skos:definition>
+		<cmns-av:explanatoryNote>For certain calculations, such as certain measures of dispersion, date value pairs are expected as input, in other words, a dated structured collection.</cmns-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasPeriodicity">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasRecurrenceInterval"/>
+		<rdfs:label>has periodicity</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-stat;RecurrenceInterval"/>
+		<skos:definition>specifies a recurrence interval (monthly, quarterly, annual) that a statistical measure reflects</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasPopulationSize">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasCollectionSize"/>
+		<rdfs:label>has population size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in a given population</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasRecurrenceInterval">
+		<rdfs:label>has recurrence interval</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-stat;RecurrenceInterval"/>
+		<skos:definition>indicates the frequency with which some calculation, event or publication occurs</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasReferencePeriod">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasRecurrenceInterval"/>
+		<rdfs:label>has reference period</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-stat;RecurrenceInterval"/>
+		<skos:definition>specifies a reference (baseline) recurrence interval for which a given measure applies</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasRelativeComparativeDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDate"/>
+		<rdfs:label>has relative comparative date</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-stat;RelativeDate"/>
+		<skos:definition>specifies a date against which the value of a scoped measure is compared (e.g., one month prior, three months prior, etc., and typically against a prior release or average over prior releases)</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasRelativeComparativePeriod">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDatePeriod"/>
+		<rdfs:label>has relative comparative period</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;DatePeriod"/>
+		<skos:definition>specifies a period (typically a prior period) against which the scoped measure is compared, such as an average set of values for some period of time compared with a more recent or projected average for a forward looking period of time</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasRelativeDuration">
+		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
+		<rdfs:label>has relative duration</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>duration between two explicit dates</skos:definition>
+		<cmns-av:explanatoryNote>A relative duration may be negative.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Note that this property is distinct from hasDurationValue in the Dates and Times ontology, as a relative duration may resolve to a relative date or date time (both of which are time points) rather than an interval, which would result in a logical inconsistency if its parent property is hasDurationValue.</cmns-av:explanatoryNote>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasReleaseDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDate"/>
+		<rdfs:label>has release date</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;Date"/>
+		<skos:definition>specifies the date on which something is published</skos:definition>
+		<cmns-av:explanatoryNote>A release date is typically a date fixed in advance for the release of a film, recording, document, report, or product or publication.</cmns-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasReleaseDateTime">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasObservedDateTime"/>
+		<rdfs:label>has release date and time</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;CombinedDateTime"/>
+		<skos:definition>specifies the date and time on which something is published</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;hasSubtrahend">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasArgument"/>
+		<rdfs:label>has subtrahend</rdfs:label>
+		<rdfs:domain rdf:resource="&cmns-stat;Difference"/>
+		<skos:definition>specifies the quantity value that is subtracted from something</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasUniverseSize">
+		<rdfs:subPropertyOf rdf:resource="&cmns-stat;hasCollectionSize"/>
+		<rdfs:label>has universe size</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
+		<skos:definition>indicates the number of elements in a given universe</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;hasWeight">
+		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasNumericValue"/>
+		<rdfs:label>has weight</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition>indicates an amount given to increase or decrease the importance of an item</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;isCalculatedViaMethodology">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
+		<rdfs:label>is calculated via methodology</rdfs:label>
+		<rdfs:domain rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<skos:definition>high-level description of the approach taken to obtain the result</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&cmns-stat;isEstimate">
+		<rdfs:label>is estimate</rdfs:label>
+		<rdfs:domain rdf:resource="&cmns-stat;StatisticalMeasure"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition>indicates whether the measure reflects an estimate (approximation) or not</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-stat;isRelativeTo">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDate"/>
+		<rdfs:label>is relative to</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;Date"/>
+		<skos:definition>identifies a specific date that a relative date or relative date period references</skos:definition>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/CMNS/StatisticalMeasures.rdf
+++ b/CMNS/StatisticalMeasures.rdf
@@ -495,13 +495,15 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
+				<owl:onClass rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-stat;StatisticalArea"/>
+				<owl:onClass rdf:resource="&cmns-stat;StatisticalArea"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>statistical population</rdfs:label>

--- a/CMNS/catalog-v001.xml
+++ b/CMNS/catalog-v001.xml
@@ -26,6 +26,7 @@
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/QuantitiesAndUnits/" uri="./QuantitiesAndUnits.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RegistrationAuthorities/" uri="./RegistrationAuthorities.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RegulatoryAgencies/" uri="./RegulatoryAgencies.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/StatisticalMeasures/" uri="./StatisticalMeasures.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/StructuredCollections/" uri="./StructuredCollections.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/TextDatatype/" uri="./TextDatatype.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/" uri="../LCC/Countries/CountryRepresentation.rdf"/>

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -22,6 +22,7 @@
 	<!ENTITY idmp-eura "https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities/">
 	<!ENTITY idmp-eurga "https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies/">
 	<!ENTITY idmp-mprd "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/">
+	<!ENTITY idmp-phprd "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/">
 	<!ENTITY idmp-ra "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/">
 	<!ENTITY idmp-sub "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/">
 	<!ENTITY idmp-ucum "https://spec.pistoiaalliance.org/idmp/ontology/EXT/Extensions/UnifiedCodeForUnitsOfMeasure/">
@@ -59,6 +60,7 @@
 	xmlns:idmp-eura="https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities/"
 	xmlns:idmp-eurga="https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies/"
 	xmlns:idmp-mprd="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
+	xmlns:idmp-phprd="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/"
 	xmlns:idmp-ra="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/"
 	xmlns:idmp-sub="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/"
 	xmlns:idmp-ucum="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Extensions/UnifiedCodeForUnitsOfMeasure/"
@@ -332,6 +334,28 @@
 		<cmns-dsg:isDefinedIn rdf:resource="&idmp-amp;AmlodipineEMCComposition"/>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-AnginaPectoris">
+		<rdf:type rdf:resource="&idmp-phprd;TherapeuticIndication"/>
+		<idmp-phprd:hasIndication>
+			<rdf:Description>
+				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
+			</rdf:Description>
+		</idmp-phprd:hasIndication>
+		<idmp-phprd:hasIndicationDescription>indicated for the treatment of stable angina</idmp-phprd:hasIndicationDescription>
+		<idmp-phprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-Hypertension">
+		<rdf:type rdf:resource="&idmp-phprd;TherapeuticIndication"/>
+		<idmp-phprd:hasIndication>
+			<rdf:Description>
+				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
+			</rdf:Description>
+		</idmp-phprd:hasIndication>
+		<idmp-phprd:hasIndicationDescription>indicated for the treatment of hypertension</idmp-phprd:hasIndicationDescription>
+		<idmp-phprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCComposition">
 		<rdf:type rdf:resource="&idmp-mprd;ProductComposition"/>
 		<rdfs:label>Amlodipine EMC composition</rdfs:label>
@@ -569,6 +593,32 @@
 		<cmns-ra:isRegisteredBy rdf:resource="&idmp-eurga;EuropeanMedicinesAgencyAsMedicinesRegulatoryAgency"/>
 		<cmns-txt:hasTextValue>EMEA/H/A-30/1288</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&idmp-amp;MedDRA-AnginaPectoris">
+		<rdfs:label>Angina pectoris</rdfs:label>
+		<rdf:subClassOf rdf:resource="&idmp-phprd;MedicalCondition"/>
+		<cmns-id:isIdentifiedBy>
+			<idmp-phprd:MedDRAMedicalConditionIdentifier>
+				<rdfs:label>10002383</rdfs:label>
+				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
+				<cmns-ra:isRegisteredIn rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
+				<cmns-txt:hasTextValue>10002383</cmns-txt:hasTextValue>
+			</idmp-phprd:MedDRAMedicalConditionIdentifier>
+		</cmns-id:isIdentifiedBy>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-amp;MedDRA-Hypertension">
+		<rdfs:label>Hypertension</rdfs:label>
+		<rdf:subClassOf rdf:resource="&idmp-phprd;MedicalCondition"/>
+		<cmns-id:isIdentifiedBy>
+			<idmp-phprd:MedDRAMedicalConditionIdentifier>
+				<rdfs:label>10020772</rdfs:label>
+				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
+				<cmns-ra:isRegisteredIn rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
+				<cmns-txt:hasTextValue>10020772</cmns-txt:hasTextValue>
+			</idmp-phprd:MedDRAMedicalConditionIdentifier>
+		</cmns-id:isIdentifiedBy>
+	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;Norvasc-ManufacturedItem">
 		<rdf:type rdf:resource="&idmp-sub;ManufacturedItem"/>

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -107,7 +107,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230401/Examples/AmlodipineExample/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230601/Examples/AmlodipineExample/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Informative"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -346,7 +346,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-Hypertension">
-		<rdf:type rdf:resource="&idmp-phprd;TherapeuticIndication"/>
+		<rdf:type rdf:resource="&idmp-mprd;TherapeuticIndication"/>
 		<idmp-mprd:hasIndication>
 			<rdf:Description>
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -597,10 +597,12 @@
 	<owl:Class rdf:about="&idmp-amp;MedDRA-AnginaPectoris">
 		<rdfs:label>Angina pectoris</rdfs:label>
 		<rdf:subClassOf rdf:resource="&idmp-phprd;MedicalCondition"/>
+		<skos:definition>MedDRA concept of angina pectoris medical condition</skos:definition>
 		<cmns-id:isIdentifiedBy>
 			<idmp-phprd:MedDRAMedicalConditionIdentifier>
 				<rdfs:label>10002383</rdfs:label>
 				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
+				<skos:definition>MedDRA identifier for angina pectoris medical condition</skos:definition>
 				<cmns-ra:isRegisteredIn rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
 				<cmns-txt:hasTextValue>10002383</cmns-txt:hasTextValue>
 			</idmp-phprd:MedDRAMedicalConditionIdentifier>
@@ -610,10 +612,12 @@
 	<owl:Class rdf:about="&idmp-amp;MedDRA-Hypertension">
 		<rdfs:label>Hypertension</rdfs:label>
 		<rdf:subClassOf rdf:resource="&idmp-phprd;MedicalCondition"/>
+		<skos:definition>MedDRA concept of hypertension medical condition</skos:definition>
 		<cmns-id:isIdentifiedBy>
 			<idmp-phprd:MedDRAMedicalConditionIdentifier>
 				<rdfs:label>10020772</rdfs:label>
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
+				<skos:definition>MedDRA identifier for hypertension medical condition</skos:definition>
 				<cmns-ra:isRegisteredIn rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
 				<cmns-txt:hasTextValue>10020772</cmns-txt:hasTextValue>
 			</idmp-phprd:MedDRAMedicalConditionIdentifier>

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -599,13 +599,13 @@
 		<rdf:subClassOf rdf:resource="&idmp-mprd;MedicalCondition"/>
 		<skos:definition>MedDRA concept of angina pectoris medical condition</skos:definition>
 		<cmns-id:isIdentifiedBy>
-			<idmp-phprd:MedDRAMedicalConditionIdentifier>
+			<idmp-ra:MedDRAMedicalConditionIdentifier>
 				<rdfs:label>10002383</rdfs:label>
 				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
 				<skos:definition>MedDRA identifier for angina pectoris medical condition</skos:definition>
 				<cmns-ra:isRegisteredIn rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
 				<cmns-txt:hasTextValue>10002383</cmns-txt:hasTextValue>
-			</idmp-phprd:MedDRAMedicalConditionIdentifier>
+			</idmp-ra:MedDRAMedicalConditionIdentifier>
 		</cmns-id:isIdentifiedBy>
 	</owl:Class>
 	
@@ -614,13 +614,13 @@
 		<rdf:subClassOf rdf:resource="&idmp-mprd;MedicalCondition"/>
 		<skos:definition>MedDRA concept of hypertension medical condition</skos:definition>
 		<cmns-id:isIdentifiedBy>
-			<idmp-phprd:MedDRAMedicalConditionIdentifier>
+			<idmp-ra:MedDRAMedicalConditionIdentifier>
 				<rdfs:label>10020772</rdfs:label>
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
 				<skos:definition>MedDRA identifier for hypertension medical condition</skos:definition>
 				<cmns-ra:isRegisteredIn rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
 				<cmns-txt:hasTextValue>10020772</cmns-txt:hasTextValue>
-			</idmp-phprd:MedDRAMedicalConditionIdentifier>
+			</idmp-ra:MedDRAMedicalConditionIdentifier>
 		</cmns-id:isIdentifiedBy>
 	</owl:Class>
 	

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -341,8 +341,8 @@
 				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
 			</rdf:Description>
 		</idmp-mprd:hasIndication>
-		<idmp-mprd:hasIndicationDescription>indicated for the treatment of stable angina</idmp-mprd:hasIndicationDescription>
 		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
+		<cmns-dsg:hasDescription>indicated for the treatment of stable angina</cmns-dsg:hasDescription>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-Hypertension">
@@ -352,8 +352,8 @@
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
 			</rdf:Description>
 		</idmp-mprd:hasIndication>
-		<idmp-mprd:hasIndicationDescription>indicated for the treatment of hypertension</idmp-mprd:hasIndicationDescription>
 		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
+		<cmns-dsg:hasDescription>indicated for the treatment of hypertension</cmns-dsg:hasDescription>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCComposition">

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -341,8 +341,8 @@
 				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
 			</rdf:Description>
 		</idmp-mprd:hasMedicalCondition>
+		<idmp-mprd:hasTherapeuticIndicationText>indicated for the treatment of stable angina</idmp-mprd:hasTherapeuticIndicationText>
 		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
-		<cmns-dsg:hasDescription>indicated for the treatment of stable angina</cmns-dsg:hasDescription>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-Hypertension">
@@ -352,8 +352,8 @@
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
 			</rdf:Description>
 		</idmp-mprd:hasMedicalCondition>
+		<idmp-mprd:hasTherapeuticIndicationText>indicated for the treatment of hypertension</idmp-mprd:hasTherapeuticIndicationText>
 		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
-		<cmns-dsg:hasDescription>indicated for the treatment of hypertension</cmns-dsg:hasDescription>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCComposition">

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -336,22 +336,22 @@
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-AnginaPectoris">
 		<rdf:type rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<idmp-mprd:hasIndication>
+		<idmp-mprd:hasMedicalCondition>
 			<rdf:Description>
 				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
 			</rdf:Description>
-		</idmp-mprd:hasIndication>
+		</idmp-mprd:hasMedicalCondition>
 		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
 		<cmns-dsg:hasDescription>indicated for the treatment of stable angina</cmns-dsg:hasDescription>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-Hypertension">
 		<rdf:type rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<idmp-mprd:hasIndication>
+		<idmp-mprd:hasMedicalCondition>
 			<rdf:Description>
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
 			</rdf:Description>
-		</idmp-mprd:hasIndication>
+		</idmp-mprd:hasMedicalCondition>
 		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
 		<cmns-dsg:hasDescription>indicated for the treatment of hypertension</cmns-dsg:hasDescription>
 	</owl:NamedIndividual>

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -335,25 +335,25 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-AnginaPectoris">
-		<rdf:type rdf:resource="&idmp-phprd;TherapeuticIndication"/>
-		<idmp-phprd:hasIndication>
+		<rdf:type rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<idmp-mprd:hasIndication>
 			<rdf:Description>
 				<rdf:nodeId>MedDRAAnginaPectorisId</rdf:nodeId>
 			</rdf:Description>
-		</idmp-phprd:hasIndication>
-		<idmp-phprd:hasIndicationDescription>indicated for the treatment of stable angina</idmp-phprd:hasIndicationDescription>
-		<idmp-phprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct"/>
+		</idmp-mprd:hasIndication>
+		<idmp-mprd:hasIndicationDescription>indicated for the treatment of stable angina</idmp-mprd:hasIndicationDescription>
+		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMC-TherapeuticIndication-Hypertension">
 		<rdf:type rdf:resource="&idmp-phprd;TherapeuticIndication"/>
-		<idmp-phprd:hasIndication>
+		<idmp-mprd:hasIndication>
 			<rdf:Description>
 				<rdf:nodeId>MedDRAHypertensionId</rdf:nodeId>
 			</rdf:Description>
-		</idmp-phprd:hasIndication>
-		<idmp-phprd:hasIndicationDescription>indicated for the treatment of hypertension</idmp-phprd:hasIndicationDescription>
-		<idmp-phprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMC-PharmaceuticalProduct"/>
+		</idmp-mprd:hasIndication>
+		<idmp-mprd:hasIndicationDescription>indicated for the treatment of hypertension</idmp-mprd:hasIndicationDescription>
+		<idmp-mprd:isTherapeuticIndicationFor rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineEMCComposition">
@@ -596,7 +596,7 @@
 	
 	<owl:Class rdf:about="&idmp-amp;MedDRA-AnginaPectoris">
 		<rdfs:label>Angina pectoris</rdfs:label>
-		<rdf:subClassOf rdf:resource="&idmp-phprd;MedicalCondition"/>
+		<rdf:subClassOf rdf:resource="&idmp-mprd;MedicalCondition"/>
 		<skos:definition>MedDRA concept of angina pectoris medical condition</skos:definition>
 		<cmns-id:isIdentifiedBy>
 			<idmp-phprd:MedDRAMedicalConditionIdentifier>
@@ -611,7 +611,7 @@
 	
 	<owl:Class rdf:about="&idmp-amp;MedDRA-Hypertension">
 		<rdfs:label>Hypertension</rdfs:label>
-		<rdf:subClassOf rdf:resource="&idmp-phprd;MedicalCondition"/>
+		<rdf:subClassOf rdf:resource="&idmp-mprd;MedicalCondition"/>
 		<skos:definition>MedDRA concept of hypertension medical condition</skos:definition>
 		<cmns-id:isIdentifiedBy>
 			<idmp-phprd:MedDRAMedicalConditionIdentifier>

--- a/ISO/ISO11238-RegistrationAuthorities.rdf
+++ b/ISO/ISO11238-RegistrationAuthorities.rdf
@@ -65,8 +65,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-RegistrationAuthorities/"/>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-RegistrationAuthorities.rdf version of this ontology was modified to split the named individual for FDA patent exclusivity into two separate named individuals - one for patent exclusivity and one for FDA exclusivity (IDMP-514)</skos:changeNote>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11238-RegistrationAuthorities/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11238-RegistrationAuthorities.rdf version of this ontology was modified to split the named individual for FDA patent exclusivity into two separate named individuals - one for patent exclusivity and one for FDA exclusivity (IDMP-514) and to add the registry and identifier for the International Medical Dictionary for Regulatory Activities (MeDRA) (IDMP-561).</skos:changeNote>
 		<skos:scopeNote>Note that jurisdiction-specific counterparties and codes are specified in subordinate ontologies supporting those jurisdictions.</skos:scopeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -435,6 +435,26 @@
 		<cmns-av:synonym>TSN</cmns-av:synonym>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&idmp-ra;InternationalCouncilForHarmonisationOfTechnicalRequirementsForPharmaceuticalsForHumanUse">
+		<rdf:type rdf:resource="&cmns-pts;Party"/>
+		<rdfs:label>International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use</rdfs:label>
+		<skos:definition>consortium founded by the European Commission in the EU, Food and Drug Administration (FDA) in the United States, and MHLW/PMDA in Japan that supports drug registration worldwide</skos:definition>
+		<cmns-av:abbreviation>ICH</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.ich.org/page/mission</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) is unique in bringing together the regulatory authorities and pharmaceutical industry to discuss scientific and technical aspects of drug registration. Since its inception in 1990, ICH has gradually evolved, to respond to the increasingly global face of drug development. ICH&apos;s mission is to achieve greater harmonisation worldwide to ensure that safe, effective, and high quality medicines are developed and registered in the most resource-efficient manner. Harmonisation is achieved through the development of ICH Guidelines via a process of scientific consensus with regulatory and industry experts working side-by-side. Key to the success of this process is the commitment of the ICH regulators to implement the final Guidelines.</cmns-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-ra;InternationalCouncilForHarmonisationOfTechnicalRequirementsForPharmaceuticalsForHumanUseRegistrationAuthority">
+		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
+		<rdfs:label>International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use as Registration Authority</rdfs:label>
+		<skos:definition>International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) in its role as a Registration Authority (RA), for registration of medicinal products in the Medical Dictionary for Regulatory Activities</skos:definition>
+		<cmns-av:abbreviation>ICH RA</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>https://www.ich.org/</cmns-av:adaptedFrom>
+		<cmns-av:synonym>MeDRA RA</cmns-av:synonym>
+		<cmns-pts:isPlayedBy rdf:resource="&idmp-ra;InternationalCouncilForHarmonisationOfTechnicalRequirementsForPharmaceuticalsForHumanUse"/>
+		<cmns-ra:manages rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&idmp-ra;InternationalNonproprietaryName">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;SubstanceName"/>
 		<rdfs:subClassOf>
@@ -482,12 +502,33 @@
 		<lcc-lr:hasTextualName>LiverTox</lcc-lr:hasTextualName>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&idmp-ra;MedDRAMedicalConditionIdentifier">
+		<rdfs:subClassOf rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>
+				<owl:hasValue rdf:resource="&idmp-ra;MedicalDictionaryForRegulatoryActivities"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>MedDRA medical condition identifier</rdfs:label>
+		<skos:definition>identifier for medical condition terms registered in the Medical Dictionary for Regulatory Activities registry</skos:definition>
+	</owl:Class>
+	
 	<owl:NamedIndividual rdf:about="&idmp-ra;MedNetINN">
 		<rdf:type rdf:resource="&cmns-ra;Registry"/>
 		<rdfs:label>MedNet INN</rdfs:label>
 		<cmns-av:directSource rdf:resource="https://extranet.who.int/soinn/"/>
 		<cmns-ra:isManagedBy rdf:resource="&idmp-ra;WorldHealthOrganizationRegistrationAuthority"/>
 		<lcc-lr:hasTextualName>MedNet INN</lcc-lr:hasTextualName>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-ra;MedicalDictionaryForRegulatoryActivities">
+		<rdf:type rdf:resource="&cmns-ra;Registry"/>
+		<rdfs:label>Medical Dictionary for Regulatory Activities</rdfs:label>
+		<dct:source rdf:resource="https://www.meddra.org/"/>
+		<skos:definition>The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) developed MedDRA, a rich and highly specific standardised medical terminology to facilitate sharing of regulatory information internationally for medical products used by humans.</skos:definition>
+		<cmns-av:abbreviation>MedDRA</cmns-av:abbreviation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-ra;MedicalSubjectHeadings">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -16,6 +16,7 @@
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-stat "https://www.omg.org/spec/Commons/StatisticalMeasures/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
@@ -48,6 +49,7 @@
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-stat="https://www.omg.org/spec/Commons/StatisticalMeasures/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
@@ -88,6 +90,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/202300601/ISO11615-MedicinalProducts/"/>
@@ -850,8 +853,8 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasPopulationSpecifics"/>
-				<owl:onClass rdf:resource="&idmp-mprd;PopulationSpecifics"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasTargetPopulation"/>
+				<owl:onClass rdf:resource="&idmp-mprd;TargetPopulation"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1879,22 +1882,16 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<cmns-av:explanatoryNote>A placebo is essentially a medicinal product, with the same packaging, etc. from a patient perspective as the actual investigational or authorized product used in a clinical trial, but without the active ingredient studied in the trial.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-mprd;Population">
-		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
-		<rdfs:label>population</rdfs:label>
-		<skos:definition>collection of humans or animals sharing something in common or selected for a purpose</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-mprd;PopulationSpecifics">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+	<owl:Class rdf:about="&idmp-mprd;PopulationCharacteristic">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;Population"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;TargetPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>population specifics</rdfs:label>
-		<skos:definition>specification of a population for use as target of a therapeutic indication or contraindication</skos:definition>
+		<rdfs:label>population characteristic</rdfs:label>
+		<skos:definition>classifier of a target population intended as the target of a therapeutic indication or contraindication</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -2110,6 +2107,22 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<cmns-av:explanatoryNote>When required for expression of strength, the unit of presentation shall be specified in accordance with ISO 11239 and its resulting terminology. The controlled term and a term identifier for the unit of presentation shall be specified in the associated manufactured item or pharmaceutical product. For strength expressed using standard units, the unit of measure symbol and the symbol identifier as defined in ISO 11240 and its resulting controlled vocabulary shall be specified.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;TargetPopulation">
+		<rdfs:subClassOf rdf:resource="&cmns-stat;StatisticalPopulation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>target population</rdfs:label>
+		<skos:definition>collection of patients or consumers for which the indication of a medicinal product is authorised or is under investigation</skos:definition>
+		<skos:editorialNote>This definition should be extended to include requirements for membership, such as being a patient and/or consumer, or animal.</skos:editorialNote>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.81</cmns-av:adaptedFrom>
+		<cmns-av:synonym>population specifics</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;TherapeuticIndication">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
 		<rdfs:subClassOf>
@@ -2156,8 +2169,8 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasPopulationSpecifics"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;PopulationSpecifics"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasTargetPopulation"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;TargetPopulation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -2380,23 +2393,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Annex A, Full Model</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&idmp-mprd;hasPopulationSpecifics">
-		<rdfs:label>has population specifics</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&idmp-mprd;Contraindication">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&idmp-mprd;PopulationSpecifics"/>
-		<skos:definition>relates a therapeutic indication or contraindication to a population category</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasReferenceStrength">
 		<rdfs:subPropertyOf rdf:resource="&idmp-mprd;hasStrength"/>
 		<rdfs:label>has reference strength</rdfs:label>
@@ -2426,6 +2422,23 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>has strength</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;Strength"/>
 		<skos:definition>indicates the actual strength of any element in a substance or pharmaceutical product</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTargetPopulation">
+		<rdfs:label>has target population</rdfs:label>
+		<rdfs:domain>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:domain>
+		<rdfs:range rdf:resource="&idmp-mprd;TargetPopulation"/>
+		<skos:definition>relates a therapeutic indication or contraindication to its the target population</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTherapeuticIndication">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -1449,7 +1449,7 @@ c) medicinal product name;
 d) pharmaceutical dose form;
 e) active ingredient(s)/active moieties and their corresponding strength;
 f) device(s) where a medicinal product is combined with a medical device and where the pharmacological, immunological or metabolic action should be considered as the principal mode of action; the medical device is presented as part of the medicinal product;
-g) therapeutic indication(s) as authorised for the medicinal product.</skos:note>
+g) therapeutic indication(s) as authorized for the medicinal product.</skos:note>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 8.3.2</cmns-av:directSource>
 	</owl:Class>
 	
@@ -1556,7 +1556,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>medicinal product name</rdfs:label>
-		<skos:definition>name as authorised by a medicines regulatory agency</skos:definition>
+		<skos:definition>name as authorized by a medicines regulatory agency</skos:definition>
 		<skos:note>This may be either an invented name not liable to be confused with the common name, or a common or a scientific name accompanied by a trade mark or any other applicable descriptor.</skos:note>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.54</cmns-av:directSource>
 	</owl:Class>
@@ -1981,6 +1981,8 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 							</rdf:Description>
 							<rdf:Description rdf:about="&idmp-mprd;PharmaceuticalProduct">
 							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;MedicinalProduct">
+							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
@@ -2021,11 +2023,41 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<skos:definition>specification for something that is produced by, results from, or obtained as a consequence of some process or transformation</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;QualitativeComposition">
+		<rdfs:subClassOf rdf:resource="&idmp-mprd;ProductComposition"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>qualitative composition</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.70</dct:source>
+		<skos:definition>composition of all the constituents of the investigational or authorized Medicinal Product), if applicable, before or after reconstitution and functioning of the constituents of:
+- the substance (and specified substance description;
+- the excipients, whatever their nature or the quantity used, including colouring matter, preservatives, adjuvants, stabilizers, thickeners, emulsifiers, flavouring and aromatic substances, etc.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;QuantitativeComposition">
+		<rdfs:subClassOf rdf:resource="&idmp-mprd;ProductComposition"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>quantitative composition</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.71</dct:source>
+		<skos:definition>amount of substance and specified substance constituents of the investigational or authorized medicinal product expressed in a ratio scale</skos:definition>
+		<skos:note>It is necessary for the quantitative composition of the substance(s) or the specified substance descriptions of the finished investigational or authorized Medicinal Products (depending on the pharmaceutical form concerned) to specify the mass, or the number of units of biological activity, either per dosage unit or per unit of mass or volume, of each substance or specified substance. Substance or specified substance descriptions present in the form of compounds or derivatives are always designated quantitatively by their total mass and, if necessary or relevant, by the mass of active entity, or entities, of the molecule. The term strength is a synonym of quantitative composition.</skos:note>
+		<cmns-av:usageNote>Note that quantitative composition is modeled as a kind of product composition in the ontology rather than as a quantity value, which is how the strength of a given ingredient is modeled.</cmns-av:usageNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;ReferenceStrength">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Strength"/>
 		<rdfs:label>reference strength</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.72</dct:source>
-		<skos:definition>strength of an active substance(s) and/or specified substance(s) used as a reference from which the strength of an investigational or authorised medicinal product is described</skos:definition>
+		<skos:definition>strength of an active substance(s) and/or specified substance(s) used as a reference from which the strength of an investigational or authorized medicinal product is described</skos:definition>
 		<skos:note>The strength of the active substance(s) and/or specified substance(s) shall be described as a quantity of the substance present in a given unit of the pharmaceutical product or manufactured item.</skos:note>
 	</owl:Class>
 	
@@ -2117,7 +2149,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>target population</rdfs:label>
-		<skos:definition>collection of patients or consumers for which the indication of a medicinal product is authorised or is under investigation</skos:definition>
+		<skos:definition>collection of patients or consumers for which the indication of a medicinal product is authorized or is under investigation</skos:definition>
 		<skos:editorialNote>This definition should be extended to include requirements for membership, such as being a patient and/or consumer, or animal.</skos:editorialNote>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.81</cmns-av:adaptedFrom>
 		<cmns-av:synonym>population specifics</cmns-av:synonym>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2162,9 +2162,9 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasIndicationText"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -2182,10 +2182,11 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>therapeutic indication</rdfs:label>
 		<dct:source rdf:resource="https://www.cancer.gov/publications/dictionaries/cancer-terms/def/indication"/>
 		<rdfs:seeAlso rdf:resource="https://www.ema.europa.eu/en/glossary/indication"/>
-		<skos:definition>a specification about a medical condition that leads to the recommendation of a treatment, test, or procedure</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2</cmns-av:adaptedFrom>
+		<skos:definition>specification that defines the target disease or condition for which the medicinal product is authorized or under investigation</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.2</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>A medical condition that a medicine is used for. This can include the treatment, prevention and diagnosis of a disease. (EMA)</cmns-av:explanatoryNote>
 		<cmns-av:synonym>indication</cmns-av:synonym>
+		<cmns-av:usageNote>This class shall be used to describe the authorized indication(s) for the medicinal product in accordance with the regulated product information. A region may further refine the requirements in relation to the therapeutic indication(s) information at implementation so that this information is to be specified only if required.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;administers">
@@ -2353,14 +2354,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<skos:note>indication as &quot;disease/symptom/procedure&quot;</skos:note>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.3</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasIndicationText">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
-		<rdfs:label>has indication text</rdfs:label>
-		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<skos:definition>the authorized textual description of the medical condition where the treatment is adviced</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.2</cmns-av:adaptedFrom>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -32,7 +32,6 @@
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
-	xmlns="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
@@ -91,7 +90,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230526/ISO11615-MedicinalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/202300601/ISO11615-MedicinalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also extended to include concepts such as process, manufacturing process, process identifier, batch, batch identifier, lot, lot number, and others required in support of the regulatory to manufacturing bridge use case.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename product constituency to product composition, which is better understood by the user community, and to move a couple of restrictions from ingredient to substance, including strength and whether or not that substance is potentially allergenic. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate additional manufacturing and packaging details required for UC-2 (IDMP-465), to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to change the status of this ontology to &apos;release&apos; (IDMP-525), to add content related to dose forms (IDMP-531, IDMP-538), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
@@ -280,7 +279,6 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.47</dct:source>
-		<owl:disjointWith rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
 		<skos:editorialNote>Note that because a manufactured item might be some sort of container or other package item, the dose form is optional.</skos:editorialNote>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packagings, clause 3.1.16</cmns-av:adaptedFrom>
@@ -1753,6 +1751,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>pharmaceutical product</rdfs:label>
+		<owl:disjointWith rdf:resource="&idmp-sub;ManufacturedItem"/>
 		<skos:definition>specification for the qualitative and quantitative composition of a medicinal product in the dose form approved for administration in line with the regulated product information</skos:definition>
 		<skos:note>In many instances, the pharmaceutical product is equal to the manufactured item. However, there are instances where the manufactured item shall undergo a transformation before being administered to the patient (as the pharmaceutical product) and the two are not equal.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
@@ -1809,9 +1808,9 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&idmp-mprd;PharmaceuticalProduct">
-							</rdf:Description>
 							<rdf:Description rdf:about="&idmp-mprd;PhysicalPharmaceuticalProduct">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;PharmaceuticalProduct">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -1995,13 +1994,13 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product composition</rdfs:label>
-		<owl:equivalentClass rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<skos:definition>constituency that defines some product based on its relationship(s) to some other substance(s) (ingredient(s)), potentially with a given strength, in some context</skos:definition>
 		<cmns-av:usageNote>From an implementation (mapping) perspective, this product constituency class provides the basis for a (blank) node in the relationship &apos;product realizes ingredient role played by some substance&apos;, where the ingredient role may be that of an active ingredient which, in turn, may have some basis of strength in some context. The same product constituency could be used to link inactive ingredients to a product in which they are realized. A given product may include multiple active ingredients, each of which may have a different basis of strength.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductConstituency">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-mprd;ProductComposition"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductRole">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2218,7 +2218,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasTherapeuticIndicationText"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger"></owl:qualifiedCardinality>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -719,6 +719,35 @@
 		<skos:definition>two or more manufactured items that are intended to be combined in a specific way to produce a single pharmaceutical product, and that includes information on the manufactured dose form of each manufactured item and the administrable dose form of the pharmaceutical product</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;Comorbidity">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>comorbidity</rdfs:label>
+		<skos:definition>classifier for a cooccurring condition or co-infection that is described as part of the indication</skos:definition>
+		<skos:note>If there is any comorbidity (concurrent condition) or co-infection described as part of the indication as it is referenced in the regulated product information, it can be specified here using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.5, 9.9.2.2.3.5 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>For a much more comprehensive treatise on the concept of comorbidity, including distinctions based on (1) the nature of the health condition, (2) the relative importance of the co-occurring conditions, (3) the chronology of presentation of the conditions, and (4) expanded conceptualizations, see https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2713155/.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;Concentration">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Strength"/>
 		<rdfs:label>concentration</rdfs:label>
@@ -853,6 +882,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasComorbidity"/>
+				<owl:onClass rdf:resource="&idmp-mprd;Comorbidity"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasTargetPopulation"/>
 				<owl:onClass rdf:resource="&idmp-mprd;TargetPopulation"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -860,14 +896,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasComorbidity"/>
-				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasContraindicationText"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -879,9 +908,10 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contraindication</rdfs:label>
-		<skos:definition>prescription that the presence of a sign, symptom, or medical condition makes of a treatment, test, or procedure inadvisable</skos:definition>
-		<skos:note>A jurisdiction may further refine the requirements in relation to the contraindications information at implementation so that this information is to be specified only if required.</skos:note>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3</cmns-av:adaptedFrom>
+		<skos:definition>situation where the medicinal product shall not be given for safety reasons</skos:definition>
+		<skos:note>This class shall be used to describe the authorised contraindication(s) for the Medicinal Product as described in the regulated product information. A jurisdiction may further refine the requirements in relation to the contraindications information at implementation so that this information is to be specified only if required.</skos:note>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.17 and 9.9.2.3</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.3</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;DiscreteManufacturingProcess">
@@ -916,10 +946,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>disease status</rdfs:label>
 		<skos:definition>classifier for the status of a disease or symptom</skos:definition>
-		<skos:note>The status of the disease or symptom of the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified</skos:note>
+		<skos:note>The status of the disease or symptom of the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.4 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -1124,6 +1154,35 @@
 		<rdfs:label>ingredient role code</rdfs:label>
 		<skos:definition>sequence of characters denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</cmns-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;IntendedEffect">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>intended effect</rdfs:label>
+		<skos:definition>classifier for the type of outcome or result intended for the target condition</skos:definition>
+		<skos:note>The intended effect is specifically the part of the indication that describes the type of outcome or result intended for the target condition, whereas the indication is the full text description of the benefits from the medicine for the target condition in the target population.</skos:note>
+		<skos:note>The intended effect, aim or strategy to be achieved by the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.6 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;IntermediatePackaging">
@@ -2188,15 +2247,15 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasMedicalCondition"/>
-				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasIntendedEffect"/>
+				<owl:onClass rdf:resource="&idmp-mprd;IntendedEffect"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasIntendedEffect"/>
-				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasMedicalCondition"/>
+				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2210,7 +2269,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasComorbidity"/>
-				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:onClass rdf:resource="&idmp-mprd;Comorbidity"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2336,6 +2395,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasComorbidity">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has comorbidity</rdfs:label>
 		<rdfs:domain>
 			<owl:Class>
@@ -2347,8 +2407,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:domain>
+		<rdfs:range rdf:resource="&idmp-mprd;Comorbidity"/>
 		<skos:definition>any comorbidity (concurrent condition) or co-infection described as part of the indication or contraindication as it is referenced in the regulated product information</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.5, 9.9.2.3.5</cmns-av:adaptedFrom>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.5, 9.9.2.2.3.5 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasContraindication">
@@ -2359,6 +2423,18 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:note>contraindication as &quot;disease/symptom/procedure&quot;</skos:note>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.17, 9.9.2.3.3</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasContraindicationText">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
+		<rdfs:label>has contraindication text</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;Contraindication"/>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>description of the contraindication(s) in line with the regulated product information as text</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3.2 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.3.1</cmns-av:adaptedFrom>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDefiningStrength">
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasExpression"/>
@@ -2402,11 +2478,18 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIntendedEffect">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has intended effect</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<skos:definition>the intended effect, aim or strategy to be archieved by the indication</skos:definition>
+		<rdfs:range rdf:resource="&idmp-mprd;IntendedEffect"/>
+		<skos:definition>specifies a classifier for the type of outcome or result intended for the target condition</skos:definition>
+		<skos:note>The intended effect can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier should be specified. The intended effect is specifically the part of the indication that describes the type of outcome or result intended for the target condition, whereas the indication is the full text description of the benefits from the medicine for the target condition in the target population.</skos:note>
+		<skos:note>The intended effect, aim or strategy to be achieved by the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.6</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>The intended effect is specifically the part of the indication that describes the type of outcome or result intended for the target condition, whereas the indication is the full text description of the benefits from the medicine for the target condition in the target population.</cmns-av:explanatoryNote>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.6 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasManufacturedItemQuantity">
@@ -2515,7 +2598,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>description of the authorized therapeutic indication as text</skos:definition>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.2 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2.1</cmns-av:adaptedFrom>
 		<cmns-av:synonym>indication text</cmns-av:synonym>
 	</owl:DatatypeProperty>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -629,7 +629,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualDesignation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;Batch"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1161,7 +1161,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualDesignation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;Lot"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1919,7 +1919,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualDesignation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;Process"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1956,7 +1956,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualDesignation"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-id;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;ProcessStep"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2570,9 +2570,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:range rdf:resource="&idmp-mprd;ClinicalTrial"/>
 		<skos:definition>indicates the clinical trial that an individual, company, institution or organization (party), initiates, manages and/or finances</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.78</cmns-av:adaptedFrom>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-id;denotes">
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2262,7 +2262,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasTimingDuration"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-dt;Duration"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2607,11 +2607,15 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTimingDuration">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDuration"/>
 		<rdfs:label>has timing/duration</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-dt;Duration"/>
 		<skos:definition>timing or duration information described as part of the indication</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.7</cmns-av:adaptedFrom>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.7 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2.6</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;immediatelyContains">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2416,6 +2416,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasContraindication">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
 		<rdfs:label>has contraindication</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;Contraindication"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isContraindicationFor"/>
@@ -2566,6 +2567,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTargetPopulation">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
 		<rdfs:label>has target population</rdfs:label>
 		<rdfs:domain>
 			<owl:Class>
@@ -2583,6 +2585,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTherapeuticIndication">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
 		<rdfs:label>has therapeutic indication</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;TherapeuticIndication"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isTherapeuticIndicationFor"/>
@@ -2674,6 +2677,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;isContraindicationFor">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
 		<rdfs:label>is contraindication for</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;Contraindication"/>
 		<skos:definition>inverse of has contraindication</skos:definition>
@@ -2717,6 +2721,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;isTherapeuticIndicationFor">
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
 		<rdfs:label>is therapeutic indication for</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
 		<skos:definition>inverse of has therapeutic indication</skos:definition>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -429,10 +429,6 @@
 		</rdfs:subClassOf>
 	</owl:Class>
 	
-	<rdf:Description rdf:about="&idmp-sub;hasIngredient">
-		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasIngredientRole"/>
-	</rdf:Description>
-	
 	<owl:Class rdf:about="&idmp-uom;UnitOfPresentation">
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.84</dct:source>
 	</owl:Class>
@@ -2225,12 +2221,12 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subPropertyOf rdf:resource="&idmp-sub;hasIngredient"/>
 		<rdfs:label>has active ingredient</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-sub;ActiveIngredient"/>
-		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasActiveIngredientRole"/>
 		<skos:definition>relates something representing the contituents of a pharmaceutical or medicinal product to something in the role of an active ingredient</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasActiveIngredientRole">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasActiveIngredient"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasAuthorization">
@@ -2355,6 +2351,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&idmp-sub;hasIngredient"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIntendedEffect">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -32,6 +32,7 @@
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
+	xmlns="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
@@ -90,11 +91,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230502/ISO11615-MedicinalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230526/ISO11615-MedicinalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also extended to include concepts such as process, manufacturing process, process identifier, batch, batch identifier, lot, lot number, and others required in support of the regulatory to manufacturing bridge use case.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename product constituency to product composition, which is better understood by the user community, and to move a couple of restrictions from ingredient to substance, including strength and whether or not that substance is potentially allergenic. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate additional manufacturing and packaging details required for UC-2 (IDMP-465), to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to change the status of this ontology to &apos;release&apos; (IDMP-525), to add content related to dose forms (IDMP-531, IDMP-538), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate content related to modifications from Figure 15 in ISO 11238 (IDMP-540) and to support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate content related to therapeutic indications in ISO 11615 (IDMP-561).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -278,6 +280,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.47</dct:source>
+		<owl:disjointWith rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
 		<skos:editorialNote>Note that because a manufactured item might be some sort of container or other package item, the dose form is optional.</skos:editorialNote>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adaptedFrom>ISO 11239:2012 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on pharmaceutical dose forms, units of presentation, routes of administration and packagings, clause 3.1.16</cmns-av:adaptedFrom>
@@ -427,6 +430,10 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
+	
+	<rdf:Description rdf:about="&idmp-sub;hasIngredient">
+		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasIngredientRole"/>
+	</rdf:Description>
 	
 	<owl:Class rdf:about="&idmp-uom;UnitOfPresentation">
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.84</dct:source>
@@ -829,6 +836,55 @@
 		<skos:note>Once established in a steady operating state, the nature of the process is not dependent on the length of time of operation. Start-ups, transitions, and shutdowns are usually treated as separate activities and do not necessarily contribute to achieving the desired processing.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:synonym>continuous process</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;Contraindication">
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasContraindication"/>
+				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasDiseaseStatus"/>
+				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasPopulationSpecifics"/>
+				<owl:onClass rdf:resource="&idmp-mprd;PopulationSpecifics"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasComorbidity"/>
+				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasContraindicationsText"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;isContraindicationFor"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>contraindication</rdfs:label>
+		<skos:definition>prescription that the presence of a sign, symptom, or medical condition makes of a treatment, test, or procedure inadvisable</skos:definition>
+		<skos:note>A jurisdiction may further refine the requirements in relation to the contraindications information at implementation so that this information is to be specified only if required.</skos:note>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;DiscreteManufacturingProcess">
@@ -1264,6 +1320,38 @@
 		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) ...</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;MedDRAMedicalConditionIdentifier">
+		<rdfs:subClassOf rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>
+				<owl:hasValue rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>MedDRA medical condition identifier</rdfs:label>
+		<skos:definition>identifier for medical condition terms registered in the Medical Dictionary for Regulatory Activities registry</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;MedicalCondition">
+		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
+		<rdfs:label>medical condition</rdfs:label>
+		<skos:definition>situation in which a patient experiences a pathological condition or disorder that impairs the body&apos;s normal functioning or its parts and is characterized by specific symptoms and/or signs</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;MedicalConditionClassifier">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>medical condition classifier</rdfs:label>
+		<skos:definition>classifier for medical conditions</skos:definition>
+		<skos:note>The classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;MedicinalProduct">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;ProductSpecification"/>
 		<rdfs:subClassOf>
@@ -1665,7 +1753,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>pharmaceutical product</rdfs:label>
-		<owl:disjointWith rdf:resource="&idmp-sub;ManufacturedItem"/>
 		<skos:definition>specification for the qualitative and quantitative composition of a medicinal product in the dose form approved for administration in line with the regulated product information</skos:definition>
 		<skos:note>In many instances, the pharmaceutical product is equal to the manufactured item. However, there are instances where the manufactured item shall undergo a transformation before being administered to the patient (as the pharmaceutical product) and the two are not equal.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
@@ -1722,9 +1809,9 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&idmp-mprd;PhysicalPharmaceuticalProduct">
-							</rdf:Description>
 							<rdf:Description rdf:about="&idmp-mprd;PharmaceuticalProduct">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;PhysicalPharmaceuticalProduct">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -1795,6 +1882,25 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<dct:source>National Cancer Institute Thesaurus, see http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C753</dct:source>
 		<skos:definition>inactive substance, treatment or procedure that is intended to provide baseline measurements for the experimental protocol of a clinical trial</skos:definition>
 		<cmns-av:explanatoryNote>A placebo is essentially a medicinal product, with the same packaging, etc. from a patient perspective as the actual investigational or authorized product used in a clinical trial, but without the active ingredient studied in the trial.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;Population">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:label>population</rdfs:label>
+		<skos:definition>collection of humans or animals sharing something in common or selected for a purpose</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;PopulationSpecifics">
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;Population"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>population specifics</rdfs:label>
+		<skos:definition>specification of a population for use as target of a therapeutic indication or contraindication</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;PresentationStrength">
@@ -1889,13 +1995,13 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>product composition</rdfs:label>
+		<owl:equivalentClass rdf:resource="&idmp-mprd;ProductConstituency"/>
 		<skos:definition>constituency that defines some product based on its relationship(s) to some other substance(s) (ingredient(s)), potentially with a given strength, in some context</skos:definition>
 		<cmns-av:usageNote>From an implementation (mapping) perspective, this product constituency class provides the basis for a (blank) node in the relationship &apos;product realizes ingredient role played by some substance&apos;, where the ingredient role may be that of an active ingredient which, in turn, may have some basis of strength in some context. The same product constituency could be used to link inactive ingredients to a product in which they are realized. A given product may include multiple active ingredients, each of which may have a different basis of strength.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductConstituency">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentClass rdf:resource="&idmp-mprd;ProductComposition"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductRole">
@@ -1966,7 +2072,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasNumerator"/>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasDenominator"/>
 				<owl:onClass>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -1982,7 +2088,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasDenominator"/>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasNumerator"/>
 				<owl:onClass>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -2007,6 +2113,71 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass)</skos:definition>
 		<skos:note>For solid dose forms, strength (concentration) is generally the same as strength (presentation) and therefore is not required to be expressed separately; the strength (presentation) only is required.</skos:note>
 		<cmns-av:explanatoryNote>When required for expression of strength, the unit of presentation shall be specified in accordance with ISO 11239 and its resulting terminology. The controlled term and a term identifier for the unit of presentation shall be specified in the associated manufactured item or pharmaceutical product. For strength expressed using standard units, the unit of measure symbol and the symbol identifier as defined in ISO 11240 and its resulting controlled vocabulary shall be specified.</cmns-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;TherapeuticIndication">
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasIndication"/>
+				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasDiseaseStatus"/>
+				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasIntendedEffect"/>
+				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasTimingDuration"/>
+				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasComorbidity"/>
+				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasIndicationText"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasPopulationSpecifics"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;PopulationSpecifics"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;isTherapeuticIndicationFor"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>therapeutic indication</rdfs:label>
+		<dct:source rdf:resource="https://www.cancer.gov/publications/dictionaries/cancer-terms/def/indication"/>
+		<rdfs:seeAlso rdf:resource="https://www.ema.europa.eu/en/glossary/indication"/>
+		<skos:definition>a specification about a medical condition that leads to the recommendation of a treatment, test, or procedure</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A medical condition that a medicine is used for. This can include the treatment, prevention and diagnosis of a disease. (EMA)</cmns-av:explanatoryNote>
+		<cmns-av:synonym>indication</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;administers">
@@ -2047,6 +2218,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 	<owl:ObjectProperty rdf:about="&idmp-mprd;evaluates">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;appliesTo"/>
 		<rdfs:label>evaluates</rdfs:label>
+		<owl:inverseOf rdf:resource="&idmp-mprd;isEvaluatedBy"/>
 		<skos:definition>assesses the nature, quality, or ability of someone or something</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2054,12 +2226,12 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subPropertyOf rdf:resource="&idmp-sub;hasIngredient"/>
 		<rdfs:label>has active ingredient</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-sub;ActiveIngredient"/>
+		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasActiveIngredientRole"/>
 		<skos:definition>relates something representing the contituents of a pharmaceutical or medicinal product to something in the role of an active ingredient</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasActiveIngredientRole">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentProperty rdf:resource="&idmp-mprd;hasActiveIngredient"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasAuthorization">
@@ -2074,6 +2246,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>has authorized party</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;Authorization"/>
 		<rdfs:range rdf:resource="&idmp-mprd;AuthorizedParty"/>
+		<owl:inverseOf rdf:resource="&idmp-mprd;isAuthorizedThrough"/>
 		<skos:definition>indicates the party that is endorsed, enabled, empowered, or otherwise permitted to do something in the situation</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2098,11 +2271,61 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<skos:definition>indicates the role of an active ingredient as the basis of strength of any substance or pharmaceutical product as manufactured</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasComorbidity">
+		<rdfs:label>has comorbidity</rdfs:label>
+		<rdfs:domain>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:domain>
+		<skos:definition>any comorbidity (concurrent condition) or co-infection described as part of the indication or contraindication as it is referenced in the regulated product information</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.5, 9.9.2.3.5</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasContraindication">
+		<rdfs:label>has contraindication</rdfs:label>
+		<rdfs:range rdf:resource="&idmp-mprd;Contraindication"/>
+		<owl:inverseOf rdf:resource="&idmp-mprd;isContraindicationFor"/>
+		<skos:definition>relates a pharmaceutical product to a contraindication that type of medical conditions where the treatment with the medicinal product is inadviable</skos:definition>
+		<skos:note>contraindication as &quot;disease/symptom/procedure&quot;</skos:note>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3.3</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasContraindicationsText">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
+		<rdfs:label>has containdications text</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<skos:definition>the authorized textual description of the contraindication(s) in line with the regulated product information</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3.2</cmns-av:adaptedFrom>
+	</owl:DatatypeProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDefiningStrength">
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasExpression"/>
 		<rdfs:label>has defining strength</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;Strength"/>
 		<skos:definition>specifies the strength of any element in a substance or pharmaceutical product</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDiseaseStatus">
+		<rdfs:label>has disease status</rdfs:label>
+		<rdfs:domain>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:domain>
+		<skos:definition>status of the disease or symptom of the indication or contraindication</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.4, 9.9.2.3.4</cmns-av:adaptedFrom>
+		<cmns-av:synonym>has disease status</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDoseForm">
@@ -2113,9 +2336,34 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.24</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIndication">
+		<rdfs:label>has indication</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<skos:definition>relates the therapeutic indication to a code or classifier for medical conditions</skos:definition>
+		<skos:example>MedDRA id of a medical condtion concept</skos:example>
+		<skos:note>The underlying disease, symptom or procedure that is the indication for treatment can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<skos:note>indication as &quot;disease/symptom/procedure&quot;</skos:note>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.3</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasIndicationText">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
+		<rdfs:label>has indication text</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<skos:definition>the authorized textual description of the medical condition where the treatment is adviced</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.2</cmns-av:adaptedFrom>
+	</owl:DatatypeProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-		<owl:equivalentProperty rdf:resource="&idmp-sub;hasIngredient"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIntendedEffect">
+		<rdfs:label>has intended effect</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<skos:definition>the intended effect, aim or strategy to be archieved by the indication</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.6</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The intended effect is specifically the part of the indication that describes the type of outcome or result intended for the target condition, whereas the indication is the full text description of the benefits from the medicine for the target condition in the target population.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasManufacturedItemQuantity">
@@ -2134,6 +2382,23 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>has package item quantity</rdfs:label>
 		<skos:definition>indicates the number/quantity of items of the same type in a container</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Annex A, Full Model</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasPopulationSpecifics">
+		<rdfs:label>has population specifics</rdfs:label>
+		<rdfs:domain>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:domain>
+		<rdfs:range rdf:resource="&idmp-mprd;PopulationSpecifics"/>
+		<skos:definition>relates a therapeutic indication or contraindication to a population category</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasReferenceStrength">
@@ -2155,6 +2420,7 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>has sponsor</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;ClinicalTrial"/>
 		<rdfs:range rdf:resource="&idmp-mprd;Sponsor"/>
+		<owl:inverseOf rdf:resource="&idmp-mprd;sponsors"/>
 		<skos:definition>indicates the party that initiates, manages, and/or finances the clinical trial</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.78</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
@@ -2164,6 +2430,22 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>has strength</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;Strength"/>
 		<skos:definition>indicates the actual strength of any element in a substance or pharmaceutical product</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTherapeuticIndication">
+		<rdfs:label>has therapeutic indication</rdfs:label>
+		<rdfs:range rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<owl:inverseOf rdf:resource="&idmp-mprd;isTherapeuticIndicationFor"/>
+		<skos:definition>relates a pharmaceutical product to a therapeutic indication that type of medical conditions where the treatment with the medicinal product is adviced</skos:definition>
+		<skos:note>indication as &quot;Disease / Symptom / Procedure&quot;</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTimingDuration">
+		<rdfs:label>has timing/duration</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<skos:definition>timing or duration information described as part of the indication</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.7</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;immediatelyContains">
@@ -2217,7 +2499,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>is authorized through</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;AuthorizedParty"/>
 		<rdfs:range rdf:resource="&idmp-mprd;Authorization"/>
-		<owl:inverseOf rdf:resource="&idmp-mprd;hasAuthorizedParty"/>
 		<skos:definition>indicates the situation that faciliates endorsement of the authorized party for some purpose</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2226,8 +2507,13 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>
 		<rdfs:label>is contained in</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;ContainerSpecification"/>
-		<owl:inverseOf rdf:resource="&idmp-mprd;contains"/>
 		<skos:definition>is held within</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isContraindicationFor">
+		<rdfs:label>is contraindication for</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;Contraindication"/>
+		<skos:definition>inverse of has contraindication</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&idmp-mprd;isDefinedAsPotentiallyAllergenic">
@@ -2244,7 +2530,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;isEvaluatedBy">
 		<rdfs:label>is evaluated by</rdfs:label>
-		<owl:inverseOf rdf:resource="&idmp-mprd;evaluates"/>
 		<skos:definition>is ascertained or determined by</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2253,7 +2538,6 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:subPropertyOf rdf:resource="&cmns-col;isDirectPartOf"/>
 		<rdfs:label>is immediately contained in</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;ContainerSpecification"/>
-		<owl:inverseOf rdf:resource="&idmp-mprd;immediatelyContains"/>
 		<skos:definition>is specified to hold within its volume or area and be in direct contact with</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -2269,6 +2553,12 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<skos:definition>is produced by or results from some process, process step, action, activity, or other effort</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isTherapeuticIndicationFor">
+		<rdfs:label>is therapeutic indication for</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<skos:definition>inverse of has therapeutic indication</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;managesAdministrationOf">
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasObjectRole"/>
 		<rdfs:label>manages administration of</rdfs:label>
@@ -2282,9 +2572,11 @@ g) therapeutic indication(s) as authorised for the medicinal product.</skos:note
 		<rdfs:label>sponsors</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;Sponsor"/>
 		<rdfs:range rdf:resource="&idmp-mprd;ClinicalTrial"/>
-		<owl:inverseOf rdf:resource="&idmp-mprd;hasSponsor"/>
 		<skos:definition>indicates the clinical trial that an individual, company, institution or organization (party), initiates, manages and/or finances</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.78</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-id;denotes">
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -867,7 +867,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasContraindicationsText"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -1317,19 +1317,6 @@
 		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) ...</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-mprd;MedDRAMedicalConditionIdentifier">
-		<rdfs:subClassOf rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>
-				<owl:hasValue rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>MedDRA medical condition identifier</rdfs:label>
-		<skos:definition>identifier for medical condition terms registered in the Medical Dictionary for Regulatory Activities registry</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-mprd;MedicalCondition">
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
 		<rdfs:label>medical condition</rdfs:label>
@@ -1345,8 +1332,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>medical condition classifier</rdfs:label>
-		<skos:definition>classifier for medical conditions</skos:definition>
-		<skos:note>The classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
+		<skos:definition>classifier for medical terminology that is used for, but not limited to, the registration, documentation and safety monitoring of medicinal products</skos:definition>
+		<skos:note>Classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicinalProduct">
@@ -2332,18 +2319,10 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>has contraindication</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;Contraindication"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isContraindicationFor"/>
-		<skos:definition>relates a pharmaceutical product to a contraindication that type of medical conditions where the treatment with the medicinal product is inadviable</skos:definition>
+		<skos:definition>relates a product to a situation wherein the medicinal product shall not be given for safety reasons</skos:definition>
 		<skos:note>contraindication as &quot;disease/symptom/procedure&quot;</skos:note>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3.3</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.17, 9.9.2.3.3</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasContraindicationsText">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
-		<rdfs:label>has containdications text</rdfs:label>
-		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<skos:definition>the authorized textual description of the contraindication(s) in line with the regulated product information</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.3.2</cmns-av:adaptedFrom>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDefiningStrength">
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasExpression"/>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -839,15 +839,15 @@
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasContraindication"/>
-				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasDiseaseStatus"/>
+				<owl:onClass rdf:resource="&idmp-mprd;DiseaseStatus"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasDiseaseStatus"/>
-				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasMedicalCondition"/>
+				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -893,6 +893,34 @@
 		<skos:note>Products are classified into production lots that are based on common raw materials, production requirements, and production histories.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:synonym>discrete process</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;DiseaseStatus">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>disease status</rdfs:label>
+		<skos:definition>classifier for the status of a disease or symptom</skos:definition>
+		<skos:note>The status of the disease or symptom of the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Dose">
@@ -1325,6 +1353,7 @@
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicalConditionClassifier">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -1334,6 +1363,12 @@
 		<rdfs:label>medical condition classifier</rdfs:label>
 		<skos:definition>classifier for medical terminology that is used for, but not limited to, the registration, documentation and safety monitoring of medicinal products</skos:definition>
 		<skos:note>Classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
+		<skos:note>The underlying disease, symptom or procedure that is the indication for treatment should be specified as it is referenced in the regulated product information using an appropriate controlled reference terminology. The controlled term and the controlled term identifier should be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.2 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:synonym>indication as &apos;disease/symptom/procedure&apos;</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicinalProduct">
@@ -2146,15 +2181,15 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasIndication"/>
-				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasDiseaseStatus"/>
+				<owl:onClass rdf:resource="&idmp-mprd;DiseaseStatus"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasDiseaseStatus"/>
-				<owl:onClass rdf:resource="&cmns-cds;CodeElement"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasMedicalCondition"/>
+				<owl:onClass rdf:resource="&idmp-mprd;MedicalConditionClassifier"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2181,9 +2216,9 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasTherapeuticIndicationText"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger"></owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -2202,7 +2237,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<dct:source rdf:resource="https://www.cancer.gov/publications/dictionaries/cancer-terms/def/indication"/>
 		<rdfs:seeAlso rdf:resource="https://www.ema.europa.eu/en/glossary/indication"/>
 		<skos:definition>specification that defines the target disease or condition for which the medicinal product is authorized or under investigation</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.2</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.2 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>A medical condition that a medicine is used for. This can include the treatment, prevention and diagnosis of a disease. (EMA)</cmns-av:explanatoryNote>
 		<cmns-av:synonym>indication</cmns-av:synonym>
 		<cmns-av:usageNote>This class shall be used to describe the authorized indication(s) for the medicinal product in accordance with the regulated product information. A region may further refine the requirements in relation to the therapeutic indication(s) information at implementation so that this information is to be specified only if required.</cmns-av:usageNote>
@@ -2332,6 +2368,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDiseaseStatus">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has disease status</rdfs:label>
 		<rdfs:domain>
 			<owl:Class>
@@ -2344,8 +2381,11 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 			</owl:Class>
 		</rdfs:domain>
 		<skos:definition>status of the disease or symptom of the indication or contraindication</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.4, 9.9.2.3.4</cmns-av:adaptedFrom>
-		<cmns-av:synonym>has disease status</cmns-av:synonym>
+		<skos:note>The status of the disease or symptom of the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier should be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.4, 9.9.2.3.4 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasDoseForm">
@@ -2354,16 +2394,6 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:range rdf:resource="&idmp-mprd;PharmaceuticalDoseForm"/>
 		<skos:definition>specifies the physical manifestation of a manufactured item or pharmaceutical product containing the active ingredient(s) and/or inactive ingredient(s) that are intended to be delivered to the patient</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.24</cmns-av:adaptedFrom>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIndication">
-		<rdfs:label>has indication</rdfs:label>
-		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
-		<skos:definition>relates the therapeutic indication to a code or classifier for medical conditions</skos:definition>
-		<skos:example>MedDRA id of a medical condtion concept</skos:example>
-		<skos:note>The underlying disease, symptom or procedure that is the indication for treatment can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
-		<skos:note>indication as &quot;disease/symptom/procedure&quot;</skos:note>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.2.3</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasIngredientRole">
@@ -2388,6 +2418,30 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 11</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasMedicalCondition">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
+		<rdfs:label>has medical condition</rdfs:label>
+		<rdfs:domain>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:domain>
+		<skos:definition>relates the contraindication or therapeutic indication to a classifier / code for medical terminology that is used for, but not limited to, the registration, documentation and safety monitoring of medicinal products</skos:definition>
+		<skos:example>MedDRA id of a medical condtion concept</skos:example>
+		<skos:note>Classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
+		<skos:note>The underlying disease, symptom or procedure that is the indication for treatment should be specified as it is referenced in the regulated product information using an appropriate controlled reference terminology. The controlled term and the controlled term identifier should be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.2 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:synonym>indication as &apos;disease/symptom/procedure&apos;</cmns-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasPackageItemQuantity">
@@ -2452,6 +2506,19 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>relates a pharmaceutical product to a therapeutic indication that type of medical conditions where the treatment with the medicinal product is adviced</skos:definition>
 		<skos:note>indication as &quot;Disease / Symptom / Procedure&quot;</skos:note>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasTherapeuticIndicationText">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasDescription"/>
+		<rdfs:label>has therapeutic indication text</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;TherapeuticIndication"/>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>description of the authorized therapeutic indication as text</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2.1</cmns-av:adaptedFrom>
+		<cmns-av:synonym>indication text</cmns-av:synonym>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTimingDuration">
 		<rdfs:label>has timing/duration</rdfs:label>

--- a/ISO/ISO11616-PharmaceuticalProducts.rdf
+++ b/ISO/ISO11616-PharmaceuticalProducts.rdf
@@ -68,7 +68,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11616-PharmaceuticalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230526/ISO11616-PharmaceuticalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11616-PharmaceuticalProducts.rdf version of this ontology was modified to rename &apos;adjuvant role&apos;s to adjuvant for clarification per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Preliminary"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
@@ -125,78 +125,5 @@
 		<skos:note>Strength is also defined as the amount of substance and specified substance constituents of the investigational or authorised medicinal product expressed in a ratio scale.</skos:note>
 		<cmns-av:synonym>quantitative composition</cmns-av:synonym>
 	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-phprd;Contraindication">
-		<rdfs:subClassOf rdf:resource="https://www.omg.org/spec/Commons/Documents/Specification"/>
-		<rdfs:label>contraindication</rdfs:label>
-		<skos:definition>prescription that the presence of a sign, symptom, or medical condition makes of a treatment, test, or procedure inadvisable</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-phprd;MedDRAMedicalConditionIdentifier">
-		<rdfs:subClassOf rdf:resource="&idmp-phprd;MedicalConditionClassifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>
-				<owl:hasValue rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>MedDRA medical condition identifier</rdfs:label>
-		<skos:definition>identifier for medical condition terms registered in the Medical Dictionary for Regulatory Activities registry</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-phprd;MedicalCondition">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
-		<rdfs:label>medical condition</rdfs:label>
-		<skos:definition>situation in which a patient experiences a pathological condition or disorder that impairs the body&apos;s normal functioning or its parts and is characterized by specific symptoms and/or signs</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-phprd;MedicalConditionClassifier">
-		<rdfs:subClassOf rdf:resource="https://www.omg.org/spec/Commons/Classifiers/Classifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://www.omg.org/spec/Commons/Classifiers/classifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-phprd;MedicalCondition"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>medical condition classifier</rdfs:label>
-		<skos:definition>classifier for medical conditions</skos:definition>
-		<skos:note>The classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-phprd;TherapeuticIndication">
-		<rdfs:subClassOf rdf:resource="https://www.omg.org/spec/Commons/Documents/Specification"/>
-		<rdfs:label>therapeutic indication</rdfs:label>
-		<dct:source rdf:resource="https://www.cancer.gov/publications/dictionaries/cancer-terms/def/indication"/>
-		<rdfs:seeAlso rdf:resource="https://www.ema.europa.eu/en/glossary/indication"/>
-		<skos:definition>a specification about a medical condition that leads to the recommendation of a treatment, test, or procedure</skos:definition>
-		<cmns-av:explanatoryNote>A medical condition that a medicine is used for. This can include the treatment, prevention and diagnosis of a disease. (EMA)</cmns-av:explanatoryNote>
-		<cmns-av:synonym>indication</cmns-av:synonym>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&idmp-phprd;hasIndication">
-		<rdfs:label>has indication</rdfs:label>
-		<skos:definition>relates the therapeutic indication to a code or classifier for medical conditions</skos:definition>
-		<skos:example>MedDRA id of a medical condtion concept</skos:example>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&idmp-phprd;hasIndicationDescription">
-		<rdfs:subPropertyOf rdf:resource="https://www.omg.org/spec/Commons/Designators/hasDescription"/>
-		<rdfs:label>has indication description</rdfs:label>
-		<skos:definition>textual description of the medical condition where the treatment is adviced</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&idmp-phprd;hasTherapeuticIndication">
-		<rdfs:label>has therapeutic indication</rdfs:label>
-		<rdfs:range rdf:resource="&idmp-phprd;TherapeuticIndication"/>
-		<owl:inverseOf rdf:resource="&idmp-phprd;isTherapeuticIndicationFor"/>
-		<skos:definition>relates a pharmaceutical product to a therapeutic indication that type of medical conditions where the treatment with the pharmaceutical product is adviced</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&idmp-phprd;isTherapeuticIndicationFor">
-		<rdfs:label>is therapeutic indication for</rdfs:label>
-		<rdfs:domain rdf:resource="&idmp-phprd;TherapeuticIndication"/>
-		<skos:definition>inverse of has therapeutic indication</skos:definition>
-	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/ISO/ISO11616-PharmaceuticalProducts.rdf
+++ b/ISO/ISO11616-PharmaceuticalProducts.rdf
@@ -75,14 +75,6 @@
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities">
-		<rdf:type rdf:resource="&cmns-ra;Registry"/>
-		<rdfs:label>Medical Dictionary for Regulatory Activities</rdfs:label>
-		<skos:definition>The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) developed MedDRA, a rich and highly specific standardised medical terminology to facilitate sharing of regulatory information internationally for medical products used by humans.</skos:definition>
-		<cmns-av:abbreviation>MedDRA</cmns-av:abbreviation>
-		<cmns-av:directSource rdf:resource="https://www.meddra.org/"/>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&idmp-sub;Adjuvant">
 		<dct:source>ISO 11616:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated pharmaceutical product information, clause 3.1.1</dct:source>
 	</owl:Class>

--- a/ISO/ISO11616-PharmaceuticalProducts.rdf
+++ b/ISO/ISO11616-PharmaceuticalProducts.rdf
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY ISO21090-HarmonizedDatatypes "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/">
+	<!ENTITY ISOConformanceAnnotations "https://spec.pistoiaalliance.org/idmp/ontology/META/ISOConformanceAnnotations/">
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
@@ -23,6 +25,9 @@
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/"
+	xmlns="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/"
+	xmlns:ISO21090-HarmonizedDatatypes="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"
+	xmlns:ISOConformanceAnnotations="https://spec.pistoiaalliance.org/idmp/ontology/META/ISOConformanceAnnotations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
@@ -69,6 +74,14 @@
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities">
+		<rdf:type rdf:resource="&cmns-ra;Registry"/>
+		<rdfs:label>Medical Dictionary for Regulatory Activities</rdfs:label>
+		<skos:definition>The International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH) developed MedDRA, a rich and highly specific standardised medical terminology to facilitate sharing of regulatory information internationally for medical products used by humans.</skos:definition>
+		<cmns-av:abbreviation>MedDRA</cmns-av:abbreviation>
+		<cmns-av:directSource rdf:resource="https://www.meddra.org/"/>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;Adjuvant">
 		<dct:source>ISO 11616:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated pharmaceutical product information, clause 3.1.1</dct:source>
@@ -120,5 +133,78 @@
 		<skos:note>Strength is also defined as the amount of substance and specified substance constituents of the investigational or authorised medicinal product expressed in a ratio scale.</skos:note>
 		<cmns-av:synonym>quantitative composition</cmns-av:synonym>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-phprd;Contraindication">
+		<rdfs:subClassOf rdf:resource="https://www.omg.org/spec/Commons/Documents/Specification"/>
+		<rdfs:label>contraindication</rdfs:label>
+		<skos:definition>prescription that the presence of a sign, symptom, or medical condition makes of a treatment, test, or procedure inadvisable</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-phprd;MedDRAMedicalConditionIdentifier">
+		<rdfs:subClassOf rdf:resource="&idmp-phprd;MedicalConditionClassifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>
+				<owl:hasValue rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/MedicalDictionaryForRegulatoryActivities"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>MedDRA medical condition identifier</rdfs:label>
+		<skos:definition>identifier for medical condition terms registered in the Medical Dictionary for Regulatory Activities registry</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-phprd;MedicalCondition">
+		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
+		<rdfs:label>medical condition</rdfs:label>
+		<skos:definition>situation in which a patient experiences a pathological condition or disorder that impairs the body&apos;s normal functioning or its parts and is characterized by specific symptoms and/or signs</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-phprd;MedicalConditionClassifier">
+		<rdfs:subClassOf rdf:resource="https://www.omg.org/spec/Commons/Classifiers/Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="https://www.omg.org/spec/Commons/Classifiers/classifies"/>
+				<owl:someValuesFrom rdf:resource="&idmp-phprd;MedicalCondition"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>medical condition classifier</rdfs:label>
+		<skos:definition>classifier for medical conditions</skos:definition>
+		<skos:note>The classifiers for medical conditions are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-phprd;TherapeuticIndication">
+		<rdfs:subClassOf rdf:resource="https://www.omg.org/spec/Commons/Documents/Specification"/>
+		<rdfs:label>therapeutic indication</rdfs:label>
+		<dct:source rdf:resource="https://www.cancer.gov/publications/dictionaries/cancer-terms/def/indication"/>
+		<rdfs:seeAlso rdf:resource="https://www.ema.europa.eu/en/glossary/indication"/>
+		<skos:definition>a specification about a medical condition that leads to the recommendation of a treatment, test, or procedure</skos:definition>
+		<cmns-av:explanatoryNote>A medical condition that a medicine is used for. This can include the treatment, prevention and diagnosis of a disease. (EMA)</cmns-av:explanatoryNote>
+		<cmns-av:synonym>indication</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&idmp-phprd;hasIndication">
+		<rdfs:label>has indication</rdfs:label>
+		<skos:definition>relates the therapeutic indication to a code or classifier for medical conditions</skos:definition>
+		<skos:example>MedDRA id of a medical condtion concept</skos:example>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&idmp-phprd;hasIndicationDescription">
+		<rdfs:subPropertyOf rdf:resource="https://www.omg.org/spec/Commons/Designators/hasDescription"/>
+		<rdfs:label>has indication description</rdfs:label>
+		<skos:definition>textual description of the medical condition where the treatment is adviced</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-phprd;hasTherapeuticIndication">
+		<rdfs:label>has therapeutic indication</rdfs:label>
+		<rdfs:range rdf:resource="&idmp-phprd;TherapeuticIndication"/>
+		<owl:inverseOf rdf:resource="&idmp-phprd;isTherapeuticIndicationFor"/>
+		<skos:definition>relates a pharmaceutical product to a therapeutic indication that type of medical conditions where the treatment with the pharmaceutical product is adviced</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-phprd;isTherapeuticIndicationFor">
+		<rdfs:label>is therapeutic indication for</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-phprd;TherapeuticIndication"/>
+		<skos:definition>inverse of has therapeutic indication</skos:definition>
+	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -32,6 +32,7 @@
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/QuantitiesAndUnits/" uri="./CMNS/QuantitiesAndUnits.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RegistrationAuthorities/" uri="./CMNS/RegistrationAuthorities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RegulatoryAgencies/" uri="./CMNS/RegulatoryAgencies.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/StatisticalMeasures/" uri="./CMNS/StatisticalMeasures.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/StructuredCollections/" uri="./CMNS/StructuredCollections.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/TextDatatype/" uri="./CMNS/TextDatatype.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/LCC/MetadataLCC/" uri="./LCC/MetadataLCC.rdf"/>


### PR DESCRIPTION
Description: This resolution augments the ontology to include therapeutic indications (with all elements of that class on Figure 14 in the ISO 11615 standard) and contraindications (again with all elements of that class on Figure 14 in the ISO 11615 standard as well as updates the Amlodipine example. Other concepts required to complete the details presented in Figure 14 for clinical particulars will be covered as required by use cases.