### PR TITLE
GitHub-278 - hasSimplifiedMolecularInputLineEntrySpecification is misleading and inconsistent

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -293,9 +293,9 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateSimplifiedMolecularInputLineEntry">
-		<rdf:type rdf:resource="&idmp-sub;SimplifiedMolecularInputLineEntry"/>
+		<rdf:type rdf:resource="&idmp-sub;SMILES"/>
 		<rdfs:label>amlodipine besylate simplified molecular input line entry</rdfs:label>
-		<cmns-txt:hasTextValue>OS(=O)(=O)C1=CC=CC=C1.CCOC(=O)C2=C(COCCN)NC(C)=C(C2C3=C(Cl)C=CC=C3)C(=O)OC</cmns-txt:hasTextValue>
+		<idmp-sub:hasSMILESValue>OS(=O)(=O)C1=CC=CC=C1.CCOC(=O)C2=C(COCCN)NC(C)=C(C2C3=C(Cl)C=CC=C3)C(=O)OC</idmp-sub:hasSMILESValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineCommonName">
@@ -498,9 +498,9 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateSimplifiedMolecularInputLineEntry">
-		<rdf:type rdf:resource="&idmp-sub;SimplifiedMolecularInputLineEntry"/>
+		<rdf:type rdf:resource="&idmp-sub;SMILES"/>
 		<rdfs:label>amlodipine mesylate monohydrate simplified molecular input line entry</rdfs:label>
-		<cmns-txt:hasTextValue>O.CS(O)(=O)=O.CCOC(=O)C1=C(COCCN)NC(C)=C(C1C1=C(Cl)C=CC=C1)C(=O)OC</cmns-txt:hasTextValue>
+		<idmp-sub:hasSMILESValue>O.CS(O)(=O)=O.CCOC(=O)C1=C(COCCN)NC(C)=C(C1C1=C(Cl)C=CC=C1)C(=O)OC</idmp-sub:hasSMILESValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMolecularFormula">
@@ -562,9 +562,9 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineSimplifiedMolecularInputLineEntry">
-		<rdf:type rdf:resource="&idmp-sub;SimplifiedMolecularInputLineEntry"/>
+		<rdf:type rdf:resource="&idmp-sub;SMILES"/>
 		<rdfs:label>amlodipine simplified molecular input line entry</rdfs:label>
-		<cmns-txt:hasTextValue>CCOC(=O)C1=C(NC(=C(C1C2=CC=CC=C2Cl)C(=O)OC)C)COCCN</cmns-txt:hasTextValue>
+		<idmp-sub:hasSMILESValue>CCOC(=O)C1=C(NC(=C(C1C2=CC=CC=C2Cl)C(=O)OC)C)COCCN</idmp-sub:hasSMILESValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;Cardboard">

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -359,9 +359,9 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSimplifiedMolecularInputLineEntry">
-		<rdf:type rdf:resource="&idmp-sub;SimplifiedMolecularInputLineEntry"/>
+		<rdf:type rdf:resource="&idmp-sub;SMILES"/>
 		<rdfs:label>terlipressin acetate simplified molecular input line entry</rdfs:label>
-		<cmns-txt:hasTextValue>CC(=O)O.CC(=O)O.C1CC(N(C1)C(=O)C2CSSCC(C(=O)NC(C(=O)NC(C(=O)NC(C(=O)NC(C(=O)N2)CC(=O)N)CCC(=O)N)CC3=CC=CC=C3)CC4=CC=C(C=C4)O)NC(=O)CNC(=O)CNC(=O)CN)C(=O)NC(CCCCN)C(=O)NCC(=O)N</cmns-txt:hasTextValue>
+		<idmp-sub:hasSMILESValue>CC(=O)O.CC(=O)O.C1CC(N(C1)C(=O)C2CSSCC(C(=O)NC(C(=O)NC(C(=O)NC(C(=O)NC(C(=O)N2)CC(=O)N)CCC(=O)N)CC3=CC=CC=C3)CC4=CC=C(C=C4)O)NC(=O)CNC(=O)CNC(=O)CN)C(=O)NC(CCCCN)C(=O)NCC(=O)N</idmp-sub:hasSMILESValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateStrengthAsManufacturedInTerlipressinAcetate1MgPerAmpouleSolutionForInjection">
@@ -567,9 +567,9 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinSimplifiedMolecularInputLineEntry">
-		<rdf:type rdf:resource="&idmp-sub;SimplifiedMolecularInputLineEntry"/>
+		<rdf:type rdf:resource="&idmp-sub;SMILES"/>
 		<rdfs:label>terlipressin simplified molecular input line entry</rdfs:label>
