### PR TITLE
IDMP-599 Adding UC2-CQ1 Amlodipine to sparql and unit tests.

### DIFF
--- a/etc/CQ/Example/uc2_cq1.sparql
+++ b/etc/CQ/Example/uc2_cq1.sparql
@@ -10,6 +10,7 @@ SELECT DISTINCT ?ManufacturedItem (SAMPLE(?ManufacturedItemLabel) AS ?Manufactur
 
 WHERE {
     # Bind Variable substance <$Substance>
+    # Example for Amplodipine: <https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/AmlodipineBesylate>
 	# Example for Terlipressin: <https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/TerlipressinExample/TerlipressinAcetate>
     BIND( uc2_cq1_parameter_1 AS $Substance )
 

--- a/etc/unit_tests/configs/idmp_tests_config.yaml
+++ b/etc/unit_tests/configs/idmp_tests_config.yaml
@@ -118,7 +118,11 @@ uc2_cq1-2_tests_amlodipine:
   expected_output: "cq_expected_results/IDMP/uc2_cq1-2_amlodipine_expected_results.json"
 # Missing terlipressin inputs
 
-# Missing amlodipine inputs
+uc2_cq1_tests_amlodipine:
+  sparql_template: "cq_templates/uc2_cq1.sparql"
+  parameters:
+    uc2_cq1_parameter_1: "<https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/AmlodipineBesylate>"
+  expected_output: "cq_expected_results/IDMP/uc2_cq1_amlodipine_expected_results.json"
 uc2_cq1_tests_terlipressin:
   sparql_template: "cq_templates/uc2_cq1.sparql"
   parameters:

--- a/etc/unit_tests/cq_expected_results/IDMP/uc2_cq1_amlodipine_expected_results.json
+++ b/etc/unit_tests/cq_expected_results/IDMP/uc2_cq1_amlodipine_expected_results.json
@@ -1,0 +1,16 @@
+{
+  "results": {
+    "bindings": [
+      {
+        "ManufacturedItem": { "type": "uri" , "value": "https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/Norvasc-ManufacturedItem" } ,
+        "ManufacturedItemName": { "type": "literal" , "value": "Norvasc - manufactured item" }
+      }
+    ]
+  },
+  "head": {
+    "vars": [
+      "ManufacturedItem",
+      "ManufacturedItemName"
+    ]
+  }
+}


### PR DESCRIPTION
Results of IDMP-599:

UC1-CQ8 ( Investigational Medicinal Products ) Missing Example data in amlodipine. ( TBD in IDMP-610)

UC2-CQ1 Sparql and unit tests missing amlodipine.  ( This Pull Request) 