-		<cmns-txt:hasTextValue>O=C(N)CNC(=O)[C@@H](NC(=O)[C@H]4N(C(=O)[C@H]1NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)CNC(=O)CNC(=O)CN)CSSC1)Cc2ccc(O)cc2)Cc3ccccc3)CCC(=O)N)CC(=O)N)CCC4)CCCCN</cmns-txt:hasTextValue>
+		<idmp-sub:hasSMILESValue>O=C(N)CNC(=O)[C@@H](NC(=O)[C@H]4N(C(=O)[C@H]1NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)CNC(=O)CNC(=O)CN)CSSC1)Cc2ccc(O)cc2)Cc3ccccc3)CCC(=O)N)CC(=O)N)CCC4)CCCCN</idmp-sub:hasSMILESValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;UNII-4U092XZF0K">

--- a/ISO/ISO11238-Substances-DeprecatedElements.rdf
+++ b/ISO/ISO11238-Substances-DeprecatedElements.rdf
@@ -26,7 +26,7 @@
 		<dct:abstract>This ontology extends the ISO 11238 Substances to incorporate deprecated concepts previously defined in the primary ISO 11238 Regulated Information on Substances Ontology (https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances). It will be eliminated from the released ontologies no later than the 0.6.0 release unless newly deprecated elements are added to this ontology. The motivation for moving these elements is that some tools, such as Protege, move the equivalent class relationships on deprecated elements to the new class when updates are saved, which makes the deprecated elements more difficult to ignore and eventually eliminate.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11238-Substances-DeprecatedElements/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances-DeprecatedElements/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -57,9 +57,19 @@
 		<owl:equivalentClass rdf:resource="&idmp-sub;Ingredient"/>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-sub;SimplifiedMolecularInputLineEntry">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&idmp-sub;SMILES"/>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-sub;SubstanceConstituency">
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
 		<owl:equivalentClass rdf:resource="&idmp-sub;SubstanceComposition"/>
 	</owl:Class>
+	
+	<owl:DatatypeProperty rdf:about="&idmp-sub;hasSimplifiedMolecularInputLineEntrySpecification">
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentProperty rdf:resource="&idmp-sub;hasSMILESValue"/>
+	</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -93,6 +93,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11238-Substances.rdf version of this ontology was modified to integrate a revised manufactured item and packaging strategy for UC-2. (IDMP-465)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230301/ISO11238-Substances.rdf version of this ontology was modified to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to extend the ontology to support some of the required and optional elements from Annex L (IDMP-483) for substances and chemical substances, to add restrictions for name and identifier to the moiety class (IDMP-510), to add content related to dose forms (IDMP-531), to revise the definitions of physical manufactured item and physical substance to add an annotation that they are extensions rather than that they correspond precisely to the IDMP 11238 standard (IDMP-528), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230502/ISO11238-Substances.rdf version of this ontology was modified to integrate content related to modifications from Figure 15 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-540), to support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), to move deprecated elements to a separate ontology, and to support additional reference information from Figure 16 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-522), addressed punning issues with modification method type, aligned the ontology with the revised basis of strength pattern (IDMP-582), and to add an axiom indicating that certain elements have data that can be used for testing purposes.</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances.rdf version of this ontology was modified to rename hasSimplifiedMolecularInputLineEntrySpecification to hasSMILES.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -1601,7 +1602,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Structure"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-sub;hasSimplifiedMolecularInputLineEntrySpecification"/>
+				<owl:onProperty rdf:resource="&idmp-sub;hasSMILESValue"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 			</owl:Restriction>
@@ -2710,6 +2711,24 @@
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause G.3.13</cmns-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-sub;SMILES">
+		<rdfs:subClassOf rdf:resource="&idmp-sub;StructuralRepresentation"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasSMILESValue"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>SMILES</rdfs:label>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause A.2.3</dct:source>
+		<skos:definition>specification for an unambiguous linear representation of chemical or molecular structures using ASCII characters</skos:definition>
+		<skos:note>It is predominantly used by Daylight Chemical Information Systems Inc., although an open source version has been recently developed. Canonical smiles is a SMILES string that is unique for each structure and can be used to ensure that duplicate structures are not entered into a database.</skos:note>
+		<skos:note>Other linear representation forms for chemical structures include SYBYL line notation (SLN) and the older Wiswesser Line Notation, which was the first line notation for the representation of chemical structures. These other formats are not currently in wide use.</skos:note>
+		<cmns-av:abbreviation>SMILES</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause A.2.3</cmns-av:adaptedFrom>
+		<cmns-av:synonym>simplified molecular input line entry</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-sub;Salt">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Substance"/>
 		<rdfs:label>salt</rdfs:label>
@@ -2725,23 +2744,6 @@
 		<rdfs:label>scientific context</rdfs:label>
 		<skos:definition>context that reflects the viewpoint of subject matter experts that are scientists, including but not limited to organic chemists</skos:definition>
 		<cmns-av:explanatoryNote>Certain definitions used in the IDMP standards appear to be specific to regulatory reporting, which differ with the perspective of a chemist (scientist) performing analysis. In such cases in this ontology we will attempt to capture both perspectives and identify distinctions to limit ambiguity.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-sub;SimplifiedMolecularInputLineEntry">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;StructuralRepresentation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-txt;hasTextValue"/>
-				<owl:someValuesFrom rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>simplified molecular input line entry</rdfs:label>
-		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause A.2.3</dct:source>
-		<skos:definition>specification for an unambiguous linear representation of chemical or molecular structures using ASCII characters</skos:definition>
-		<skos:note>It is predominantly used by Daylight Chemical Information Systems Inc., although an open source version has been recently developed. Canonical smiles is a SMILES string that is unique for each structure and can be used to ensure that duplicate structures are not entered into a database.</skos:note>
-		<skos:note>Other linear representation forms for chemical structures include SYBYL line notation (SLN) and the older Wiswesser Line Notation, which was the first line notation for the representation of chemical structures. These other formats are not currently in wide use.</skos:note>
-		<cmns-av:abbreviation>SMILES</cmns-av:abbreviation>
-		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause A.2.3</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SingleSubstance">
@@ -5167,16 +5169,18 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 		<cmns-av:explanatoryNote>It may be known that lysine residues are modified but the particular lysine in the sequence may not be known. It should be captured for both specific and non-specific modifications, e.g. sizing carbohydrate polymers by hydrolysis.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&idmp-sub;hasSimplifiedMolecularInputLineEntrySpecification">
+	<owl:DatatypeProperty rdf:about="&idmp-sub;hasSMILESValue">
 		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
-		<rdfs:label>has simplified molecular input line entry specification</rdfs:label>
+		<rdfs:label>has SMILES value</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause A.2.3</dct:source>
 		<rdfs:domain rdf:resource="&idmp-sub;MolecularStructure"/>
 		<skos:definition>specification for an unambiguous linear representation of chemical or molecular structures using ASCII characters</skos:definition>
 		<skos:note>It is predominantly used by Daylight Chemical Information Systems Inc., although an open source version has been recently developed. Canonical smiles is a SMILES string that is unique for each structure and can be used to ensure that duplicate structures are not entered into a database.</skos:note>
 		<skos:note>Other linear representation forms for chemical structures include SYBYL line notation (SLN) and the older Wiswesser Line Notation, which was the first line notation for the representation of chemical structures. These other formats are not currently in wide use.</skos:note>
 		<cmns-av:abbreviation>SMILES</cmns-av:abbreviation>
+		<cmns-av:abbreviation>has SMILES</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause A.2.3</cmns-av:adaptedFrom>
+		<cmns-av:synonym>has simplified molecular input line entry specification</cmns-av:synonym>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasStereochemistry">

--- a/etc/CQ/Example/uc1_cq9.sparql
+++ b/etc/CQ/Example/uc1_cq9.sparql
@@ -26,5 +26,5 @@ WHERE {
     OPTIONAL{?Structure  rdfs:label  ?StructureLabel }
     
     # Get the Text Value of the representation (optional)
-    optional {?Structure cmns-txt:hasTextValue ?StructureTextValue } .
+    optional {?Structure idmp-sub:hasSMILESValue ?StructureTextValue } .
 } GROUP BY ?Structure

--- a/etc/transformation/GSRS/gsrs-public-data-substances.rqg
+++ b/etc/transformation/GSRS/gsrs-public-data-substances.rqg
@@ -32,7 +32,7 @@ GENERATE {
 
     # Molecular Structure
     ?MolecularStructure a idmp-sub:MolecularStructure ;
-        idmp-sub:hasSimplifiedMolecularInputLineEntrySpecification ?structureSmilesString ;
+        idmp-sub:hasSMILESValue ?structureSmilesString ;
     .
 }
 


### PR DESCRIPTION
Description: Changed the class and property for SimplifiedMolecularInputLineEntry to SMILES and deprecated the originals throughout per SME request