### PR TITLE
IDMP-533 - Provide alignment/mapping for ISO "codedConcept" to the target IDMP-O Pattern for Reference Code Lists

### DIFF
--- a/AboutIDMPDev-ReferenceIndividuals.rdf
+++ b/AboutIDMPDev-ReferenceIndividuals.rdf
@@ -81,7 +81,18 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-2-LanguageCodes/"/>
 		
-	<!-- 
+<!-- 
+	///////////////////////////////////////////////////////////////////////////////////////
+	//
+	// Multiple Vocabulary Facility Subject Area (MF), including ontologies that may be dereferenced from the Object Management Group (OMG)
+	//
+	///////////////////////////////////////////////////////////////////////////////////////
+	-->		
+
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		
+<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
 	//
 	// Identification of Medicinal Products (IDMP) ISO Standard-specific Normative Subject Areas

--- a/AboutIDMPDev.rdf
+++ b/AboutIDMPDev.rdf
@@ -80,7 +80,19 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-2-LanguageCodes/"/>
 		
-	<!-- 
+<!-- 
+	///////////////////////////////////////////////////////////////////////////////////////
+	//
+	// Multiple Vocabulary Facility Subject Area (MF), including ontologies that may be dereferenced from the Object Management Group (OMG)
+	//
+	///////////////////////////////////////////////////////////////////////////////////////
+	-->		
+
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		
+
+<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
 	//
 	// Identification of Medicinal Products (IDMP) ISO Standard-specific Normative Subject Areas

--- a/AboutIDMPProd-ReferenceIndividuals.rdf
+++ b/AboutIDMPProd-ReferenceIndividuals.rdf
@@ -22,7 +22,7 @@
   <owl:Ontology rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/AboutIDMPProd-ReferenceIndividuals/">
   		<rdfs:label>About IDMP Production - Reference Individuals</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of IDMP users. It loads the IDMP production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that while metadata files and other 'load' files, such as the various subject area specific 'all' files, are intentionally excluded, this version of the 'load' file does include all reference data, such as governments and related jurisdictions required for complete IDMP representation.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2023-05-17T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2023-07-22T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>		
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>		
@@ -80,7 +80,18 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-2-LanguageCodes/"/>
 		
-			<!-- 
+<!-- 
+	///////////////////////////////////////////////////////////////////////////////////////
+	//
+	// Multiple Vocabulary Facility Subject Area (MF), including ontologies that may be dereferenced from the Object Management Group (OMG)
+	//
+	///////////////////////////////////////////////////////////////////////////////////////
+	-->		
+
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		
+<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
 	//
 	// Identification of Medicinal Products (IDMP) ISO Standard-specific Normative Subject Areas

--- a/AboutIDMPProd.rdf
+++ b/AboutIDMPProd.rdf
@@ -22,7 +22,7 @@
   <owl:Ontology rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/AboutIDMPProd/">
   		<rdfs:label>About IDMP Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of IDMP users. It loads the IDMP production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release. Note that reference data, metadata files and other 'load' files, such as the various subject area specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2023-05-17T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2023-07-22T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>		
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>		
@@ -72,7 +72,18 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-2-LanguageCodes/"/>
 		
-			<!-- 
+<!-- 
+	///////////////////////////////////////////////////////////////////////////////////////
+	//
+	// Multiple Vocabulary Facility Subject Area (MF), including ontologies that may be dereferenced from the Object Management Group (OMG)
+	//
+	///////////////////////////////////////////////////////////////////////////////////////
+	-->		
+
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		
+<!-- 
 	///////////////////////////////////////////////////////////////////////////////////////
 	//
 	// Identification of Medicinal Products (IDMP) ISO Standard-specific Normative Subject Areas
@@ -89,7 +100,7 @@
 	<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"/>
 	<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
 	
-	<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230601/AboutIDMPProd/"/>
+	<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230701/AboutIDMPProd/"/>
 	
   </owl:Ontology>
 

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -1090,6 +1090,8 @@
 		</rdfs:subClassOf>
 		<rdfs:label>isotopic substitution classifier</rdfs:label>
 		<skos:definition>classifier for an isotopic substitution by site of substitution</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3</cmns-av:adaptedFrom>
 		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
@@ -2071,6 +2073,11 @@
 			</owl:Class>
 		</owl:equivalentClass>
 		<skos:definition>classifier that indicates the status of an official name from a pre-defined ISO 19844 code set</skos:definition>
+		<skos:example>Current, Alternate, Superseded, Proposed, Primary</skos:example>
+		<idmp-sub:hasBusinessRules>Each official name shall have a single status. The fact that a name is alternate is evident by having more than one name assigned to the same substance by the same authority for the same language, domain, etc.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-sub:hasValuesAllowed>Current, Alternate, Superseded, Proposed, Primary</idmp-sub:hasValuesAllowed>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;OfficialNameStatus-Alternate">
@@ -2166,6 +2173,10 @@
 		<skos:definition>classifier specifying the ability of a chemical substance to rotate the plane of vibration of polarized light to the right or left</skos:definition>
 		<skos:example>(+/-), (+), (-), None, N/A, Unknown</skos:example>
 		<skos:note>The extent of optical rotation is not mandatory at the substance level.</skos:note>
+		<idmp-sub:hasBusinessRules>Shall be entered if known for substances that have at least one moiety with stereochemistry defined as chiral. Can be a defining element when the absolute stereo configuration is not known.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-sub:hasValuesAllowed>(+/-), (+), (-), None, N/A</idmp-sub:hasValuesAllowed>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;OpticalActivity-EitherDirection">
@@ -3183,6 +3194,10 @@
 		</rdfs:subClassOf>
 		<rdfs:label>source material classifier code</rdfs:label>
 		<skos:definition>code for the general high-level classification of the source material specific to the origin of the material</skos:definition>
+		<skos:example>mineral, biologic, organic, botanical</skos:example>
+		<idmp-sub:hasBusinessRules>For Structurally Diverse substances, this class shall be Mandatory.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.9.1</cmns-av:adaptedFrom>
 		<cmns-av:synonym>source material class code</cmns-av:synonym>
 		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
@@ -4239,6 +4254,11 @@
 			</owl:Class>
 		</owl:equivalentClass>
 		<skos:definition>classifier that describes the nature of the substance name from a pre-defined ISO 19844 code set</skos:definition>
+		<skos:example>Official Name; Systematic Name; Scientific Name; Company Code; Other Name; Brand Name; Herbal Name; Homeopathic Name; Specified Homeopathic Name; Plasma-Derived Name; Preferred Name; Specified Substance Group 1 Name; Specified Substance Group 2 Name; Specified Substance Group 3 Name; Display Name, Common Name; Specified Substance Group 1, Display Name; Specified Substance Group 2, Display Name; Specified Substance Group 3, Display Name; Specified Substance Group 4, Display Name</skos:example>
+		<idmp-sub:hasBusinessRules>A Substance Name shall always correspond to at least one and only one Substance Name Type. The Preferred Name is the name that describes at least all moieties of a substance and shall be used in all EU languages, e.g. Benzathine Benzylpenicillin tetrahydrate (Dutch: Benzathinebenzylpenicillinetetrahydraat). For the Substance (fresh) (e.g. Harpagophytum procumbens (Burch.) DC. ex Meisn., Root) the Substance Name Type shall be &apos;Other&apos;. Specified Substance Group 1, 2 and 3 name types are used to guide the user with regards to which level the substance name belongs to e.g. water for injection – Ph.Eur. is a name having the substance name type: Specified Substance Group 3.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-sub:hasValuesAllowed>Official Name, Systematic Name, Scientific Name, Company Code, Other Name, Brand Name, Herbal Name, Homeopathic Name, Specified Homeopathic Name, Plasma-Derived Name, Preferred Name, Specified Substance Group 1 Name, Specified Substance Group 2 Name, Specified Substance Group 3 Name, Display Name, Common Name</idmp-sub:hasValuesAllowed>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:synonym>substance name type</cmns-av:synonym>
 	</owl:Class>
 	

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -24,6 +24,7 @@
 	<!ENTITY idmp-uom "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -55,6 +56,7 @@
 	xmlns:idmp-uom="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -64,7 +66,7 @@
 	<owl:Ontology rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/">
 		<rdfs:label>ISO 11238 Regulated Information on Substances Ontology</rdfs:label>
 		<dct:abstract>The regulated information on substances ontology provides a semantic model representing the definitions for exchanging basic concepts for the unique identification and exchange of regulated information on substances. It is derived from the ISO 11238:2018 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of regulated information on substances standard.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
@@ -87,13 +89,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11238-Substances/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11238-Substances.rdf version of this ontology was modified to relax the restriction on the property isStoichiometric with respect to chemical substances to optional from required (IDMP-380), and then reversed per the SME team and to conform with the IDMP standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11238-Substances.rdf version of this ontology was modified to relax the restriction on the property hasStructure with respect to substances, single substances, and moieties to optional from at most one value, to allow for cases where there may be multiples, especially if mapping content from multiple repositories (IDMP-GitHub-244) to add definitions for certain stereochemistry nominals where they were missing (IDMP-GitHub-243), and to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename substance constituency to substance composition, which is better understood by the user community. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11238-Substances.rdf version of this ontology was modified to integrate a revised manufactured item and packaging strategy for UC-2. (IDMP-465)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230301/ISO11238-Substances.rdf version of this ontology was modified to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to extend the ontology to support some of the required and optional elements from Annex L (IDMP-483) for substances and chemical substances, to add restrictions for name and identifier to the moiety class (IDMP-510), to add content related to dose forms (IDMP-531), to revise the definitions of physical manufactured item and physical substance to add an annotation that they are extensions rather than that they correspond precisely to the IDMP 11238 standard (IDMP-528), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230502/ISO11238-Substances.rdf version of this ontology was modified to integrate content related to modifications from Figure 15 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-540), to support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), to move deprecated elements to a separate ontology, and to support additional reference information from Figure 16 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-522), addressed punning issues with modification method type, aligned the ontology with the revised basis of strength pattern (IDMP-582), and to add an axiom indicating that certain elements have data that can be used for testing purposes.</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances.rdf version of this ontology was modified to rename hasSimplifiedMolecularInputLineEntrySpecification to hasSMILES.</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11238-Substances.rdf version of this ontology was modified to rename hasSimplifiedMolecularInputLineEntrySpecification to hasSMILES and to incorporate the ability to define controlled vocabularies that may or may not be jurisdiction-specific (IDMP-533).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -440,6 +443,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>conformance level</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 5.9</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 5</dct:source>
 		<owl:equivalentClass>
 			<owl:Class>
@@ -464,7 +468,7 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 5</dct:source>
 		<skos:definition>conformance level that applies to data elements &apos;within a category&apos; as applicable, that are subject to business rules and may become required by: data rules; process rules; regional rules</skos:definition>
 		<skos:note>Conditional applies when there are alternative data sources for a given data element(s) to identify a Substance/Specified Substance. Regional implementation of the ISO 11238 and ISO/TS 19844 may elevate the conditional conformance categories to &apos;mandatory&apos; per regional requirements.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
 		<cmns-txt:hasTextValue>CONDITIONAL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -475,7 +479,7 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 5</dct:source>
 		<skos:definition>conformance level that applies to data elements that are required and shall therefore be implemented</skos:definition>
 		<skos:note>Mandatory elements are defining elements necessary for the unique identification of Substances and Specified Substances per the ISO IDMP standards/technical specifications.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
 		<cmns-txt:hasTextValue>MANDATORY</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -486,7 +490,7 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 5</dct:source>
 		<skos:definition>conformance level that applies to data elements that are informative but not definitional</skos:definition>
 		<skos:note>When listed at the category level (e.g. Specified Substance), optional corresponds to ISO categories or data elements that are not absolutely necessary for the unique identification of Substances/Specified Substances as per ISO 11238. Regional implementation of ISO 11238 and ISO/TS 19844 may elevate the optional conformance categories to &apos;mandatory&apos; or &apos;conditional&apos; per regional requirements.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
 		<cmns-txt:hasTextValue>OPTIONAL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -495,6 +499,14 @@
 		<rdfs:label xml:lang="en-US">contaminant ingredient</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient whose presence is not intended but may not be reasonably avoided given the circumstances of the mixture&apos;s nature or origin</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;ControlledVocabulary">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ValueDomain"/>
+		<rdfs:subClassOf rdf:resource="&mvf;Vocabulary"/>
+		<skos:definition>finite set of values that represent the only allowed values for a data item</skos:definition>
+		<skos:note>The allowed values can be codes, text or numeric.</skos:note>
+		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.18</cmns-av:directSource>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ElementGroup">
@@ -748,7 +760,21 @@
 		<skos:definition>system for classifying substances and substance-related information that is directly specified in the ISO 11238 specification</skos:definition>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ConformanceContext">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - conformance context</rdfs:label>
+		<skos:definition>controlled vocabulary for the conformance terminology and context as it relates to ISO 11238 and ISO/TS 19844</skos:definition>
+		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 5.9</cmns-av:directSource>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary for the conformance terminology and context as it relates to ISO 11238 and ISO/TS 19844</cmns-dsg:hasDescription>
+		<mvf:hasTextualName>ISO 11238 Conformance Context</mvf:hasTextualName>
+		<mvf:hasURI rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 19844 code set</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/71965.html</rdfs:seeAlso>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -212,7 +212,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;AgentModificationMethod"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;AgentModificationMethod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;AgentModificationMethod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>agent modification type</rdfs:label>
@@ -222,6 +228,7 @@
 		<skos:example>chemical, enzymatic, immunological, organism, UV radiation</skos:example>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Amount">
@@ -712,6 +719,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 16</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.6.5.2 and Figure 8</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;GeneIdentifier">
@@ -830,6 +838,21 @@
 		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-IsotopicSubstitutionVocabulary</mvf:hasURI>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ModificationMethodVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - modification method vocabulary</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
+		<skos:definition>controlled vocabulary specifying the nature of the method of modification</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary specifying the nature of the method of modification</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Modification Method vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ModificationMethodVocabulary</mvf:hasURI>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
 		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
@@ -902,6 +925,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 16</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.6.4.3</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Isotope">
@@ -1103,6 +1127,7 @@
 		<skos:example>synthetic material</skos:example>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 8.5.5, Figure 30</cmns-av:adaptedFrom>
 		<cmns-av:synonym>material type</cmns-av:synonym>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MaterialRole">
@@ -1289,6 +1314,21 @@
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;Modification">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-sub;ModificationMethod">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>modification method type</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
@@ -1303,12 +1343,11 @@
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ModificationMethodType-Agent">
 		<rdf:type rdf:resource="&idmp-sub;ModificationMethodType"/>
-		<rdf:type rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>modification method type - agent</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ModificationMethodVocabulary"/>
 		<cmns-txt:hasTextValue>agent</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1318,8 +1357,8 @@
 		<rdfs:label>modification method type - physical</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ModificationMethodVocabulary"/>
 		<cmns-txt:hasTextValue>physical</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1329,8 +1368,8 @@
 		<rdfs:label>modification method type - structural</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ModificationMethodVocabulary"/>
 		<cmns-txt:hasTextValue>structural</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -799,7 +799,7 @@
 		<cmns-dsg:hasDescription>controlled vocabulary specifying how the value associated with an amount should be interpreted</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Amount Type vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-AmountTypeVocabulary</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-AmountTypeVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ClassificationScheme">
@@ -820,7 +820,7 @@
 		<cmns-dsg:hasDescription>controlled vocabulary for the conformance terminology and context as it relates to ISO 11238 and ISO/TS 19844</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Conformance Context</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ConformanceContext</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ConformanceContext/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary">
@@ -835,7 +835,7 @@
 		<cmns-dsg:hasDescription>controlled vocabulary specifying the nature of isotopic substitution by site of substitution</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Isotopic Substitution vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-IsotopicSubstitutionVocabulary</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-IsotopicSubstitutionVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ModificationMethodVocabulary">
@@ -850,7 +850,7 @@
 		<cmns-dsg:hasDescription>controlled vocabulary specifying the nature of the method of modification</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Modification Method vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ModificationMethodVocabulary</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ModificationMethodVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-OfficialNameStatusVocabulary">
@@ -865,7 +865,7 @@
 		<cmns-dsg:hasDescription>controlled vocabulary for the status of an official name from a pre-defined ISO 19844 code set</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Official Name Status vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-OfficialNameStatusVocabulary</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-OfficialNameStatusVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-OpticalActivityVocabulary">
@@ -880,7 +880,22 @@
 		<cmns-dsg:hasDescription>controlled vocabulary indicating the ability of a chemical substance to rotate the plane of vibration of polarized light to the right or left</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Optical Activity vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-OpticalActivityVocabulary</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-OpticalActivityVocabulary/</mvf:hasURI>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - reference source class vocabulary</rdfs:label>
+		<skos:definition>controlled vocabulary for a broad category for the source in which the data elements were found</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figures 13, 14, 16-23, 25-26, 28-29, and 31-32</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</cmns-av:adaptedFrom>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary for a broad category for the source in which the data elements were found</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Reference Source Class vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ReferenceSourceClassVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
@@ -1041,14 +1056,14 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:allValuesFrom rdf:resource="&idmp-sub;IsotopicSubstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;IsotopicSubstitution"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;IsotopicSubstitution"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>isotopic substitution classifier</rdfs:label>
@@ -1332,7 +1347,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom>
+				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&idmp-sub;Modification">
@@ -1341,13 +1356,13 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:someValuesFrom>
+				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:someValuesFrom>
+				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&idmp-sub;Modification">
@@ -1356,7 +1371,7 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:someValuesFrom>
+				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>modification method type</rdfs:label>
@@ -2695,13 +2710,38 @@
 	
 	<owl:Class rdf:about="&idmp-sub;ReferenceSourceClass">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:allValuesFrom rdf:resource="&idmp-sub;ReferenceSource"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;ReferenceSource"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>reference source class</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;ReferenceSourceClass-Literature">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ReferenceSourceClass-OfficialNameSource">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ReferenceSourceClass-OtherNameSource">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ReferenceSourceClass-PublicDatabase">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ReferenceSourceClass-RegulatorySubmission">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ReferenceSourceClass-Web">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>classifier indicating a broad category for the source in which the data elements were found</skos:definition>
 		<skos:example>Regulatory submission, Public Database</skos:example>
 		<skos:note>Each reference information type should be associated with a class. The class will be automatically associated with each type of information.</skos:note>
@@ -2717,7 +2757,8 @@
 		<rdfs:label>reference source class - literature</rdfs:label>
 		<skos:definition>classifier for a reference source indicating that the source is domain and topic-specific literature</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.3</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
 		<cmns-txt:hasTextValue>Literature</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2727,7 +2768,8 @@
 		<owl:differentFrom rdf:resource="&idmp-sub;ReferenceSourceClass-OtherNameSource"/>
 		<skos:definition>classifier for a reference source indicating that the source is an official, jurisdiction-specific source for an official name</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.3</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
 		<cmns-txt:hasTextValue>Official Name Source</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2736,7 +2778,8 @@
 		<rdfs:label>reference source class - other name source</rdfs:label>
 		<skos:definition>classifier for a reference source indicating that the source of information about a name is not an official, jurisdiction-specific source for that name</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.3</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
 		<cmns-txt:hasTextValue>Other Name Source</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2745,7 +2788,8 @@
 		<rdfs:label>reference source class - public database</rdfs:label>
 		<skos:definition>classifier for a reference source indicating that the source is a publicly available database</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.3</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
 		<cmns-txt:hasTextValue>Public Database</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2754,7 +2798,8 @@
 		<rdfs:label>reference source class - regulatory submission</rdfs:label>
 		<skos:definition>classifier for a reference source indicating that the source is a regulatory submission</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.3</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
 		<cmns-txt:hasTextValue>Regulatory Submission</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2763,7 +2808,8 @@
 		<rdfs:label>reference source class - web</rdfs:label>
 		<skos:definition>classifier for a reference source indicating that the source is a web site</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.3</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary"/>
 		<cmns-txt:hasTextValue>Web</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2828,6 +2874,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figures 13, 14, 16-23, 25-26, 28-29, and 31-32</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.7.5</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ReferenceSourceDocumentIdentifier">
@@ -2862,6 +2909,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figures 13, 14, 16-23, 25-26, 28-29, and 31-32</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4.7.3</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ReferenceSourceIdentifier">
@@ -2898,6 +2946,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figures 13, 14, 16-23, 25-26, 28-29, and 31-32</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;RegulatoryContext">

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -694,6 +694,12 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;GeneElement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;GeneElement"/>
 			</owl:Restriction>
@@ -809,6 +815,21 @@
 		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ConformanceContext</mvf:hasURI>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - isotopic substitution</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 14</dct:source>
+		<skos:definition>controlled vocabulary specifying the nature of isotopic substitution by site of substitution</skos:definition>
+		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3, table 62</cmns-av:adaptedFrom>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary specifying the nature of isotopic substitution by site of substitution</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Isotopic Substitution vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-IsotopicSubstitutionVocabulary</mvf:hasURI>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
 		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
@@ -864,8 +885,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-sub;SubstrateTargetInteraction"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstrateTargetInteraction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstrateTargetInteraction"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>interaction type</rdfs:label>
@@ -933,6 +959,8 @@
 		<owl:differentFrom rdf:resource="&idmp-sub;IsotopicSubstitution-Unknown"/>
 		<skos:definition>isotopic substitution where the nuclide is distributed thoughtout molecule or substance</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3, table 62</cmns-av:adaptedFrom>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;IsotopicSubstitution-Specific">
@@ -941,6 +969,8 @@
 		<owl:differentFrom rdf:resource="&idmp-sub;IsotopicSubstitution-Unknown"/>
 		<skos:definition>isotopic substitution if the site of attachment/substitution is specific and indicated in the structure</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3, table 62</cmns-av:adaptedFrom>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;IsotopicSubstitution-Unknown">
@@ -948,10 +978,19 @@
 		<rdfs:label>isotopic substitution - unknown</rdfs:label>
 		<skos:definition>isotopic substitution where the site of attachment/substitution is unknown</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3, table 62</cmns-av:adaptedFrom>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;IsotopicSubstitutionClassifier">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;IsotopicSubstitution"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -959,6 +998,18 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>isotopic substitution classifier</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;IsotopicSubstitution-NonSpecific">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;IsotopicSubstitution-Specific">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;IsotopicSubstitution-Unknown">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>classifier for an isotopic substitution by site of substitution</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3</cmns-av:adaptedFrom>
 	</owl:Class>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -3438,6 +3438,10 @@
 		<skos:definition>relative spatial arrangement of atoms in 3-dimensional space within molecules</skos:definition>
 		<skos:example>absolute, axial r, axial s, square planar 1, square planar 2, square planar 3, square planar 4, tetrahedral, octahedral 12, octahedral 22, octahedral 21, chiral, geometric, achiral, racemic, mixed</skos:example>
 		<skos:note>Stereochemistry is concerned with the 3-dimensional arrangement of atoms in molecules, and stereoisomers are isomers with no difference in connectivity or bond multiplicity, but whose atomicspatial arrangements differ.</skos:note>
+		<idmp-sub:hasBusinessRules>When the Substance type, as defined in is either chemical or polymer, this class is MANDATORY; for all other cases this class is CONDITIONAL.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-sub:hasValuesAllowed>ABSOLUTE, AXIAL R, AXIAL S, SQUARE PLANAR 1, SQUARE PLANAR 2, SQUARE PLANAR 3, SQUARE PLANAR 4, TETRAHEDRAL, OCTAHEDRAL 12, OCTAHEDRAL 22, OCTAHEDRAL 21; RACEMIC, MIXED, CHIRAL, ACHIRAL, ABSOLUTE, AXIAL, EPIMERIC, MESO, UNKNOWN, CIS, TRANS</idmp-sub:hasValuesAllowed>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.80, clause 7.2.2 Figure 14</cmns-av:directSource>
 		<cmns-av:explanatoryNote>Stereochemistry is a structure. In most cases it is also a molecular structure, but the way stereochemistry is defined in IDMP it is not necessarily so because the list in IDMP includes &apos;racemic&apos;, which is a mereological property of a mixture and depends on the stereochemistry of its constituents. The stereochemistry of the molecule is the 3d spatial and topological structure. The stereochemistry can also be represented different ways, so one can define a stereochemical representation along with structural representation, but both are often represented together.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>molecular geometry</cmns-av:synonym>
@@ -4014,6 +4018,7 @@
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceCode">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -4052,12 +4057,17 @@
 		</rdfs:subClassOf>
 		<rdfs:label>substance code</rdfs:label>
 		<skos:definition>sequence of characters denoting a registered code for a given substance that is associated with a publicly recognized code system</skos:definition>
+		<skos:example>11-22-356; ab02sh</skos:example>
 		<skos:example>CAS Registry numbers, EC numbers, FDA UNII codes, EMA XEVMPD codes, ASK numbers, EPA Pesticide codes</skos:example>
 		<skos:example>These codes include Chemical Abstract Service (CAS) Registry Numbers, European Inventory of Existing Commercial Chemical Substances (EINECS), European Drug Codes (XEVMPD) and Japanese Drug Codes.</skos:example>
 		<skos:note>Codes typically facilitate mapping and linking of substances to a variety of information sources.</skos:note>
 		<skos:note>The actual code shall be captured using the same format that is used in the code system. Only codes associated with a code system shall be captured. The code shall be specifically associated with a given substance. Many public and non-public databases identify substances with a code and these codes can be very helpful in mapping substances to various systems. Codes shall always be verified against the source system. Different jurisdictions may require a code from a code system or multiple code systems to be associated and submitted with a substance.</skos:note>
+		<idmp-sub:hasBusinessRules>Only codes from recognized code systems will be captured. The code should specifically link to a substance but need not uniquely link to substance. This code can also be a deprecated Substance ID generated based on ISO 11238.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.8</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.5</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>Note that although this element is encoded as CD.Code in the ISO/TS 19844 implementation guide, that code type does not exist in the ISO 21090 specification, and this it is modeled as a CD in the ontology.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceComposition">

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -526,15 +526,6 @@
 		<skos:definition>role of an inactive ingredient whose presence is not intended but may not be reasonably avoided given the circumstances of the mixture&apos;s nature or origin</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-sub;ControlledVocabulary">
-		<rdfs:subClassOf rdf:resource="&idmp-dtp;ValueDomain"/>
-		<rdfs:subClassOf rdf:resource="&mvf;Vocabulary"/>
-		<rdfs:label>controlled vocabulary</rdfs:label>
-		<skos:definition>finite set of values that represent the only allowed values for a data item</skos:definition>
-		<skos:note>The allowed values can be codes, text or numeric.</skos:note>
-		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.18</cmns-av:directSource>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-sub;ElementGroup">
 		<rdfs:subClassOf rdf:resource="&cmns-col;Arrangement"/>
 		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
@@ -787,7 +778,7 @@
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-AmountTypeVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - amount type vocabulary</rdfs:label>
@@ -810,7 +801,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ConformanceContext">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - conformance context</rdfs:label>
@@ -824,7 +815,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-IsotopicSubstitutionVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - isotopic substitution</rdfs:label>
@@ -839,7 +830,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ModificationMethodVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - modification method vocabulary</rdfs:label>
@@ -854,7 +845,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-OfficialNameStatusVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - official name status</rdfs:label>
@@ -869,7 +860,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-OpticalActivityVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - optical activity vocabulary</rdfs:label>
@@ -884,7 +875,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ReferenceSourceClassVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - reference source class vocabulary</rdfs:label>
@@ -899,7 +890,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ResidueModifiedVocabulary">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 11238 - residue modified vocabulary</rdfs:label>
@@ -914,7 +905,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
-		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 19844 code set</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/71965.html</rdfs:seeAlso>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -504,6 +504,7 @@
 	<owl:Class rdf:about="&idmp-sub;ControlledVocabulary">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;ValueDomain"/>
 		<rdfs:subClassOf rdf:resource="&mvf;Vocabulary"/>
+		<rdfs:label>controlled vocabulary</rdfs:label>
 		<skos:definition>finite set of values that represent the only allowed values for a data item</skos:definition>
 		<skos:note>The allowed values can be codes, text or numeric.</skos:note>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.18</cmns-av:directSource>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -853,6 +853,36 @@
 		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ModificationMethodVocabulary</mvf:hasURI>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-OfficialNameStatusVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - official name status</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
+		<skos:definition>controlled vocabulary specifying the nature of the method of modification</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary for the status of an official name from a pre-defined ISO 19844 code set</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Official Name Status vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-OfficialNameStatusVocabulary</mvf:hasURI>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-OpticalActivityVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - optical activity vocabulary</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.3, Figure 14</dct:source>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.2</dct:source>
+		<skos:definition>controlled vocabulary the ability of a chemical substance to rotate the plane of vibration of polarized light to the right or left</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary indicating the ability of a chemical substance to rotate the plane of vibration of polarized light to the right or left</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Optical Activity vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-OpticalActivityVocabulary</mvf:hasURI>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
 		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
@@ -1332,6 +1362,18 @@
 		<rdfs:label>modification method type</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;ModificationMethodType-Agent">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ModificationMethodType-Physical">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;ModificationMethodType-Structural">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>classifier for the method of modification</skos:definition>
 		<skos:example>structural modification, agent modification, physical modification</skos:example>
 		<idmp-sub:hasBusinessRules>In case of N-Terminal modification and C-Terminal modification of a protein subunit, modification is mandatory.</idmp-sub:hasBusinessRules>
@@ -1413,6 +1455,7 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.5.2</dct:source>
 		<skos:definition>code for the function of a modification</skos:definition>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Moiety">
@@ -1974,16 +2017,38 @@
 	
 	<owl:Class rdf:about="&idmp-sub;OfficialNameStatus">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-sub;SubstanceName"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;OfficialName"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;OfficialName"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>official name status</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;OfficialNameStatus-Alternate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OfficialNameStatus-Current">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OfficialNameStatus-Primary">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OfficialNameStatus-Proposed">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OfficialNameStatus-Superseded">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>classifier that indicates the status of an official name from a pre-defined ISO 19844 code set</skos:definition>
 	</owl:Class>
 	
@@ -1994,8 +2059,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
 		<skos:definition>status of an official name that is considered a synonym for the primary official name</skos:definition>
 		<skos:note>The fact that a name is alternate is evident by having more than one name assigned to the same substance by the same authority for the same language, domain, etc.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
 		<cmns-txt:hasTextValue>Alternate</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2005,8 +2070,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
 		<skos:definition>status of an official name that is presently in use</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
 		<cmns-txt:hasTextValue>Current</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2016,8 +2081,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
 		<skos:definition>status of an official name that is the main official name approved for use</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
 		<cmns-txt:hasTextValue>Proposed</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2027,8 +2092,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
 		<skos:definition>status of an official name that has been proposed for use but has not yet be formally adopted</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
 		<cmns-txt:hasTextValue>Proposed</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2038,23 +2103,46 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.6.2</dct:source>
 		<skos:definition>status of an official name that was formerly in use and has been replaced</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OfficialNameStatusVocabulary"/>
 		<cmns-txt:hasTextValue>Superseded</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;OpticalActivity">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;OpticalRotation"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;OpticalRotation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;OpticalRotation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>optical activity</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.3, Figure 14</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.2</dct:source>
-		<skos:definition>ability of a chemical substance to rotate the plane of vibration of polarized light to the right or left</skos:definition>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;OpticalActivity-EitherDirection">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OpticalActivity-Left">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OpticalActivity-None">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OpticalActivity-NotApplicable">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;OpticalActivity-Right">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
+		<skos:definition>classifier specifying the ability of a chemical substance to rotate the plane of vibration of polarized light to the right or left</skos:definition>
 		<skos:example>(+/-), (+), (-), None, N/A, Unknown</skos:example>
 		<skos:note>The extent of optical rotation is not mandatory at the substance level.</skos:note>
 	</owl:Class>
@@ -2064,7 +2152,8 @@
 		<rdfs:label>optical activity - either direction</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53</dct:source>
 		<skos:definition>optical activity indicating the ability of a chemical substance to rotate the plane of vibration of polarized light either to the right or left</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
 		<cmns-txt:hasTextValue>(+/-)</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2073,7 +2162,8 @@
 		<rdfs:label>optical activity - left</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53</dct:source>
 		<skos:definition>optical activity indicating the ability of a chemical substance to rotate the plane of vibration of polarized light to the left</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
 		<cmns-txt:hasTextValue>(-)</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2082,7 +2172,8 @@
 		<rdfs:label>optical activity - none</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53</dct:source>
 		<skos:definition>optical activity indicating that a chemical substance has no ability to rotate the plane of vibration of polarized light</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
 		<cmns-txt:hasTextValue>None</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2091,7 +2182,8 @@
 		<rdfs:label>optical activity - not applicable</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53</dct:source>
 		<skos:definition>optical activity indicating that optical activity does not apply to a chemical substance</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
 		<cmns-txt:hasTextValue>None</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2100,7 +2192,8 @@
 		<rdfs:label>optical activity - right</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53</dct:source>
 		<skos:definition>optical activity indicating the ability of a chemical substance to rotate the plane of vibration of polarized light to the right</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-OpticalActivityVocabulary"/>
 		<cmns-txt:hasTextValue>(+)</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2197,6 +2290,7 @@
 		<skos:example>USP</skos:example>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause F.3.7.4</cmns-av:adaptedFrom>
 		<cmns-av:synonym>pharmacopoeial grade type</cmns-av:synonym>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;PharmacopoeialGradeName">

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -22,6 +22,7 @@
 	<!ENTITY idmp-dtp "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/">
 	<!ENTITY idmp-sub "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/">
 	<!ENTITY idmp-uom "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/">
+	<!ENTITY lcc-639-1 "https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
@@ -54,6 +55,7 @@
 	xmlns:idmp-dtp="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"
 	xmlns:idmp-sub="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/"
 	xmlns:idmp-uom="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/"
+	xmlns:lcc-639-1="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
@@ -88,6 +90,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances/"/>
@@ -284,18 +287,30 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-sub;Amount"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;Amount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:onClass rdf:resource="&idmp-sub;Amount"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;Amount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>amount type</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;AmountType-Approximate">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;AmountType-Exact">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;AmountType-NLT">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;AmountType-NMT">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>classifies and denotes some quantity and states how a numeric amount is to be interpreted</skos:definition>
 		<skos:example>Exact (the default, when not specified); Approximate; NLT; NMT</skos:example>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
@@ -307,16 +322,16 @@
 		<rdf:type rdf:resource="&idmp-sub;AmountType"/>
 		<rdfs:label>amount type - approximate</rdfs:label>
 		<skos:definition>amount type for quantity values that are approximate</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;AmountType-Exact">
 		<rdf:type rdf:resource="&idmp-sub;AmountType"/>
 		<rdfs:label>amount type - exact</rdfs:label>
 		<skos:definition>amount type for quantity values that are exact</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;AmountType-NLT">
@@ -324,8 +339,8 @@
 		<rdfs:label>amount type - NLT</rdfs:label>
 		<skos:definition>amount type for quantity values that are a lower bound</skos:definition>
 		<cmns-av:synonym>amount type - not less than</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;AmountType-NMT">
@@ -333,8 +348,8 @@
 		<rdfs:label>amount type - NMT</rdfs:label>
 		<skos:definition>amount type for quantity values that are an upper bound</skos:definition>
 		<cmns-av:synonym>amount type - not more than</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-AmountTypeVocabulary"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;Analysis">
@@ -469,6 +484,7 @@
 		<skos:definition>conformance level that applies to data elements &apos;within a category&apos; as applicable, that are subject to business rules and may become required by: data rules; process rules; regional rules</skos:definition>
 		<skos:note>Conditional applies when there are alternative data sources for a given data element(s) to identify a Substance/Specified Substance. Regional implementation of the ISO 11238 and ISO/TS 19844 may elevate the conditional conformance categories to &apos;mandatory&apos; per regional requirements.</skos:note>
 		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
 		<cmns-txt:hasTextValue>CONDITIONAL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -480,6 +496,7 @@
 		<skos:definition>conformance level that applies to data elements that are required and shall therefore be implemented</skos:definition>
 		<skos:note>Mandatory elements are defining elements necessary for the unique identification of Substances and Specified Substances per the ISO IDMP standards/technical specifications.</skos:note>
 		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
 		<cmns-txt:hasTextValue>MANDATORY</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -491,6 +508,7 @@
 		<skos:definition>conformance level that applies to data elements that are informative but not definitional</skos:definition>
 		<skos:note>When listed at the category level (e.g. Specified Substance), optional corresponds to ISO categories or data elements that are not absolutely necessary for the unique identification of Substances/Specified Substances as per ISO 11238. Regional implementation of ISO 11238 and ISO/TS 19844 may elevate the optional conformance categories to &apos;mandatory&apos; or &apos;conditional&apos; per regional requirements.</skos:note>
 		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
 		<cmns-txt:hasTextValue>OPTIONAL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -754,6 +772,22 @@
 		<skos:definition>addition compound that contains water in weak chemical combination with another compound</skos:definition>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-AmountTypeVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - amount type vocabulary</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figures 14-16, 19-25, 27, and 30-32</dct:source>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.8.1</dct:source>
+		<skos:definition>controlled vocabulary specifying how the value associated with an amount should be interpreted</skos:definition>
+		<skos:note>An &apos;amount type&apos; may be associated with an amount to state if the value needs to be interpreted as an average or an exact or approximate quantity.</skos:note>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary specifying how the value associated with an amount should be interpreted</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Amount Type vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-AmountTypeVocabulary</mvf:hasURI>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ClassificationScheme">
 		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:label>ISO 11238 classification scheme</rdfs:label>
@@ -770,6 +804,7 @@
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 5.9</cmns-av:directSource>
 		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
 		<cmns-dsg:hasDescription>controlled vocabulary for the conformance terminology and context as it relates to ISO 11238 and ISO/TS 19844</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Conformance Context</mvf:hasTextualName>
 		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ConformanceContext</mvf:hasURI>
 	</owl:NamedIndividual>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -4111,8 +4111,23 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceIdentifier">
-		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;PhysicalSubstance">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-sub;Substance">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -771,7 +771,7 @@
 		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
 		<cmns-dsg:hasDescription>controlled vocabulary for the conformance terminology and context as it relates to ISO 11238 and ISO/TS 19844</cmns-dsg:hasDescription>
 		<mvf:hasTextualName>ISO 11238 Conformance Context</mvf:hasTextualName>
-		<mvf:hasURI rdf:resource="&idmp-sub;ISO11238-ConformanceContext"/>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ConformanceContext</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -4111,7 +4111,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceIdentifier">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -1347,7 +1347,7 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
 		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ModificationMethodVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
 		<cmns-txt:hasTextValue>agent</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1358,7 +1358,7 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
 		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ModificationMethodVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
 		<cmns-txt:hasTextValue>physical</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1369,7 +1369,7 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
 		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ModificationMethodVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ModificationMethodVocabulary"/>
 		<cmns-txt:hasTextValue>structural</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -207,8 +207,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;AgentModificationType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -289,8 +289,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;AmountType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -304,25 +304,12 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>amount type</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:oneOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&idmp-sub;AmountType-Approximate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;AmountType-Exact">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;AmountType-NLT">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;AmountType-NMT">
-					</rdf:Description>
-				</owl:oneOf>
-			</owl:Class>
-		</owl:equivalentClass>
 		<skos:definition>classifies and denotes some quantity and states how a numeric amount is to be interpreted</skos:definition>
 		<skos:example>Exact (the default, when not specified); Approximate; NLT; NMT</skos:example>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clauses 6.8.1</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;AmountType-Approximate">
@@ -462,8 +449,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ConformanceLevel">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>conformance level</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 5.9</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 5</dct:source>
@@ -688,8 +675,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;GeneElementType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
@@ -901,11 +888,40 @@
 		<cmns-dsg:hasDescription>controlled vocabulary for the residue of a modification</cmns-dsg:hasDescription>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 		<mvf:hasTextualName>ISO 11238 Residue Modified vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ResidueModifiedVocabulary/</mvf:hasURI>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ResidueModifiedVocabulary/</mvf:hasURI>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-StereochemistryVocabulary">
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - stereochemistry vocabulary</rdfs:label>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause B.6.5.1</dct:source>
+		<skos:definition>controlled vocabulary for the relative spatial arrangement of atoms in 3-dimensional space within molecules</skos:definition>
+		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.80, clause 7.2.2, clause 7.3, and Figure 14</cmns-av:directSource>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary for the relative spatial arrangement of atoms in 3-dimensional space within molecules</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Stereochemistry vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-StereochemistryVocabulary/</mvf:hasURI>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary">
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - substance name classifier vocabulary</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
+		<skos:definition>controlled vocabulary for the description of the nature of the substance name from a pre-defined ISO 19844 code set</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary for the description of the nature of the substance name from a pre-defined ISO 19844 code set</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Substance Name Classifier vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-SubstanceNameClassifierVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
-		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
 		<rdfs:label>ISO 19844 code set</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/71965.html</rdfs:seeAlso>
@@ -954,8 +970,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;InteractionType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -1058,8 +1074,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;IsotopicSubstitutionClassifier">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -1073,20 +1089,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>isotopic substitution classifier</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:oneOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&idmp-sub;IsotopicSubstitution-NonSpecific">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;IsotopicSubstitution-Specific">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;IsotopicSubstitution-Unknown">
-					</rdf:Description>
-				</owl:oneOf>
-			</owl:Class>
-		</owl:equivalentClass>
 		<skos:definition>classifier for an isotopic substitution by site of substitution</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.3</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ManufacturedItem">
@@ -1348,8 +1353,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ModificationMethodType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -1383,18 +1388,6 @@
 		<rdfs:label>modification method type</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:oneOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&idmp-sub;ModificationMethodType-Agent">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;ModificationMethodType-Physical">
-					</rdf:Description>
-					<rdf:Description rdf:about="&idmp-sub;ModificationMethodType-Structural">
-					</rdf:Description>
-				</owl:oneOf>
-			</owl:Class>
-		</owl:equivalentClass>
 		<skos:definition>classifier for the method of modification</skos:definition>
 		<skos:example>structural modification, agent modification, physical modification</skos:example>
 		<idmp-sub:hasBusinessRules>In case of N-Terminal modification and C-Terminal modification of a protein subunit, modification is mandatory.</idmp-sub:hasBusinessRules>
@@ -1402,6 +1395,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:explanatoryNote>The modification type becomes apparent by its description. Structural modification is described using the structural elements. Agent and physical modifications are described by a series of elements. Agents are also substances in their own right.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>modification type</cmns-av:synonym>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ModificationMethodType-Agent">
@@ -1461,7 +1455,15 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ModificationRoleCode">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass rdf:resource="&idmp-sub;ModificationRole"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
@@ -2035,8 +2037,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;OfficialNameStatus">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -2128,8 +2130,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;OpticalActivity">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -2713,8 +2715,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ReferenceSourceClass">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -2934,10 +2936,17 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ReferenceSourceType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;ReferenceSource"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:allValuesFrom rdf:resource="&idmp-sub;ReferenceSource"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2961,8 +2970,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ResidueModified">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -3165,18 +3174,18 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SourceMaterialClassifierCode">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:onClass rdf:resource="&idmp-sub;SourceMaterialClassifier"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SourceMaterialClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>source material classifier code</rdfs:label>
 		<skos:definition>code for the general high-level classification of the source material specific to the origin of the material</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.9.1</cmns-av:adaptedFrom>
 		<cmns-av:synonym>source material class code</cmns-av:synonym>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SourceMaterialRole">
@@ -3359,9 +3368,58 @@
 	
 	<owl:Class rdf:about="&idmp-sub;Stereochemistry">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Structure"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>stereochemistry</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause B.6.5.1</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Absolute">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Achiral">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Axial">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-AxialR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-AxialS">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Chiral">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Cis">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Epimeric">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Meso">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Mixed">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Octahedral12">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Octahedral21">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Octahedral22">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Racemic">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-SquarePlanar1">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-SquarePlanar2">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-SquarePlanar3">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-SquarePlanar4">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Tetrahedral">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Trans">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;Stereochemistry-Unknown">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>relative spatial arrangement of atoms in 3-dimensional space within molecules</skos:definition>
 		<skos:example>absolute, axial r, axial s, square planar 1, square planar 2, square planar 3, square planar 4, tetrahedral, octahedral 12, octahedral 22, octahedral 21, chiral, geometric, achiral, racemic, mixed</skos:example>
 		<skos:note>Stereochemistry is concerned with the 3-dimensional arrangement of atoms in molecules, and stereoisomers are isomers with no difference in connectivity or bond multiplicity, but whose atomicspatial arrangements differ.</skos:note>
@@ -3378,7 +3436,8 @@
 		<cmns-av:adaptedFrom>https://en.wikipedia.org/wiki/Absolute_configuration</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>The most common labeling method uses the descriptors R or S and is based on the Cahn-Ingold-Prelog priority rules.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Until 1951 it was not possible to determine the absolute configuration and configuration were indicated relative to glyceraldehyde with the D/L system.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>ABSOLUTE</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>absolute</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3389,7 +3448,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<owl:differentFrom rdf:resource="&idmp-sub;Stereochemistry-Chiral"/>
 		<skos:definition>stereochemistry classifier indicating that the molecule is not chiral</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>ACHIRAL</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>achiral</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3399,7 +3459,8 @@
 		<rdfs:label>stereochemistry - axial</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a chirality axis based stereochemistry where, using the Cahn-Ingold-Prelog (CIP) priority rules, ordering can be determined</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>AXIAL</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>axial</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3409,7 +3470,8 @@
 		<rdfs:label>stereochemistry - axial r</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a chirality axis based stereochemistry where, using the Cahn-Ingold-Prelog (CIP) priority rules, the priorities (from highest to lowest) of the substituent atoms exist in a clockwise direction</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>AXIAL R</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>axial r</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3419,7 +3481,8 @@
 		<rdfs:label>stereochemistry - axial s</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a chirality axis based stereochemistry where, using the Cahn-Ingold-Prelog (CIP) priority rules, the priorities (from highest to lowest) of the substituent atoms exist in an anti-clockwise direction</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>AXIAL S</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>axial s</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3430,7 +3493,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating an object or molecule that is not superimposable on its mirror image</skos:definition>
 		<skos:note>The classic description of chirality is the comparison of the hand in a mirror, because the mirror image is the opposite. A chiral molecule has one or more chiral centres.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>CHIRAL</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>chiral</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3441,7 +3505,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<owl:differentFrom rdf:resource="&idmp-sub;Stereochemistry-Trans"/>
 		<skos:definition>stereochemistry classifier indicating that the functional groups (substituents) are on the same side of some plane</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>CIS</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>cis</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3453,7 +3518,8 @@
 		<skos:definition>stereochemistry classifier indicating a particular kind of diastereomers that differ in their stereochemistry at only one chiral centre</skos:definition>
 		<cmns-av:explanatoryNote>The stereochemistry at all other chiral centres is identical.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>epimeric centres</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>EPIMERIC</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>epimeric</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3464,7 +3530,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating that a molecule is a non-optically active member of a set of stereoisomers, at least two of which are optically active</skos:definition>
 		<cmns-av:explanatoryNote>Despite containing two or more stereocenters, the molecule is not chiral (achiral).</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>MESO</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>meso</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3474,7 +3541,8 @@
 		<rdfs:label>stereochemistry - mixed</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a mixture of substances with different stereochemistries or a combination of stereochemistries at different parts of the molecule</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>MIXED</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>mixed</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3485,7 +3553,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating an octahedral molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the lowest priority donor atom directly across from (trans to) a priority 1 donor atom is also 1 and the priority of the donor atom across from (trans to) the highest priority atom in the plane perpendicular to this reference axis is 2</skos:definition>
 		<cmns-av:synonym>trans octahedral</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>OCTAHEDRAL 12</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>octahedral 12</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3496,7 +3565,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating an octahedral molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the lowest priority donor atom directly across from (trans to) a priority 1 donor atom is 2 and the priority of the donor atom across from (trans to) the highest priority atom in the plane perpendicular to this reference axis is 1</skos:definition>
 		<cmns-av:synonym>trans octahedral 21</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>OCTAHEDRAL 21</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>octahedral 21</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3507,7 +3577,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating an octahedral molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the lowest priority donor atom directly across from (trans to) a priority 1 donor atom is 2 and the priority of the donor atom across from (trans to) the highest priority atom in the plane perpendicular to this reference axis is 2</skos:definition>
 		<cmns-av:synonym>trans octahedral 22</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>OCTAHEDRAL 22</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>octahedral 22</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3520,7 +3591,8 @@
 		<skos:example>See example in ISO/TS 19844:2018(E) Figure B.17 racemic Amlodipine structure.</skos:example>
 		<skos:note>A racemate is optically inactive.</skos:note>
 		<cmns-av:synonym>racemate</cmns-av:synonym>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>RACEMIC</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>racemic</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3530,7 +3602,8 @@
 		<rdfs:label>stereochemistry - square planar 1</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a square planar molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the donor atom directly across from the priority 1 donor atom is also 1</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>SQUARE PLANAR 1</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>square planar 1</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3540,7 +3613,8 @@
 		<rdfs:label>stereochemistry - square planar 2</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a square planar molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the donor atom directly across from the priority 1 donor atom is 2</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>SQUARE PLANAR 2</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>square planar 2</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3550,7 +3624,8 @@
 		<rdfs:label>stereochemistry - square planar 3</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a square planar molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the donor atom directly across from the priority 1 donor atom is 3</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>SQUARE PLANAR 3</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>square planar 3</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3560,7 +3635,8 @@
 		<rdfs:label>stereochemistry - square planar 4</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a square planar molecular geometry where the Cahn-Ingold-Prelog (CIP) priority of the donor atom directly across from the priority 1 donor atom is 4</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>SQUARE PLANAR 4</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>square planar 4</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3570,7 +3646,8 @@
 		<rdfs:label>stereochemistry - tetrahedral</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating a molecule in which the central atom is bound to four atoms that form the vertices of a tetrahedron and are described by the chirality symbols (R) and (S)</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>TETRAHEDRAL</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>tetrahedral</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3580,7 +3657,8 @@
 		<rdfs:label>stereochemistry - trans</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53, clause B.6.5.1</dct:source>
 		<skos:definition>stereochemistry classifier indicating that the functional groups (substituents) are on opposing (transverse) sides of some plane</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>TRANS</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>trans</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3590,7 +3668,8 @@
 		<rdfs:label>stereochemistry - unknown</rdfs:label>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.1, Table 53</dct:source>
 		<skos:definition>stereochemistry classifier indicating that the molecular geometry is not known</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-StereochemistryVocabulary"/>
 		<cmns-txt:hasTextValue>UNKNOWN</cmns-txt:hasTextValue>
 		<cmns-txt:hasTextValue>unknown</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -3873,12 +3952,11 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceClassifierCode">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:onClass rdf:resource="&idmp-sub;SubstanceClassifier"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstanceClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>substance classifier code</rdfs:label>
@@ -3891,6 +3969,7 @@
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 16, clause 7.2.4.2</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.6.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceClassifierDomain">
@@ -3898,8 +3977,13 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-sub;SubstanceClassifier"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstanceClassifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstanceClassifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>substance classifier domain</rdfs:label>
@@ -3910,10 +3994,11 @@
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 16, clause 7.2.4.2</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.6.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11238 or the ISO/TS 19844 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceCode">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -4001,7 +4086,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceIdentifier">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-ra;RegisteredIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -4098,17 +4183,61 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceNameClassifier">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-sub;SubstanceName"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstanceName"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;SubstanceName"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>substance name classifier</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-BrandName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-CommonName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-CompanyCode">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-DisplayName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-HerbalName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-HomeopathicName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-OfficialName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-OtherName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-PlasmaDerivedName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-PreferredName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-ScientificName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-SpecifiedHomeopathicName">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-SpecifiedSubstanceGroup1Name">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-SpecifiedSubstanceGroup2Name">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-SpecifiedSubstanceGroup3Name">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-sub;SubstanceNameClassifier-SystematicName">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>classifier that describes the nature of the substance name from a pre-defined ISO 19844 code set</skos:definition>
 		<cmns-av:synonym>substance name type</cmns-av:synonym>
 	</owl:Class>
@@ -4119,8 +4248,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name by which a company identifies a given substance typically for marketing purposes</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Brand Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4130,8 +4259,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Common Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4143,8 +4272,8 @@
 		<skos:definition>substance name classifier for a name associated with a given substance that is an internal corporate code</skos:definition>
 		<skos:example>During the early stages of clinical development, the preferred term for a substance can be its company code. In later stages, an INN can be associated with the substance and become the preferred term for that substance.</skos:example>
 		<skos:note>A company code may be used in cases where no official name is available and if it is associated with defining information and is found together in at least one single reference that is from a reputable source in the public domain (i.e. scientific journal, presentations or posters at scientific conferences, company publication, patent or published patent application, public databases such as STN from CAS).</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Company Code</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4154,8 +4283,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Display Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4165,8 +4294,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Herbal Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4176,8 +4305,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Homeopathic Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4189,8 +4318,8 @@
 		<skos:definition>substance name classifier for a name that is typically nonproprietary used in a given jurisdiction and domain to refer to a specific substance</skos:definition>
 		<skos:example>INN: International Nonproprietary Name, also known as rINN, recommended International Nonproprietary Name or pINN, proposed International Nonproprietary Name or INNM, Modified International Nonproprietary Name published by WHO: World Health Organization: in accordance with rules.</skos:example>
 		<skos:note>The domain, jurisdiction, and authority that assigned the name (USAN, INN, JAN etc.) and the language of the name are also captured.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Official</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4200,8 +4329,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name associated with a given substance that is considered a synonym</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Other Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4211,8 +4340,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Plasma-Derived Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4222,8 +4351,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that is considered to be the best choice in some context</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Preferred Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4234,8 +4363,8 @@
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2, 6.9.5</dct:source>
 		<skos:definition>substance name classifier for a name that is the taxonomic name for an organism</skos:definition>
 		<skos:note>The accepted scientific name for plants is provided by Kew Gardens&apos; Medicinal Plant Names Services (MPNS). The names for other organisms will be provided by other authoritative sources.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Scientific Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4245,8 +4374,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Specified Homeopathic Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4256,8 +4385,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Specified Substance Group 1 Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4267,8 +4396,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Specified Substance Group 2 Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4278,8 +4407,8 @@
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.4</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.2</dct:source>
 		<skos:definition>substance name classifier for a name that ...</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Specified Substance Group 3 Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4291,8 +4420,8 @@
 		<skos:definition>substance name classifier for a name that is typically be used for simple chemicals and structurally diverse materials where the definitions are based on a chemical structure or systematic taxonomic information</skos:definition>
 		<skos:example>IUPAC name, CAS Registry Name and definitions of a Pharmacopoeial Monograph</skos:example>
 		<skos:note>For chemicals, these names are typically derived from IUPAC or CAS systems of nomenclature. From the systematic names of chemicals, a molecular structure can typically be derived and the name can be checked by a number of chemical drawing programmes that convert a given name to a molecular structure.</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ClassificationScheme"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-SubstanceNameClassifierVocabulary"/>
 		<cmns-txt:hasTextValue>Systematic Name</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -4418,7 +4547,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceRelationshipCode">
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
@@ -4437,8 +4566,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceRelationshipType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -898,6 +898,21 @@
 		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/ISO11238-ReferenceSourceClassVocabulary/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11238-ResidueModifiedVocabulary">
+		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11238 - residue modified vocabulary</rdfs:label>
+		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
+		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.2</dct:source>
+		<skos:definition>controlled vocabulary for the residue of a modification</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary for the residue of a modification</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11238 Residue Modified vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/idmp-sub;ISO11238-ResidueModifiedVocabulary/</mvf:hasURI>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ISO19844-CodeSet">
 		<rdf:type rdf:resource="&idmp-sub;ControlledVocabulary"/>
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
@@ -1410,7 +1425,6 @@
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ModificationMethodType-Physical">
 		<rdf:type rdf:resource="&idmp-sub;ModificationMethodType"/>
-		<rdf:type rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>modification method type - physical</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
@@ -1421,7 +1435,6 @@
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ModificationMethodType-Structural">
 		<rdf:type rdf:resource="&idmp-sub;ModificationMethodType"/>
-		<rdf:type rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>modification method type - structural</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.1</dct:source>
@@ -2957,7 +2970,38 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ResidueModified">
-		<rdfs:subClassOf rdf:resource="&cmns-cls;Aspect"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;Modification">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-sub;ModificationMethod">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:allValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;Modification">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-sub;ModificationMethod">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:allValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-txt;hasTextValue"/>
@@ -2977,6 +3021,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:explanatoryNote>It may be known that lysine residues are modified but the particular lysine in the sequence may not be known. It should be captured for both specific and non-specific modifications, e.g. sizing carbohydrate polymers by hydrolysis.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>The residues of modification can be specific to a type of residue, optionally at a specific site, in a molecular entity, non-specific or random.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>Note that because there may be additional values, over and above those specified, an equivalence to a list of the valid values is not appropriate.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-sub;ResidueModified-NonSpecificModifications">
@@ -2984,7 +3029,8 @@
 		<rdfs:label>residue modified - non-specific modifications</rdfs:label>
 		<skos:definition>code for non-specific residue(s) of modification</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.2</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ResidueModifiedVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ResidueModifiedVocabulary"/>
 		<cmns-txt:hasTextValue>non-specific modifications</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -2993,7 +3039,8 @@
 		<rdfs:label>residue modified - random</rdfs:label>
 		<skos:definition>code for random residue(s) of modification</skos:definition>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.2</cmns-av:adaptedFrom>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO19844-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11238-ResidueModifiedVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11238-ResidueModifiedVocabulary"/>
 		<cmns-txt:hasTextValue>random</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -25,7 +25,9 @@
 	<!ENTITY idmp-mprd "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/">
 	<!ENTITY idmp-sub "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/">
 	<!ENTITY idmp-uom "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/">
+	<!ENTITY lcc-639-1 "https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -58,7 +60,9 @@
 	xmlns:idmp-mprd="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
 	xmlns:idmp-sub="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/"
 	xmlns:idmp-uom="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11240-UnitsOfMeasurement/"
+	xmlns:lcc-639-1="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -93,12 +97,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11615-MedicinalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also extended to include concepts such as process, manufacturing process, process identifier, batch, batch identifier, lot, lot number, and others required in support of the regulatory to manufacturing bridge use case.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename product constituency to product composition, which is better understood by the user community, and to move a couple of restrictions from ingredient to substance, including strength and whether or not that substance is potentially allergenic. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate additional manufacturing and packaging details required for UC-2 (IDMP-465), to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to change the status of this ontology to &apos;release&apos; (IDMP-525), to add content related to dose forms (IDMP-531, IDMP-538), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) integrate content related to modifications from Figure 15 in ISO 11238 (IDMP-540), (2) support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), (3) integrate content related to therapeutic indications in ISO 11615 (IDMP-561), (4) clarify the definition of marketing authorization holder (IDMP-395), (5) refine restrictions between medicinal products and authorized medicinal products (IDMP-550), (6) aligne the ontology with the revised basis of strength pattern (IDMP-582), and (7) loosen a constraint on ingredient with respect to manufactured item (IDMP-602).</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) make indication texts as nodes instead of literals (IDMP-591), (2) add the concept of shelf life / storage per Figure 11 in the ISO 11615 specification (IDMP-371), (3) add undesirable effect per Figure 14 in the ISO 11615 specification (IDMP-591), (4) rename &apos;has medical condition&apos; to use a more aligned label with ISO 11615 (IDMP-591), and (5) add the concept of route of administration (IDMP-614).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) make indication texts as nodes instead of literals (IDMP-591), (2) add the concept of shelf life / storage per Figure 11 in the ISO 11615 specification (IDMP-371), (3) add undesirable effect per Figure 14 in the ISO 11615 specification (IDMP-591), (4) rename &apos;has medical condition&apos; to use a more aligned label with ISO 11615 (IDMP-591), (5) add the concept of route of administration (IDMP-614), and (6) integrate the refined pattern for controlled vocabularies (IDMP-533).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -180,6 +186,21 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11615-IngredientRoleVocabulary">
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11615 - ingredient role vocabulary</rdfs:label>
+		<skos:definition>controlled vocabulary denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.7.2.2.2 and Figure 12</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</cmns-av:adaptedFrom>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11615 Ingredient Role vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/ISO11615-IngredientRoleVocabulary/</mvf:hasURI>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;InactiveIngredient">
 		<rdfs:subClassOf>
@@ -1145,7 +1166,8 @@
 		<rdfs:label>ingredient role - ACTI</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient whose basis of strength cannot be specified</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTI</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1154,7 +1176,8 @@
 		<rdfs:label>ingredient role - ACTIB</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient where the entire substance is the basis of strength</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTIB</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1163,7 +1186,8 @@
 		<rdfs:label>ingredient role - ACTIM</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient where the active moiety is basis of strength</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTIM</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1172,7 +1196,8 @@
 		<rdfs:label>ingredient role - ACTIR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient where another reference substance is the basis of strength</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTIR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1181,7 +1206,8 @@
 		<rdfs:label>ingredient role - ADJV</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an adjuvant, an ingredient(s) which augments or promotes the pharmacological effect of the active ingredient(s) without itself being considered active (typically used with vaccines)</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ADJV</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1191,7 +1217,8 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient that is any additive added</skos:definition>
 		<skos:note>Use only when there is no described pharmacological action and classification as merely &apos;inactive&apos; ingredient is not appropriate</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ADTV</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1201,7 +1228,8 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient that is the base of a preparation</skos:definition>
 		<skos:example>water, vaseline, ethanol</skos:example>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>BASE</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1210,7 +1238,8 @@
 		<rdfs:label>ingredient role - CNTM</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for a contaminant, an ingredient whose presence is not intended but may not be reasonably avoided given the circumstances of the mixture&apos;s nature or origin</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>CNTM</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1219,7 +1248,8 @@
 		<rdfs:label>ingredient role - COLR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient added to alter the color appearance</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>COLR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1228,7 +1258,8 @@
 		<rdfs:label>ingredient role - FLVR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient added to alter the taste of the product</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>FLVR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1237,7 +1268,8 @@
 		<rdfs:label>ingredient role - IACT</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an inactive ingredient, i.e. ingredients added for a purpose other than the intended pharmacological action</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>IACT</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1246,7 +1278,8 @@
 		<rdfs:label>ingredient role - INGR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient not otherwise specified, used in cases of devices or foods where further classification is not common</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>INGR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1257,7 +1290,8 @@
 		<skos:definition>code for a mechanical ingredient, an ingredient which, as a whole, lends a spatial structure to the product, which structure is meaningful to the delivery of the pharmacologically active ingredients near the target site</skos:definition>
 		<skos:example>For example, a collagen matrix used as a base for transplanting skin cells.</skos:example>
 		<skos:note>Such ingredient has a function other than merely delivering the pharmacologically active substances into a systemic compartment (such as, for example, an ordinary capsule would have.)</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>MECH</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1266,7 +1300,8 @@
 		<rdfs:label>ingredient role - PRSV</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for a preservative, an ingredient added to delay the risk of the product&apos;s spoiling</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>PRSV</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1275,21 +1310,67 @@
 		<rdfs:label>ingredient role - STBL</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for a stabilizer, an ingredient added to keep the mixture homogenic (e.g. prevent the phases of an emulsion to separate)</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>STBL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-mprd;IngredientRoleCode">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;Ingredient"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
-				<owl:onClass rdf:resource="&idmp-sub;Ingredient"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-sub;Ingredient"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>ingredient role code</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-ACTI">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-ACTIB">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-ACTIM">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-ACTIR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-ADJV">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-ADTV">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-BASE">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-CNTM">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-COLR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-FLVR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-IACT">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-INGR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-MECH">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-PRSV">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-mprd;IngredientRole-STBL">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>sequence of characters denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.7.2.2.2 and Figure 12</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</cmns-av:adaptedFrom>
 	</owl:Class>
 	

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -187,21 +187,6 @@
 		</rdfs:subClassOf>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&idmp-sub;ISO11615-IngredientRoleVocabulary">
-		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
-		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
-		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
-		<rdfs:label>ISO 11615 - ingredient role vocabulary</rdfs:label>
-		<skos:definition>controlled vocabulary denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.7.2.2.2 and Figure 12</cmns-av:adaptedFrom>
-		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</cmns-av:adaptedFrom>
-		<cmns-col:isConstituentOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
-		<cmns-dsg:hasDescription>controlled vocabulary denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</cmns-dsg:hasDescription>
-		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
-		<mvf:hasTextualName>ISO 11615 Ingredient Role vocabulary</mvf:hasTextualName>
-		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/ISO11615-IngredientRoleVocabulary/</mvf:hasURI>
-	</owl:NamedIndividual>
-	
 	<owl:Class rdf:about="&idmp-sub;InactiveIngredient">
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -820,6 +805,21 @@
 				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:allValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>comorbidity</rdfs:label>
 		<skos:definition>classifier for a cooccurring condition or co-infection that is described as part of the indication</skos:definition>
 		<skos:note>If there is any comorbidity (concurrent condition) or co-infection described as part of the indication as it is referenced in the regulated product information, it can be specified here using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
@@ -1027,6 +1027,12 @@
 				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>contraindication as &apos;disease/symptom/procedure&apos;</rdfs:label>
 		<skos:definition>classifier for diseases, symptoms or procedures from medical terminology that is used for, but not limited to, the registration, documentation and safety monitoring of medicinal products</skos:definition>
 		<skos:note>Classifiers for diseases, symptoms or procedures are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
@@ -1079,6 +1085,21 @@
 				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:allValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>disease status</rdfs:label>
 		<skos:definition>classifier for the status of a disease or symptom</skos:definition>
 		<skos:note>The status of the disease or symptom of the indication can be specified as it is referenced in the regulated product information using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
@@ -1094,6 +1115,21 @@
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.23</dct:source>
 		<skos:definition>specified quantity of a medicine, to be taken at one time or at stated intervals</skos:definition>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&idmp-mprd;ISO11615-IngredientRoleVocabulary">
+		<rdf:type rdf:resource="&idmp-dtp;ControlledVocabulary"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
+		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:label>ISO 11615 - ingredient role vocabulary</rdfs:label>
+		<skos:definition>controlled vocabulary denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.7.2.2.2 and Figure 12</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</cmns-av:adaptedFrom>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-mprd;ISO20443-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary denoting an ingredient role, according to the ISO 20443 implementation guide for ISO 11615</cmns-dsg:hasDescription>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>ISO 11615 Ingredient Role vocabulary</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/ISO11615-IngredientRoleVocabulary/</mvf:hasURI>
+	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-mprd;ISO20443-CodeSet">
 		<rdf:type rdf:resource="&cmns-cds;CodeSet"/>
@@ -1147,6 +1183,12 @@
 				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>indication as &apos;disease/symptom/procedure&apos;</rdfs:label>
 		<skos:definition>classifier for diseases, symptoms or procedures from medical terminology that is used for, but not limited to, the registration, documentation and safety monitoring of medicinal products</skos:definition>
 		<skos:note>Classifiers for diseases, symptoms or procedures are defined in controlled vocabularies such as SNOMED-CT or MedDRA.</skos:note>
@@ -1162,8 +1204,8 @@
 		<rdfs:label>ingredient role - ACTI</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient whose basis of strength cannot be specified</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTI</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1172,8 +1214,8 @@
 		<rdfs:label>ingredient role - ACTIB</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient where the entire substance is the basis of strength</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTIB</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1182,8 +1224,8 @@
 		<rdfs:label>ingredient role - ACTIM</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient where the active moiety is basis of strength</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTIM</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1192,8 +1234,8 @@
 		<rdfs:label>ingredient role - ACTIR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an active ingredient where another reference substance is the basis of strength</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ACTIR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1202,8 +1244,8 @@
 		<rdfs:label>ingredient role - ADJV</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an adjuvant, an ingredient(s) which augments or promotes the pharmacological effect of the active ingredient(s) without itself being considered active (typically used with vaccines)</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ADJV</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1213,8 +1255,8 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient that is any additive added</skos:definition>
 		<skos:note>Use only when there is no described pharmacological action and classification as merely &apos;inactive&apos; ingredient is not appropriate</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>ADTV</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1224,8 +1266,8 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient that is the base of a preparation</skos:definition>
 		<skos:example>water, vaseline, ethanol</skos:example>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>BASE</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1234,8 +1276,8 @@
 		<rdfs:label>ingredient role - CNTM</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for a contaminant, an ingredient whose presence is not intended but may not be reasonably avoided given the circumstances of the mixture&apos;s nature or origin</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>CNTM</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1244,8 +1286,8 @@
 		<rdfs:label>ingredient role - COLR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient added to alter the color appearance</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>COLR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1254,8 +1296,8 @@
 		<rdfs:label>ingredient role - FLVR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient added to alter the taste of the product</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>FLVR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1264,8 +1306,8 @@
 		<rdfs:label>ingredient role - IACT</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an inactive ingredient, i.e. ingredients added for a purpose other than the intended pharmacological action</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>IACT</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1274,8 +1316,8 @@
 		<rdfs:label>ingredient role - INGR</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for an ingredient not otherwise specified, used in cases of devices or foods where further classification is not common</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>INGR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1286,8 +1328,8 @@
 		<skos:definition>code for a mechanical ingredient, an ingredient which, as a whole, lends a spatial structure to the product, which structure is meaningful to the delivery of the pharmacologically active ingredients near the target site</skos:definition>
 		<skos:example>For example, a collagen matrix used as a base for transplanting skin cells.</skos:example>
 		<skos:note>Such ingredient has a function other than merely delivering the pharmacologically active substances into a systemic compartment (such as, for example, an ordinary capsule would have.)</skos:note>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>MECH</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1296,8 +1338,8 @@
 		<rdfs:label>ingredient role - PRSV</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for a preservative, an ingredient added to delay the risk of the product&apos;s spoiling</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>PRSV</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1306,8 +1348,8 @@
 		<rdfs:label>ingredient role - STBL</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>code for a stabilizer, an ingredient added to keep the mixture homogenic (e.g. prevent the phases of an emulsion to separate)</skos:definition>
-		<cmns-col:isMemberOf rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
-		<cmns-dsg:isDefinedIn rdf:resource="&idmp-sub;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
+		<cmns-dsg:isDefinedIn rdf:resource="&idmp-mprd;ISO11615-IngredientRoleVocabulary"/>
 		<cmns-txt:hasTextValue>STBL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
@@ -1376,6 +1418,21 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;TherapeuticIndication">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:allValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -2507,6 +2564,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 				<owl:allValuesFrom rdf:resource="&idmp-mprd;ShelfLife"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;ShelfLife"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>shelf life type</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure 11 and clause 9.6.2.11</dct:source>
 		<skos:definition>classifier for the period during which a medical product retains its properties and stated performance within specified limits if stored under defined conditions, taking into account various scenarios such as shelf life of the packaged medicinal product itself, shelf life after transformation where necessary, shelf life after first opening of a bottle, etc.</skos:definition>
@@ -2522,6 +2585,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;ShelfLife"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:allValuesFrom rdf:resource="&idmp-mprd;ShelfLife"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2790,6 +2859,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -803,12 +803,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Comorbidity">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass>
+				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
@@ -817,8 +817,7 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:onClass>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>comorbidity</rdfs:label>
@@ -1020,13 +1019,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ContraindicationAsDiseaseSymptomProcedure">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>contraindication as &apos;disease/symptom/procedure&apos;</rdfs:label>
@@ -1064,12 +1062,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;DiseaseStatus">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass>
+				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
@@ -1078,8 +1076,7 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:onClass>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>disease status</rdfs:label>
@@ -1142,13 +1139,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;IndicationAsDiseaseSymptomProcedure">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>indication as &apos;disease/symptom/procedure&apos;</rdfs:label>
@@ -1316,8 +1312,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-mprd;IngredientRoleCode">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
@@ -1375,12 +1371,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;IntendedEffect">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass>
+				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&idmp-mprd;Contraindication">
@@ -1389,8 +1385,7 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:onClass>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				</owl:allValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>intended effect</rdfs:label>
@@ -2504,13 +2499,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ShelfLifeType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-mprd;ShelfLife"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;ShelfLife"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>shelf life type</rdfs:label>
@@ -2523,13 +2517,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;SpecialPrecautionsForStorage">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:onClass rdf:resource="&idmp-mprd;ShelfLife"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;ShelfLife"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>special precautions for storage</rdfs:label>
@@ -2600,8 +2593,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;SymptomConditionEffectClassification">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>symptom/condition/effect classification</rdfs:label>
 		<skos:definition>classifier for the symptom, condition or effect that is undesirable effect</skos:definition>
 		<skos:note>The symptom, condition or effect in relation to the undesirable effect as described in the regulated product information can be specified using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
@@ -2792,13 +2785,12 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;UndesirableEffectAsSymptomConditionEffect">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
-		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicalCondition"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>undesirable effect as &apos;symptom/condition/effect&apos;</rdfs:label>

--- a/ISO/ISO21090-HarmonizedDatatypes.rdf
+++ b/ISO/ISO21090-HarmonizedDatatypes.rdf
@@ -14,7 +14,9 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
 	<!ENTITY idmp-dtp "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/">
+	<!ENTITY lcc-639-1 "https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -36,7 +38,9 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
 	xmlns:idmp-dtp="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"
+	xmlns:lcc-639-1="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -49,8 +53,8 @@
 		
 		The implementation of ISO 21090 included herein is an OWL 2 DL compliant representation of the datatypes defined in the ISO specification. This means that it is not a perfect match for the UML (Unified Modeling Language) representation given in the standard, as there is not a one-to-one alignment between UML and OWL. For details on mapping UML to OWL, please refer to the Object Management Group (OMG) specifications for (1) the Ontology Definition Metamode (ODM), available at https://www.omg.org/spec/ODM/, and (2) MOF to RDF Mapping (MOF2RDF), available at https://www.omg.org/spec/MOF2RDF/. As a consequence, this ontology is an indirectly conforming implementation that provides mappings to the XML Schema Datatypes that are supported in OWL 2 for some ISO 21090 datatypes, and encodes others in a manner that is OWL 2 DL compliant. References to ISO 11179 with respect to the representation of codes and code sets are faithful to the 3rd edition of 11179 as well as to revisions to that standard that are part of emerging work in the ISO JTC 1 SC32 WG2 working group to the degree possible.
 		
-		For more information on the ontologies on which this ontology depends, please refer to the Object Management Group (OMG) specifications for (1) the Commons Ontology Library (Commons) specification, available at https://www.omg.org/spec/COMMONS/, and (2) the Languages, Countries and Codes (LCC) specification, available at https://www.omg.org/spec/LCC/. Note that certain Commons ontologies referenced herein, including Documents and Quantities and Units, are not part of the Commons Ontology Library 1.0 Specification but are planned for inclusion in the 1.1 revision planned for late 2022 or early 2023.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		For more information on the ontologies on which this ontology depends, please refer to the Object Management Group (OMG) specifications for (1) the Commons Ontology Library (Commons) specification, available at https://www.omg.org/spec/COMMONS/, (2) the Languages, Countries and Codes (LCC) specification, available at https://www.omg.org/spec/LCC/, and (3) the Multiple Vocabulary Facility (MVF) specification, available at https://www.omg.org/spec/MVF/. Note that certain Commons ontologies referenced herein, including Documents and Quantities and Units, are not part of the Commons Ontology Library 1.0 Specification but are planned for inclusion in the 1.1 revision of the Commons planned for late 2023.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
@@ -63,14 +67,35 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO21090-HarmonizedDatatypes/"/>
 		<owl:versionInfo>The IDMP MVP version of this ontology is incomplete, and covers only the parts of the ISO 21090 standard required to support the MVP use cases.</owl:versionInfo>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO21090-HarmonizedDatatypes.rdf version of this ontology was modified to incorporate the Multiple Vocabulary Facility (MVF) for consistent representation of controlled vocabularies and code systems.</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022 Pistoia Alliance, Inc.</cmns-av:copyright>
 		<cmns-av:explanatoryNote>The harmonized datatypes ontology provides a set of codes for datatypes and classes used in other standards in the health informatics family of standards, including those published by HL7. These codes need to be referenced via an annotation in the context of the IDMP ontologies due to the fact that any other approach would result in punning.</cmns-av:explanatoryNote>
 	</owl:Ontology>
+	
+	<owl:Class rdf:about="&idmp-dtp;CodeSystem">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ControlledVocabulary"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeSet"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:onClass rdf:resource="&cmns-id;Identifier"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>code system</rdfs:label>
+		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 3.4</dct:source>
+		<skos:definition>managed collection of concept identifiers, usually codes, but sometimes more complex sets of rules and references</skos:definition>
+		<skos:note>They are often described as collections of uniquely identifiable concepts with associated representations, designations, associations and meanings.</skos:note>
+		<cmns-av:usageNote>ISO 21090 does not explicitly define a datatype called CD.CodeSystem (or codeSystem, or codeSystem: Uid, depending on the reference), which is referenced in some of the IDMP standards. The relationship &apos;is member of&apos; some code system, which is a property of every code element, corresponds to CD.CodeSystem, however, and, the UID/OID for the relevant system can be retrieved via SPARQL.</cmns-av:usageNote>
+		<cmns-av:usageNote>The restriction, isIdentifiedBy exactly 1 Identifier corresponds to the &apos;codeSystem : Uid&apos; attribute given in ISO 21090. ISO 21090 requires the code system name to be associated with every code; in this ontology, the name is associated with the code system and a code is a member of that system, thus one can retrieve the code system name via SPARQL. The &apos;codeSystemVersion : String&apos; corresponds with the hasVersion property, and again can be retrieved for any code using SPARQL to query through to the definition of the code system of which it is a member. Both the name and version are inherited from CodeSet.</cmns-av:usageNote>
+	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-dtp;CodeSystemName">
 		<rdfs:subClassOf rdf:resource="&cmns-dsg;Name"/>
@@ -85,12 +110,42 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.3</dct:source>
 		<skos:definition>common name of the coding system</skos:definition>
 		<skos:note>The purpose of a code system name is to assist an unaided human interpreter of a code value to understand which code system is referenced.</skos:note>
+		<cmns-av:usageNote>ISO 21090 does not explicitly define a datatype called CD.CodeSystemName (or codeSystemName), which is referenced in some of the IDMP standards. The relationship &apos;has name&apos; some code system name, which is a property of every code set, corresponds to CD.CodeSystemName, however. This element can be retrieved by using SPARQL from any code to the code system of which it is a member.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-dtp;CodingRationale">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;DatatypeFlavor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&cmns-cds;CodeElement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&cmns-cds;CodeElement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>coding rationale</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.10</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-dtp;CodingRationale-O">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CodingRationale-OR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CodingRationale-P">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CodingRationale-PR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CodingRationale-R">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>code element that indicates a reason why a particular CD has been provided, either as the root concept or as one of the translations.</skos:definition>
 		<skos:note>A code is deemed to be post-coded if the user does not assign the code when they first enter the data. codingRationale is not expected to act as a quality review marker on the quality of the coding or the translation processes.</skos:note>
 		<skos:note>A code is required when it is present in the instance to meet some constraints imposed on the instance by the context of use. Information Processing Entities shall not be required to mark a particular translation as required even though it is required by the context of use, but may do so. Information processing entities shall not reject instances because of the presence or absence of the codingRationale flag.</skos:note>
@@ -103,7 +158,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.10</dct:source>
 		<skos:definition>code indicating that the code descriptor represents the originally produced code</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CodingRationaleEnumeration"/>
 		<cmns-dsg:hasDescription>Original</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>O</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -114,7 +169,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.10</dct:source>
 		<skos:definition>code indicating that the code descriptor is an originally produced code and is required by the specification describing the use of the coded concept</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CodingRationaleEnumeration"/>
 		<cmns-dsg:hasDescription>Original and Required</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>OR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -125,7 +180,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.10</dct:source>
 		<skos:definition>code indicating that the code descriptor was post-coded from free text source</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CodingRationaleEnumeration"/>
 		<cmns-dsg:hasDescription>Post-coded</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>P</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -136,7 +191,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.10</dct:source>
 		<skos:definition>code indicating that the code descriptor is post-coded from free text source and is required by the specification describing the use of the coded concept</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CodingRationaleEnumeration"/>
 		<cmns-dsg:hasDescription>Post-coded and Required</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>PR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -148,22 +203,48 @@
 		<skos:definition>code indicating that the code descriptor is required by the specification describing the use of the coded concept</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>The exact form of the requirement is not specified here; it may be required by the specification directly, or it may arise as an indirect result of other conformance tools. More than one different requirement may exist simultaineously, so more than one code in a CD complex may be required.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CodingRationaleEnumeration"/>
 		<cmns-dsg:hasDescription>Required</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>R</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;CodingRationaleEnumeration">
-		<rdf:type rdf:resource="&idmp-dtp;CodingRationale"/>
+		<rdf:type rdf:resource="&idmp-dtp;CodeSystem"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:label>coding rationale enumeration</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.5.2.4.10</dct:source>
-		<skos:definition>singleton used for reference to the coding rationale code element class to avoid punning</skos:definition>
+		<skos:definition>controlled vocabulary representing the enumeration for coding rationale as specified in ISO 21090</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary representing the enumeration for coding rationale</cmns-dsg:hasDescription>
+		<cmns-id:isIdentifiedBy rdf:resource="&idmp-dtp;OID-2.16.840.1.113883.5.1074"/>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>Coding Rationale Enumeration</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/CodingRationaleEnumeration/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-dtp;CompressionAlgorithm">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;DatatypeFlavor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>compression algorithm</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-dtp;CompressionAlgorithm-BZ">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CompressionAlgorithm-DF">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CompressionAlgorithm-GZ">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CompressionAlgorithm-Z">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CompressionAlgorithm-Z7">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;CompressionAlgorithm-ZL">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>code element that identifies an algorithm, if any, used to compress the raw byte data</skos:definition>
 		<skos:note>If populated, the value of this attribute shall be taken from the HL7 CompressionAlgorithm code system.</skos:note>
 		<skos:note>If the attribute is null, the data are not compressed. Compression only applies to the binary form of the content.</skos:note>
@@ -176,7 +257,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
 		<skos:definition>code indicating the bzip-2 compression format. See [http://www.bzip.org/] for more information.</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CompressionAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>bzip</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>BZ</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -187,7 +268,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
 		<skos:definition>code indicating the deflate compressed data format as specified in IETF RFC 1951</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CompressionAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>deflate</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>DF</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -198,7 +279,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
 		<skos:definition>code indicating a compressed data format that is compatible with the widely used GZIP utility as specified in IETF RFC 1952 (uses the deflate algorithm)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CompressionAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>gzip</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>GZ</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -209,7 +290,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
 		<skos:definition>code indicating the original UNIX compress algorithm and file format using the LZC algorithm (a variant of LZW). Patent encumbered and less efficient than deflate</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CompressionAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>compress</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>Z</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -220,7 +301,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
 		<skos:definition>code indicating the 7z compression file format. See [http://www.7-zip.org/7z.html] for more information.</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CompressionAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>Z7</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>Z7</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -231,17 +312,34 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
 		<skos:definition>code indicating a compressed data format that also uses the deflate algorithm. Specified as IETF RFC 1950</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;CompressionAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>zlib</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>ZL</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;CompressionAlgorithmEnumeration">
-		<rdf:type rdf:resource="&idmp-dtp;CompressionAlgorithm"/>
+		<rdf:type rdf:resource="&idmp-dtp;CodeSystem"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:label>compression algorithm enumeration</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.8</dct:source>
-		<skos:definition>singleton used for reference to the compression algorithm code element class to avoid punning</skos:definition>
+		<skos:definition>controlled vocabulary representing the enumeration for compression algorithms as specified in ISO 21090</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary representing the enumeration for compression algorithms as specified in ISO 21090</cmns-dsg:hasDescription>
+		<cmns-id:isIdentifiedBy rdf:resource="&idmp-dtp;OID-2.16.840.1.113883.5.1009"/>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>Compression Algorithm Enumeration</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/CompressionAlgorithmEnumeration/</mvf:hasURI>
 	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&idmp-dtp;ControlledVocabulary">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ValueDomain"/>
+		<rdfs:subClassOf rdf:resource="&mvf;Vocabulary"/>
+		<rdfs:label>controlled vocabulary</rdfs:label>
+		<skos:definition>finite set of values that represent the only allowed values for a data item</skos:definition>
+		<skos:note>The allowed values can be codes, text or numeric.</skos:note>
+		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.18</cmns-av:directSource>
+		<cmns-av:directSource>ISO 11240:2012 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.5</cmns-av:directSource>
+	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;DatatypeCode-ANY">
 		<rdf:type rdf:resource="&cmns-cds;CodeElement"/>
@@ -705,11 +803,21 @@
 	
 	<owl:Class rdf:about="&idmp-dtp;IntegrityCheckAlgorithm">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;DatatypeFlavor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>integrity check algorithm</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.10</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-dtp;IntegrityCheckAlgorithm-SHA1">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;IntegrityCheckAlgorithm-SHA256">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>code element that identifies the algorithm used to compute the integrityCheck value</skos:definition>
 		<skos:note>If populated, the value of this attribute shall be taken from the HL7 IntegrityCheckAlgorithm code system.</skos:note>
-		<cmns-av:synonym>integrity check algorithm enumeration</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;IntegrityCheckAlgorithm-SHA1">
@@ -718,7 +826,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.10</dct:source>
 		<skos:definition>code indicating the algorithm defined in FIPS PUB 180-1: Secure Hash Standard, As of April 17, 1995</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;IntegrityCheckAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>secure hash algorithm - 1</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>SHA1</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -729,26 +837,69 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.10</dct:source>
 		<skos:definition>code indicating the algorithm defined in FIPS PUB 180-2: Secure Hash Standard</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;IntegrityCheckAlgorithmEnumeration"/>
 		<cmns-dsg:hasDescription>secure hash algorithm - 256</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>SHA256</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;IntegrityCheckAlgorithmEnumeration">
-		<rdf:type rdf:resource="&idmp-dtp;IntegrityCheckAlgorithm"/>
+		<rdf:type rdf:resource="&idmp-dtp;CodeSystem"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:label>integrity check algorithm enumeration</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.4.2.3.10</dct:source>
-		<skos:definition>singleton used for reference to the integrity check algorithm code element class to avoid punning</skos:definition>
+		<skos:definition>controlled vocabulary representing the enumeration for integrity check algorithms as specified in ISO 21090</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary representing the enumeration for integrity check algorithms as specified in ISO 21090</cmns-dsg:hasDescription>
+		<cmns-id:isIdentifiedBy rdf:resource="&idmp-dtp;OID-2.16.840.1.113883.5.1010"/>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>Integrity Check Algorithm Enumeration</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/IntegrityCheckAlgorithmEnumeration/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-dtp;NullFlavor">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;DatatypeFlavor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>null flavor</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-ASKU">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-DER">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-INV">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-MSK">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-NA">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-NASK">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-NAV">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-NI">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-NINF">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-OTH">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-PINF">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-QS">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-TRC">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-UNC">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;NullFlavor-UNK">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:definition>code element that provides a general framework for handling incomplete data which is often encountered in healthcare information collection, use and analysis</skos:definition>
 		<skos:note>Some of the Null flavors are not generally applicable to all datatypes. The NullFlavors NINF, PINF, QS, and TRC shall only be used in association with QTY types. The NullFlavor UNC shall only be used with any type that has an originalText, and when UNC is used the originalText property shall be populated. When the NullFlavor DER is used, an expression shall be provided.</skos:note>
 		<skos:note>The nullFlavor property may also play a special role in conformance frameworks in specifications that make use of these types.</skos:note>
-		<cmns-av:synonym>null flavor enumeration</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;NullFlavor-ASKU">
@@ -757,7 +908,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value for which information was sought but not found (e.g. patient was asked but did not know).</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Asked but unknown</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-UNK"/>
 		<cmns-txt:hasTextValue>ASKU</cmns-txt:hasTextValue>
@@ -769,7 +920,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for value for which no attempt has been made to encode the information correctly but the raw source information is represented (usually in originalText)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Derived</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-INV"/>
 		<cmns-txt:hasTextValue>DER</cmns-txt:hasTextValue>
@@ -781,7 +932,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value as represented in the instance that is not a member of the set of permitted data values in the constrained value domain of a variable</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">2</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Invalid</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-NI"/>
 		<cmns-txt:hasTextValue>INV</cmns-txt:hasTextValue>
@@ -795,7 +946,7 @@
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">2</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>There may be an alternate mechanism for gaining access to this information.</cmns-av:explanatoryNote>
 		<cmns-av:explanatoryNote>Warning: Using this Nullflavor does provide information that may be a breach of confidentiality, even though no detailed data are provided. Its primary purpose is for those circumstances where it is necessary to inform the receiver that the information does exist without providing any detail.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Masked</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-NI"/>
 		<cmns-txt:hasTextValue>MSK</cmns-txt:hasTextValue>
@@ -807,7 +958,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value for which no proper value is applicable in this context (e.g. last menstrual period for a male)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">2</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Not applicable</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-NI"/>
 		<cmns-txt:hasTextValue>NA</cmns-txt:hasTextValue>
@@ -819,7 +970,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value for which information has not been sought (e.g. patient was not asked)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Not asked</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-UNK"/>
 		<cmns-txt:hasTextValue>NASK</cmns-txt:hasTextValue>
@@ -831,7 +982,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value for which information is not available at this time but it is expected that it would be available later</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">4</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Temporarily unavailable</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-ASKU"/>
 		<cmns-txt:hasTextValue>NAV</cmns-txt:hasTextValue>
@@ -844,7 +995,7 @@
 		<skos:definition>code for a value that is exceptional (missing, omitted, incomplete, improper)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>No information as to the reason for being an exceptional value is provided. This is the most general exceptional value. It is also the default exceptional value.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>No information</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>NI</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -855,7 +1006,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value that is part of a value domain including a negative infinity of numbers</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">4</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Negative infinity</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-OTH"/>
 		<cmns-txt:hasTextValue>NINF</cmns-txt:hasTextValue>
@@ -867,7 +1018,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for an actual value that is not a member of the set of permitted data values in the constrained value domain of a variable (e.g. concept not provided by required code system)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Other</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-INV"/>
 		<cmns-txt:hasTextValue>OTH</cmns-txt:hasTextValue>
@@ -879,7 +1030,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value that is part of a value domain including a positive infinity of numbers</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">4</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Positive infinity</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-OTH"/>
 		<cmns-txt:hasTextValue>PINF</cmns-txt:hasTextValue>
@@ -891,7 +1042,7 @@
 		<skos:definition>code for a value for which a specific quantity is not known, but is known to be non-zero and is not specified because it makes up the bulk of the material</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>&apos;Add 10 mg of ingredient X, 50 mg of ingredient Y, and sufficient quantity of water to 100 ml.&apos; The null flavor would be used to express the quantity of water.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Sufficient quantity</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-UNK"/>
 		<cmns-txt:hasTextValue>QS</cmns-txt:hasTextValue>
@@ -902,7 +1053,7 @@
 		<rdfs:label>null flavor TRC</rdfs:label>
 		<skos:definition>code for a value for which content is greater than zero, but too small to be quantified</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Trace</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-UNK"/>
 		<cmns-txt:hasTextValue>TRC</cmns-txt:hasTextValue>
@@ -914,7 +1065,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value for which an actual value may exist, but it must be derived from the information provided (usually an expression is provided directly)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">3</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Unencoded</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-INV"/>
 		<cmns-txt:hasTextValue>UNC</cmns-txt:hasTextValue>
@@ -926,17 +1077,24 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
 		<skos:definition>code for a value for which proper value is applicable, but not known</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">2</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;NullFlavorEnumeration"/>
 		<cmns-dsg:hasDescription>Unknown</cmns-dsg:hasDescription>
 		<cmns-qtu:specializes rdf:resource="&idmp-dtp;NullFlavor-NI"/>
 		<cmns-txt:hasTextValue>UNK</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;NullFlavorEnumeration">
-		<rdf:type rdf:resource="&idmp-dtp;NullFlavor"/>
+		<rdf:type rdf:resource="&idmp-dtp;CodeSystem"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:label>null flavor enumeration</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.1.4</dct:source>
-		<skos:definition>singleton used for reference to the null flavor code element class to avoid punning</skos:definition>
+		<skos:definition>controlled vocabulary representing the enumeration for null flavor codes as specified in ISO 21090</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary representing the enumeration for null flavor codes as specified in ISO 21090</cmns-dsg:hasDescription>
+		<cmns-id:isIdentifiedBy rdf:resource="&idmp-dtp;OID-2.16.840.1.113883.5.1008"/>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>Null Flavor Enumeration</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/NullFlavorEnumeration/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;OID-2.16.840.1.113883.5.1008">
@@ -1001,11 +1159,31 @@
 	
 	<owl:Class rdf:about="&idmp-dtp;UpdateMode">
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;DatatypeFlavor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>update mode</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.3.3.3.2</dct:source>
-		<skos:definition>code element that allows a sending system to identify the role that thevcattribute plays in processing the instance that is being represented</skos:definition>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-A">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-AR">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-D">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-K">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-N">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-R">
+					</rdf:Description>
+					<rdf:Description rdf:about="&idmp-dtp;UpdateMode-U">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
+		<skos:definition>code element that allows a sending system to identify the role that the attribute plays in processing the instance that is being represented</skos:definition>
 		<skos:note>If populated, the value of this attribute shall be taken from the HL7 UpdateMode code system.</skos:note>
-		<cmns-av:synonym>update mode enumeration</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;UpdateMode-A">
@@ -1015,7 +1193,7 @@
 		<skos:definition>code indicating that an item was (or is to be) added, having not been present immediately before</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>If it is already present, this may be treated as an error condition.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>Add</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>A</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -1027,7 +1205,7 @@
 		<skos:definition>code indicating that an item was (or is to be) either added or replaced</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>No assertion is made as to whether the item previously existed.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>Add or replace</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>AR</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -1039,7 +1217,7 @@
 		<skos:definition>code indicating that an item item was (or is to be) removed (sometimes referred to as deleted)</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>If the item is part of a collection, delete any matching items.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>Remove</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>D</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -1050,7 +1228,7 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.3.3.3.2</dct:source>
 		<skos:definition>code indicating that the item is part of the identifying information for the object that contains it</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>Key</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>K</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -1062,7 +1240,7 @@
 		<skos:definition>code indicating that there was (or is to be) no change to the item</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>This is primarily used when this element has not changed, but other attributes in the instance have changed.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>No change</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>N</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -1074,7 +1252,7 @@
 		<skos:definition>code indicating that an item existed previously and has been (or is to be) revised</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
 		<cmns-av:explanatoryNote>If an item does not already exist, this may be treated as an error condition.</cmns-av:explanatoryNote>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>Replace</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>R</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
@@ -1085,16 +1263,23 @@
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.3.3.3.2</dct:source>
 		<skos:definition>code indicating that it is not specified whether or what kind of change has occurred to the item, or whether the item is present as a reference or identifying property</skos:definition>
 		<idmp-dtp:hasLevelInHierarchy rdf:datatype="&xsd;nonNegativeInteger">1</idmp-dtp:hasLevelInHierarchy>
-		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;UpdateModeEnumeration"/>
 		<cmns-dsg:hasDescription>Unknown</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>U</cmns-txt:hasTextValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-dtp;UpdateModeEnumeration">
-		<rdf:type rdf:resource="&idmp-dtp;UpdateMode"/>
+		<rdf:type rdf:resource="&idmp-dtp;CodeSystem"/>
+		<rdf:type rdf:resource="&cmns-cls;ClassificationScheme"/>
 		<rdfs:label>update mode enumeration</rdfs:label>
 		<dct:source>ISO 21090:2011 Health informatics - Harmonized data types for information interchange, clause 7.3.3.3.2</dct:source>
-		<skos:definition>singleton used for reference to the update mode code element class to avoid punning</skos:definition>
+		<skos:definition>controlled vocabulary representing the enumeration for update mode codes as specified in ISO 21090</skos:definition>
+		<cmns-col:isConstituentOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
+		<cmns-dsg:hasDescription>controlled vocabulary representing the enumeration for update mode codes as specified in ISO 21090</cmns-dsg:hasDescription>
+		<cmns-id:isIdentifiedBy rdf:resource="&idmp-dtp;OID-2.16.840.1.113883.5.57"/>
+		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
+		<mvf:hasTextualName>Update Mode Enumeration</mvf:hasTextualName>
+		<mvf:hasURI rdf:datatype="&xsd;anyURI">https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/UpdateModeEnumeration/</mvf:hasURI>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-dtp;ValueDomain">

--- a/MVF/AboutMVF.rdf
+++ b/MVF/AboutMVF.rdf
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY abt-mvf "http://www.omg.org/spec/MVF/AboutMVF/">
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF
+	xmlns:abt-mvf="http://www.omg.org/spec/MVF/AboutMVF/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="http://www.omg.org/spec/MVF/AboutMVF/">
+		<rdfs:label>About the Multiple Vocabulary Facility (MVF) Specification</rdfs:label>
+		<dct:abstract>This ontology is provided for the convenience of MVF users. It can be used to load all of the current MVF ontologies, using a relative catalog as needed for Protege and other tools.</dct:abstract>
+		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
+		<dct:references rdf:resource="http://purl.org/dc/terms/"/>
+		<dct:references rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09</dct:source>
+		<dct:source>ISO 704:2009 Terminology work - Principles and methods, Third edition, 2009-11-01</dct:source>
+		<dct:source>ISO/IEC 11179-3:2013 Information technology - Metadata registries (MDR) - Registry metamodel and basic attributes, Third edition, 2013-02-15</dct:source>
+		<dct:source>International Information Centre for Terminology (InfoTerm), see http://www.infoterm.info/</dct:source>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/20230501/AboutMVF/"/>
+		<dct:contributor>Davide Sottara, Mayo Clinic</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Evan Wallace, U.S. National Institute of Standards and Technology (NIST)</dct:contributor>
+		<dct:contributor>Pete Rivett, agnos.ai U.K. Ltd</dct:contributor>
+		<cmns-av:copyright>Copyright (c) 2019-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Mayo Clinic</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 QuoteWell Insurance Services, LLC</cmns-av:copyright>
+	</owl:Ontology>
+
+</rdf:RDF>

--- a/MVF/ISO1087-TerminologyScience.rdf
+++ b/MVF/ISO1087-TerminologyScience.rdf
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
+	<!ENTITY mvf-trm "https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/">
+	<!ENTITY mvf-tsc "https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
+	xmlns:mvf-trm="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"
+	xmlns:mvf-tsc="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/">
+		<rdfs:label>Multiple Vocabulary Facility (MVF) Terminologies Ontology</rdfs:label>
+		<dct:abstract>The MVF ontology consists of three components:
+- a core ontology corresponding to the MVF metamodel,
+- an extension representing the subset of the ISO 1087 reference vocabulary used in other ISO standards for vocabulary representation, 
+- an extension that incorporates additional vocabulary from ISO 1087 for terminology science. 
+MVF also reuses several ontologies from the OMG Commons library for specific patterns, including designations, collections, and classifiers (this ontology).</dct:abstract>
+		<dct:contributor>Ed Barkmeyer, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/20230501/ISO1087-TerminologyScience/"/>
+		<skos:scopeNote>Note that the set of ontologies provided for MVF do not provide exhaustive coverage of ISO 1087. We have not incorporated the terms related to data validation or natural language processing in the latest version of the standard, and certain classes under the heading of concept relation in the standard are handled as properties herein.</skos:scopeNote>
+		<cmns-av:copyright>Copyright (c) 2011-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&cmns-col;StructuredCollection">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasArrangement"/>
+				<owl:onClass rdf:resource="&mvf-tsc;Macrostructure"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<skos:example>collection of artifacts, books, periodicals, artwork, terms, or other objects that form the core basis for a vocabulary, exhibit, library, or other organization</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;BaseList">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyResource"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dsg;Designation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>base list</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.5.7</dct:source>
+		<skos:definition>list of designations resulting from term extraction</skos:definition>
+		<skos:note>A base list usually gives rise to further terminology work.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Borrowing">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>borrowing</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.32</dct:source>
+		<skos:definition>method for the formation of designations in which a designation is adopted from another natural language or another domain or subject</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;ConceptHarmonization">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>concept harmonization</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.5.4</dct:source>
+		<skos:definition>terminology work aimed at the establishment of a correspondence between two or more closely related or overlapping concepts to eliminate or reduce minor differences between them</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Conversion">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>conversion</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.39</dct:source>
+		<skos:definition>method for the formation of designations in which the syntactic category of an existing word or lexical unit is changed</skos:definition>
+		<skos:example>The conversion of &apos;constant&apos; as an adjective to &apos;constant&apos; as a noun in the domain of mathematics; the conversion of &apos;output&apos; as a noun to &apos;output&apos; as a verb in the domain of economics.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;DataCategory">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:label>data category</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.6.3</dct:source>
+		<skos:definition>specification of a type of terminological data that is used for structuring terminological entries or terminology resources</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Derivation">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>derivation</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.38</dct:source>
+		<skos:definition>method for the formation of designations in which a designation is formed by adding one or more morphological elements to a word or lexical unit</skos:definition>
+		<skos:example>Terms formed by derivation: &apos;printer&apos; (print | -er), &apos;disassembly&apos; (assemble | dis- | -y), &apos;hormonal&apos; (hormon | -al).</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Glossary">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologicalDictionary"/>
+		<rdfs:label>glossary</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.6</dct:source>
+		<skos:definition>terminological dictionary that contains designations from one or more domains or subjects together with equivalents in one or more natural languages</skos:definition>
+		<skos:note>In English common language usage, glossary can refer to a monolingual list of designations and definitions in a domain or subject.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;LanguageSpecificOrder">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Macrostructure"/>
+		<rdfs:label>language-specific order</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.12</dct:source>
+		<skos:definition>macrostructure in which the terminological entries reflect the ordering conventions specific to a given natural language or script</skos:definition>
+		<skos:note>Alphabetical order in a monolingual terminology resource.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;LoanTranslation">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>loan translation</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.35</dct:source>
+		<skos:definition>method for the formation of designations in which the elements of a designation in another natural language are translated literally into the recipient language</skos:definition>
+		<skos:example>Loan translations in English are &apos;flea market&apos; (from French marché aux puces), &apos;loan translation&apos; (from German Lehnübersetzung).</skos:example>
+		<cmns-av:synonym>calque translation</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Macrostructure">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Arrangement"/>
+		<rdfs:label>macrostructure</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.8</dct:source>
+		<skos:definition>selection and arrangement of terminological entries in a collection</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Microstructure">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Arrangement"/>
+		<rdfs:label>microstructure</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.9</dct:source>
+		<skos:definition>selection and arrangement of terminological data in each terminological entry of a collection</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;MixedOrder">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Macrostructure"/>
+		<rdfs:label>mixed order</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.13</dct:source>
+		<skos:definition>macrostructure which is a combination of systematic order, thematic order, and language-specific order</skos:definition>
+		<cmns-av:synonym>mixed arrangement</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Nomenclature">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Terminology"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasArrangement"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;SystematicOrder"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>nomenclature</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.7</dct:source>
+		<skos:definition>terminology structured systematically according to pre-established naming rules</skos:definition>
+		<skos:example>International Code of Virus Classification and Nomenclature</skos:example>
+		<skos:note>Nomenclatures have been elaborated in various domains (3.1.4), such as biology, medicine, and chemistry.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;SystematicOrder">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Macrostructure"/>
+		<rdfs:label>systematic order</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.10</dct:source>
+		<skos:definition>macrostructure in which the terminological entries reflect the underlying concept system</skos:definition>
+		<cmns-av:synonym>systematic arrangement</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TermBank">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyResource"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;TerminologicalDatabase"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>term bank</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.3</dct:source>
+		<skos:definition>collection of terminology databases including the organizational framework for recording, processing and disseminating terminological data</skos:definition>
+		<cmns-av:synonym>terminological data bank</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TermExtraction">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-tsc;produces"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;BaseList"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-tsc;produces"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;TerminologicalConcordance"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-tsc;reflects"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;TextCorpus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>term extraction</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.5.6</dct:source>
+		<skos:definition>terminology work that involves the identification and excerption of terminological data by searching through a text corpus</skos:definition>
+		<skos:note>Term extraction is often supported by dedicated software tools.</skos:note>
+		<skos:note>Terminological data of primary interest are typically designations, definitions and contexts.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TermFormation">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>term harmonization</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.31</dct:source>
+		<skos:definition>terminology work aimed at creating new terms using one or more of a variety of methods</skos:definition>
+		<skos:note>By analogy, &apos;term formation&apos; can apply also to appellations, proper names and symbols.</skos:note>
+		<skos:note>Methods of term formation may among others include transdisciplinary borrowing, translingual borrowing, loan translation, transliteration, transcription, derivation, or conversion, the creation of abbreviations or blends.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TermHarmonization">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>term harmonization</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.5.5</dct:source>
+		<skos:definition>terminology work leading to the selection of designations for harmonized concepts either in different natural languages or within the same natural language</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Terminography">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>terminography</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.5.5</dct:source>
+		<skos:definition>terminology work aimed at creating and maintaining terminology resources</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologicalConcordance">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyResource"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:onClass rdf:resource="&cmns-cxtdsg;Context"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dsg;Designation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-tsc;reflects"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;TextCorpus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>terminological concordance</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.5.8</dct:source>
+		<skos:definition>list of designations extracted from a text corpus together with a context and a source reference</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologicalDatabase">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;isManagedBy"/>
+				<owl:allValuesFrom rdf:resource="&mvf-tsc;TermBank"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:allValuesFrom rdf:resource="&mvf-tsc;TerminologyResource"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>terminological database</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.7.2</dct:source>
+		<skos:definition>database comprising a terminology resource</skos:definition>
+		<cmns-av:synonym>termbase</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologicalDictionary">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyResource"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&mvf;VocabularyEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasArrangement"/>
+				<owl:someValuesFrom rdf:resource="&mvf-tsc;Macrostructure"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
+				<owl:someValuesFrom rdf:resource="&mvf-trm;SpecialLanguage"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>terminological dictionary</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.7.4</dct:source>
+		<skos:definition>terminology resource that is designed to be used as a reference work</skos:definition>
+		<cmns-av:abbreviation>LSP dictionary</cmns-av:abbreviation>
+		<cmns-av:synonym>special-language dictionary</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Terminologization">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-tsc;produces"/>
+				<owl:allValuesFrom rdf:resource="&mvf-trm;Term"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>terminologization</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.30</dct:source>
+		<skos:definition>process by which a general language word or lexical unit is being used more and more as a term in a specific domain or subject</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;Terminology">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&mvf-trm;Domain">
+							</rdf:Description>
+							<rdf:Description rdf:about="&mvf-trm;Subject">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dsg;Designation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>terminology</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.11</dct:source>
+		<skos:definition>set of designations and concepts belonging to one domain or subject</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologyPlanning">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyWork"/>
+		<rdfs:label>terminology planning</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.5.3</dct:source>
+		<skos:definition>terminology work aimed at developing, improving, implementing and disseminating the terminology of a domain or subject</skos:definition>
+		<skos:note>Terminology planning involves all aspects of terminology work and has among other objectives the objective of achieving vocabulary control through such normative documents as thesauri and terminology standards.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologyProcessing">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Terminography"/>
+		<rdfs:label>terminology processing</rdfs:label>
+		<dct:source>ISO 1087-1, paragraph 3.6.3</dct:source>
+		<skos:definition>part of terminography concerned with computer aspects of database creation, maintenance and extraction of terminology from texts</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologyResource">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&mvf;VocabularyEntry"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>terminology resource</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.7.1</dct:source>
+		<skos:definition>collection of terminological entries</skos:definition>
+		<skos:note>Terminology resources may be in paper or electronic format, e.g. paper dictionaries or glossaries, CDs, DVDs, databases or term banks.</skos:note>
+		<cmns-av:abbreviation>TDC</cmns-av:abbreviation>
+		<cmns-av:synonym>terminological data collection</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologyScience">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Domain"/>
+		<rdfs:label>terminology science</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.12</dct:source>
+		<skos:definition>science studying terminologies, aspects of terminology work, the resulting terminology resources, and terminological data</skos:definition>
+		<cmns-av:synonym>terminology studies</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TerminologyWork">
+		<rdfs:label>terminology work</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.5.1</dct:source>
+		<skos:definition>work concerned with the systematic collection, description, processing and presentation of concepts and their designations</skos:definition>
+		<skos:note>Terminology work often aims at creating and maintaining terminology resources.</skos:note>
+		<skos:note>Terminology work often aims at terminology planning and can involve all of concept harmonization, term harmonization, and term formation.</skos:note>
+		<cmns-av:synonym>terminology management</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TextCorpus">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:label>text corpus</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.6.4</dct:source>
+		<skos:definition>collection of natural language data</skos:definition>
+		<cmns-av:synonym>corpus</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;ThematicOrder">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Macrostructure"/>
+		<rdfs:label>thematic order</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.7.11</dct:source>
+		<skos:definition>macrostructure in which the terminological entries are grouped in accordance with a relational theme</skos:definition>
+		<skos:example>In a human resource vocabulary, one group of terminological entries relates to recruitment processes, while another group relates to employee assessment.</skos:example>
+		<cmns-av:synonym>thematic arrangement</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TransdisciplinaryBorrowing">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Borrowing"/>
+		<rdfs:label>transdisciplinary borrowing</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.33</dct:source>
+		<skos:definition>borrowing from another domain or subject</skos:definition>
+		<skos:example>The term &apos;virus&apos; was originally used in biology and later transferred to information technology.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-tsc;TranslingualBorrowing">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;Borrowing"/>
+		<rdfs:label>translingual borrowing</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.34</dct:source>
+		<skos:definition>borrowing from another natural language</skos:definition>
+		<skos:example>An example of a direct borrowing into English is the French term &apos;calque&apos;.</skos:example>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&mvf-tsc;excerpts">
+		<rdfs:label>excerpts</rdfs:label>
+		<skos:definition>selects for quoting (from a passage), extracts</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-tsc;informs">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;characterizes"/>
+		<rdfs:label>informs</rdfs:label>
+		<skos:definition>gives character or essence to, communicates knowledge to</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-tsc;makesTransparent">
+		<rdfs:subPropertyOf rdf:resource="&mvf-tsc;informs"/>
+		<rdfs:label>makes transparent</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.40</dct:source>
+		<skos:definition>expresses one or more characteristics of</skos:definition>
+		<skos:note>Designations in the relation of transparency are called &apos;transparent&apos; designations or &apos;motivated&apos; designations. Designations lacking transparency are called &apos;unmotivated&apos; designations.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-tsc;produces">
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>produces</rdfs:label>
+		<skos:definition>causes something to exist, makes something available, manufactures</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-tsc;reflects">
+		<rdfs:label>reflects</rdfs:label>
+		<skos:definition>makes manifest or apparent, shows</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-tsc;studies">
+		<rdfs:label>studies</rdfs:label>
+		<skos:definition>application of the mental faculties to the acquisition of knowledge 
+- such application in a particular field or to a specific subject 
+- careful or extended consideration 
+- a careful examination or analysis of a phenomenon, development, or question</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&mvf-trm;SpecialLanguage">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologyResource"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;Vocabulary">
+		<rdfs:subClassOf rdf:resource="&mvf-tsc;TerminologicalDictionary"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:onClass rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.7.5</dct:source>
+		<skos:note>A vocabulary is a terminological dictionary that contains designations and definitions from one or more domains or subjects.</skos:note>
+		<skos:note>A vocabulary may be monolingual, bilingual or multilingual. A vocabulary is a terminological dictionary that contains designations (vocabulary entries) and definitions from one or more specific subject fields.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;VocabularyEntry">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasArrangement"/>
+				<owl:onClass rdf:resource="&mvf-tsc;Microstructure"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+				<owl:onClass rdf:resource="&mvf-trm;Subject"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.6.2</dct:source>
+		<skos:note>A terminological entry prepared in accordance with the principles and methods given in ISO 704 follows the same structural principles whether it is monolingual or multilingual.</skos:note>
+		<skos:note>From a terminology perspective, a vocabulary entry is a collection of terminological data related to only one concept</skos:note>
+		<cmns-av:explanatoryNote>Notes on vocabulary entries can be represented using the skos:note annotation or any of its subproperties or other annotations as appropriate.</cmns-av:explanatoryNote>
+		<cmns-av:synonym>terminological entry</cmns-av:synonym>
+	</owl:Class>
+
+</rdf:RDF>

--- a/MVF/ISO1087-VocabularyForTermsAndDefinitions.rdf
+++ b/MVF/ISO1087-VocabularyForTermsAndDefinitions.rdf
@@ -1,0 +1,856 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
+	<!ENTITY mvf-trm "https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
+	xmlns:mvf-trm="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/">
+		<rdfs:label>Multiple Vocabulary Facility (MVF) Terms and Definitions Ontology</rdfs:label>
+		<dct:abstract>The MVF ontology consists of three components:
+- a core ontology corresponding to the MVF metamodel,
+- an extension representing the subset of the ISO 1087 reference vocabulary used in other ISO standards for vocabulary representation (this ontology), 
+- an extension that incorporates additional vocabulary from ISO 1087 for terminology science. 
+MVF also reuses several ontologies from the OMG Commons library for specific patterns, including designations, collections, and classifiers.</dct:abstract>
+		<dct:contributor>Ed Barkmeyer, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Jim Odell, Thematix Partners LLC</dct:contributor>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/20230501/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<skos:scopeNote>Note that the set of ontologies provided for MVF do not provide exhaustive coverage of ISO 1087. We have not incorporated the terms related to data validation or natural language processing in the latest version of the standard, and certain classes under the heading of concept relation in the standard are handled as properties herein.</skos:scopeNote>
+		<cmns-av:copyright>Copyright (c) 2011-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&cmns-cls;Aspect">
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.1.3, 3.2.1</dct:source>
+		<skos:example>&apos;Being made of wood&apos; as a property of a given &apos;table&apos;; &apos;Belonging to person A&apos; as a property of a given &apos;pet&apos;; &apos;Having been formulated by Einstein&apos; as a property of the equation &apos;E = mc squared&apos;</skos:example>
+		<skos:note>Characteristics are used for describing concepts.</skos:note>
+		<cmns-av:synonym>property</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&cmns-col;hasPart">
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.2.14, 3.2.21</dct:source>
+		<skos:note>hasPart is a concept relation between a comprehensive concept and a partitive concept.</skos:note>
+		<cmns-av:synonym>partitive concept relation</cmns-av:synonym>
+		<cmns-av:synonym>partitive relation</cmns-av:synonym>
+		<cmns-av:synonym>whole-part relation</cmns-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-col;isPartOf">
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.22</dct:source>
+		<skos:example>A partitive relation exists between the concepts &apos;bicycle&apos; and &apos;wheel&apos;, &apos;molecule&apos; and &apos;atom&apos;.</skos:example>
+		<skos:note>isPartOf is a concept relation between a partitive concept and a comprehensive concept.</skos:note>
+		<cmns-av:synonym>part-of relation</cmns-av:synonym>
+		<cmns-av:synonym>part-whole relation</cmns-av:synonym>
+		<cmns-av:synonym>partitive concept relation</cmns-av:synonym>
+		<cmns-av:synonym>partitive relation</cmns-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-dt;precedes">
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-dt;succeeds">
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&cmns-dsg;Name">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&lcc-lr;NaturalLanguage">
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.7</dct:source>
+		<skos:note>A natural language is a language that is or was in active use in a community of people, and the rules of which are mainly deduced from usage.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;AcceptabilityRating">
+		<rdfs:subClassOf rdf:resource="&mvf;TermStatus"/>
+		<rdfs:label>acceptability rating</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.18</dct:source>
+		<skos:definition>rating that allows for designations to be placed in order of preference as a guide to users</skos:definition>
+		<skos:note>The following ratings are common: preferred term, admitted term, deprecated term.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Acronym">
+		<rdfs:subClassOf rdf:resource="&mvf;Abbreviation"/>
+		<rdfs:label>acronym</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.15</dct:source>
+		<skos:definition>abbreviation that is made up of the initial letters of the components of the full form of a term or proper name or from syllables of the full form and that is pronounced syllabically</skos:definition>
+		<skos:example>Examples of acronyms are: laser, ISO, GATT, UNESCO, UNICEF</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;AdmittedTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;RatedTerm"/>
+		<rdfs:label>admitted term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.20</dct:source>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;hasAcceptabilityRating"/>
+				<owl:hasValue rdf:resource="&mvf-trm;admitted"/>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>term that is a synonym for a preferred term, but not rated according to the acceptability rating scale as a preferred term</skos:definition>
+		<skos:example>With regard to the concept &apos;terminology science&apos;, &quot;terminology studies&quot; is an admitted term, whereas &quot;terminology science&quot; is the preferred term, and &quot;terminology&quot; is a deprecated term.</skos:example>
+		<skos:note>There can be more than one admitted term. By analogy, &quot;admitted&quot; can also apply to appellations, proper names, and symbols.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Appellation">
+		<rdfs:subClassOf rdf:resource="&cmns-dsg;Name"/>
+		<rdfs:label>appellation</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.3</dct:source>
+		<skos:definition>term that is applied to a group of objects whose relevant properties are identical</skos:definition>
+		<skos:example>Examples of appellations are: &apos;Nokia 7 Plus®&apos; (mobile phone), &apos;Adobe® Acrobat® X Pro&apos; (software), &apos;Road King®&apos; (motorcycle).</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Blend">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:label>blend</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.13</dct:source>
+		<skos:definition>designation that is formed by clipping and combining two or more words</skos:definition>
+		<skos:example>Examples of blends are: infotainment, cyberspace, quasar</skos:example>
+		<cmns-av:synonym>blended designation</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;BorrowedTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:label>borrowed term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.11</dct:source>
+		<skos:definition>term taken from another language or from another domain or subject</skos:definition>
+		<skos:example>The term &apos;virus&apos; was originally used in biology and later transferred to information. The English term &apos;internet&apos; has been borrowed by many other languages.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ClippedTerm">
+		<rdfs:subClassOf rdf:resource="&mvf;Abbreviation"/>
+		<rdfs:label>clipped term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.17</dct:source>
+		<skos:definition>abbreviation that is made up of a truncated term</skos:definition>
+		<skos:example>vet school (veterinarian school)</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ComplexTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:label>complex term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.9, 3.4.10</dct:source>
+		<skos:definition>term that consists of more than one word or lexical unit</skos:definition>
+		<skos:example>Examples of complex terms are: computer mouse, fault recognition circuit.</skos:example>
+		<cmns-av:synonym>multi-word term</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;CompoundTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:label>compound term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.8</dct:source>
+		<skos:definition>simple term that can be split morphologically into separate components</skos:definition>
+		<skos:example>Examples of compound terms are: steamship, blackbird, afterbirth.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ConceptDiagram">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Diagram"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&mvf-trm;ConceptSystem"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;depicts"/>
+				<owl:someValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>concept diagram</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.29</dct:source>
+		<skos:definition>graphic representation of a concept system</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ConceptField">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:allValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&mvf-trm;Domain">
+							</rdf:Description>
+							<rdf:Description rdf:about="&mvf-trm;Subject">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>concept field</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.10</dct:source>
+		<skos:definition>unstructured set of concepts belonging to the same domain or subject</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ConceptModel">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;ConceptDiagram"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;compliesWith"/>
+				<owl:someValuesFrom rdf:resource="&mvf-trm;FormalLanguage"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>concept model</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.30</dct:source>
+		<dct:source>ISO 24156-1:2014 Graphic notations for concept modelling in terminology work and its relationship with UML - Part 1: Guidelines for using UML notation in terminology work</dct:source>
+		<skos:definition>concept diagram formed by means of a formal language</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ConceptSystem">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
+				<owl:onClass rdf:resource="&mvf-trm;Domain"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>concept system</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.28</dct:source>
+		<skos:definition>set of concepts structured in one or more related domains according to the concept relations among its concepts</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Definition">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Aspect"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
+				<owl:onClass rdf:resource="&mvf;MVFEntry"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>definition</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.3.1</dct:source>
+		<skos:definition>representation of a concept by an expression that describes it and differentiates it from related concepts</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;DelimitingCharacteristic">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;EssentialCharacteristic"/>
+		<rdfs:label>delimiting characteristic</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.5</dct:source>
+		<skos:definition>essential characteristic used for distinguishing a concept from related concepts</skos:definition>
+		<skos:example>The delimiting characteristic &apos;support for the back&apos; may be used for distinguishing the concepts stool and chair.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;DeprecatedTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;RatedTerm"/>
+		<rdfs:label>deprecated term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.21</dct:source>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;hasAcceptabilityRating"/>
+				<owl:hasValue rdf:resource="&mvf-trm;deprecated"/>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>term which is a synonym for a preferred term, but rated according to the acceptability rating scale as undesired</skos:definition>
+		<skos:example>With regard to the concept &apos;terminology science, &apos;terminology&apos; is a deprecated term, whereas &apos;terminology science&apos; is the preferred term, and &apos;terminology studies&apos; is an admitted term.</skos:example>
+		<skos:note>There can be more than one deprecated term. By analogy, &apos;deprecated&apos; can also apply to appellations, proper names and symbols.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Diagram">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;depicts"/>
+				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>diagram</rdfs:label>
+		<skos:definition>two-dimensional geometric, symbolic representation of information that shows the appearance, structure, or workings of something</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Domain">
+		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;Context"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
+				<owl:onClass rdf:resource="&mvf-trm;SpecialLanguage"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>domain</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09,clause 3.1.4</dct:source>
+		<skos:definition>field of special knowledge</skos:definition>
+		<skos:scopeNote>The borderlines and the granularity of a domain are determined from a purpose-related point of view. If a domain is subdivided, the result is again a domain.</skos:scopeNote>
+		<cmns-av:synonym>subject field</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;EssentialCharacteristic">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Aspect"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;characterizes"/>
+				<owl:someValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>essential characteristic</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.3</dct:source>
+		<skos:definition>characteristic of a concept that is indispensable to understand that concept</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ExtensionalDefinition">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Definition"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:onClass rdf:resource="&cmns-cls;Aspect"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&mvf-trm;Object"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>extensional definition</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.1.2, 3.3.3</dct:source>
+		<skos:definition>definition that enumerates the objects to which a concept corresponds under one criterion of subdivision</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;FormalLanguage">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;Language"/>
+		<rdfs:label>formal language</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.10</dct:source>
+		<skos:definition>language whose rules are explicitly established before its use</skos:definition>
+		<skos:example>Web Ontology Language (OWL); the structured English informative language that is specified in the Semantics For Business Vocabulary and Rules (SBVR) Specification</skos:example>
+		<skos:note>A formal language is a collection of expressions, following formal rules of well-formedness. See the Distributed Ontology, Model, and Specification Language (DOL) specification for additional criteria and classification, available at https://www.omg.org/spec/DOL/.</skos:note>
+		<skos:scopeNote>The purpose of formal language is to assure exact communication of information.</skos:scopeNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;GeneralConcept">
+		<rdfs:subClassOf rdf:resource="&mvf;MVFEntry"/>
+		<rdfs:label>general concept</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.9</dct:source>
+		<owl:disjointWith rdf:resource="&mvf-trm;IndividualConcept"/>
+		<skos:definition>concept that corresponds to a potentially unlimited number of objects which form a group by reason of shared properties</skos:definition>
+		<skos:example>Examples of general concepts are &apos;planet&apos;, &apos;tower&apos;, &apos;Nobel Prize in Physics&apos;, &apos;moon&apos;.</skos:example>
+		<skos:note>For a general concept it is essential that a number of corresponding objects greater than 1 can be perceived or conceived of. For example &apos;spaceship&apos; has been a general concept before such a material object existed, at the time when there existed only 1 such object, and later, when there existed several such objects.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;GeneralLanguage">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;NaturalLanguage"/>
+		<rdfs:label>general language</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.8</dct:source>
+		<skos:definition>natural language characterized by the use of linguistic means of expression independent of any specific domain</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;GenericExtensionalDefinition">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;ExtensionalDefinition"/>
+		<rdfs:label>generic extensional definition</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.3.4</dct:source>
+		<skos:definition>extensional definition that enumerates all the specific concepts of a generic concept under one criterion of subdivision on the same hierarchical level</skos:definition>
+		<skos:example>noble gas - helium, neon, argon, crypton, xenon or radon</skos:example>
+		<skos:note>A generic extensional definition is based on a generic relation, and the enumeration ends with the operator &apos;or&apos;; [i.e., a disjoint union of the subordinate concepts].</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;IndividualConcept">
+		<rdfs:subClassOf rdf:resource="&mvf;MVFEntry"/>
+		<rdfs:label>individual concept</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.8</dct:source>
+		<skos:definition>concept that corresponds to a unique object</skos:definition>
+		<skos:example>Examples of individual concepts are &apos;Saturn&apos;, &apos;Eiffel Tower&apos;, &apos;Moon&apos;, &apos;serial number FRHR603928&apos;, &apos;2016 Nobel Prize in Physics&apos;.</skos:example>
+		<skos:note>Individual concepts are represented by proper names. In a UML model or similar context, an individual concept corresponds to a singleton class.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Initialism">
+		<rdfs:subClassOf rdf:resource="&mvf;Abbreviation"/>
+		<rdfs:label>initialism</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.16</dct:source>
+		<skos:definition>abbreviation that is made up of the initial letters of the components of the full form of a term or proper name or from syllables of the full form and that is pronounced letter by letter</skos:definition>
+		<skos:example>Examples of initialisms are: UN, ASTM, IEC, US, EU, DNA</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;IntensionalDefinition">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Definition"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;hasDelimitingCharacteristic"/>
+				<owl:allValuesFrom rdf:resource="&mvf-trm;DelimitingCharacteristic"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:someValuesFrom rdf:resource="&cmns-cls;Aspect"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>intensional definition</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.2.6, 3.3.2</dct:source>
+		<skos:definition>definition that conveys the intension of a concept by stating the immediate generic concept and its characteristics, including any delimiting characteristic(s)</skos:definition>
+		<skos:example>mechanical mouse: computer mouse in which movements are detected by rollers and a ball</skos:example>
+		<skos:example>optical mouse: computer mouse in which movements are detected by light sensors</skos:example>
+		<skos:note>Intensional definitions are preferable to other types of definitions because they clearly reveal the characteristics of a concept within a concept system: they should be used whenever possible.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;NewTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:label>new term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.12</dct:source>
+		<skos:definition>term that is specifically coined for a given general concept</skos:definition>
+		<skos:example>smartwatch</skos:example>
+		<skos:note>A new term may supersede an older term or may designate a new concept.</skos:note>
+		<cmns-av:synonym>neonym</cmns-av:synonym>
+		<cmns-av:synonym>neoterm</cmns-av:synonym>
+		<cmns-av:synonym>terminological neologism</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;NonEssentialCharacteristic">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Aspect"/>
+		<rdfs:label>non-essential characteristic</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09,claue 3.2.4</dct:source>
+		<skos:definition>characteristic of a concept that is not indispensable to understand that concept</skos:definition>
+		<skos:example>For defining the concept &apos;traffic light&apos;, the colour &apos;red&apos;, &apos;green&apos; or &apos;amber&apos; is an essential characteristic, while for defining the concept &apos;computer mouse&apos;, the colour (e.g. &apos;ivory&apos;, &apos;blue&apos; or &apos;red&apos;) is a non-essential characteristic.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Object">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:onClass rdf:resource="&cmns-cls;Aspect"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>object</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.1</dct:source>
+		<skos:definition>anything perceivable or conceivable</skos:definition>
+		<skos:note>Objects may be material (e.g. an engine, a sheet of paper, a diamond), immaterial (e.g. conversion ratio, a project plan) or imagined (e.g. a unicorn). Objects correspond to individuals in an ontology, instances in many programming languages.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ObsoleteTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;RatedTerm"/>
+		<rdfs:label>obsolete term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.22</dct:source>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;hasAcceptabilityRating"/>
+				<owl:hasValue rdf:resource="&mvf-trm;obsolete"/>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>term which is no longer in common use</skos:definition>
+		<skos:note>By analogy, &apos;obsolete&apos; can also apply to appellations, proper names and symbols.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;PartitiveExtensionalDefinition">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;ExtensionalDefinition"/>
+		<rdfs:label>partitive extensional definition</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.3.5</dct:source>
+		<skos:definition>extensional definition that enumerates all the partitive concepts of a comprehensive concept on the same hierarchical level</skos:definition>
+		<skos:example>Family 18 in the Periodic Table: helium, neon, argon, crypton, xenon and radon.</skos:example>
+		<skos:note>A partitive extensional definition is based on a partitive relation, and the enumeration ends with the operator &apos;and&apos;; [i.e., a union that is disjoint and covering of all parts of the whole].</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;PreferredTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;RatedTerm"/>
+		<rdfs:label>preferred term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.19</dct:source>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;hasAcceptabilityRating"/>
+				<owl:hasValue rdf:resource="&mvf-trm;preferred"/>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>term rated according to the acceptability rating as the primary term for a given concept</skos:definition>
+		<skos:example>With regard to the concept &apos;terminology science&apos; the preferred term is &apos;terminology science&apos;, whereas &apos;terminology studies&apos; is an admitted term, and &apos;terminology&apos; is a deprecated term.</skos:example>
+		<skos:note>By analogy, &apos;preferred&apos; can also apply to appellations, proper names and symbols.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ProperName">
+		<rdfs:subClassOf rdf:resource="&cmns-dsg;Name"/>
+		<rdfs:label>proper name</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.4</dct:source>
+		<skos:definition>designation that represents an individual concept</skos:definition>
+		<skos:example>&apos;International Organization for Standardization&apos;, &apos;IBM®&apos;, &apos;British Isles&apos;, &apos;United Nations&apos;</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;RatedTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf-trm;hasAcceptabilityRating"/>
+				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>rated term</rdfs:label>
+		<skos:definition>term rated according to an acceptability rating scale that allows for designations to be placed in order of preference as a guide to users</skos:definition>
+		<skos:note>The following ratings are common: preferred term, admitted term, deprecated term.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;ShortForm">
+		<rdfs:subClassOf rdf:resource="&mvf;Abbreviation"/>
+		<rdfs:label>short form</rdfs:label>
+		<skos:definition>abbreviatiated form for a very long complex term or appellation, using fewer words to designate the same concept</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;SimpleTerm">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<rdfs:label>simple term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.4.6, 3.4.7</dct:source>
+		<skos:definition>term that consists of a single word or lexical unit</skos:definition>
+		<skos:example>Examples of simple terms are: sound, light, barrier, accessory, accessorize, virus, viral.</skos:example>
+		<cmns-av:synonym>single word term</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;SpecialLanguage">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;NaturalLanguage"/>
+		<rdfs:subClassOf rdf:resource="&mvf-trm;ConceptSystem"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&mvf-trm;Domain">
+							</rdf:Description>
+							<rdf:Description rdf:about="&mvf-trm;Subject">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>special language</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.9</dct:source>
+		<skos:definition>natural language used in communication between experts in a domain and characterized by the use of specific linguistic means of expression</skos:definition>
+		<skos:scopeNote>The specific linguistic means of expression always include domain-specific terminology and phraseology and also can cover stylistic or syntactic features.</skos:scopeNote>
+		<cmns-av:synonym>LSP</cmns-av:synonym>
+		<cmns-av:synonym>language for special purposes</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Subject">
+		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;Context"/>
+		<rdfs:label>subject</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.1.5</dct:source>
+		<skos:definition>area of interest or expertise</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Symbol">
+		<rdfs:subClassOf rdf:resource="&mvf;VocabularyEntry"/>
+		<rdfs:label>symbol</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.5</dct:source>
+		<skos:definition>designation that represents a concept by non-linguistic means</skos:definition>
+		<skos:note>From section 7.5, ISO 704, symbols are an important aid to international communication because their visual representation of concepts functions independently of any given language. They can communicate information directly under difficult circumstances (e.g., traffic signs).
+
+Iconic symbols should bear some visual resemblance to the concept they represent. Generally their meaning should be directly apparent without explanation. In some cases, however, the visual resemblance of the symbol is less pronounced or completely lost. Its meaning may be no longer directly recognizable and may be supported only by general agreement.
+
+Terms using the letters of the alphabet as iconic symbols to communicate the shape of the letter itself rather than its sound shall not be considered a symbol.
+
+Characters that replace words or parts of words, such as mathematical symbols or currency symbols, are considered symbols.</skos:note>
+		<skos:note>There are several types of symbols such as graphical symbols (ISO 3864, all parts) and letter symbols (ISO 80000, all parts).</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf-trm;Term">
+		<rdfs:subClassOf rdf:resource="&mvf;VocabularyEntry"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:onClass rdf:resource="&mvf-trm;GeneralConcept"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>term</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.2</dct:source>
+		<skos:definition>verbal designation of a general concept in a specific subject field</skos:definition>
+		<skos:note>A term may contain symbols and can have variants, e.g. different forms of spelling.</skos:note>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&mvf-trm;admitted">
+		<rdf:type rdf:resource="&mvf-trm;AcceptabilityRating"/>
+		<rdfs:label>admitted</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.20</dct:source>
+		<skos:definition>term rated as a synonym for a preferred term</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;associates">
+		<rdfs:label>associates</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.23</dct:source>
+		<skos:definition>relates two concepts having a non-hierarchical, thematic connection by virtue of experience</skos:definition>
+		<skos:example>An associative relation exists between the concepts education and teaching, baking and oven.</skos:example>
+		<skos:note>Associative relations are evidence that the terms are semantically or conceptually associated to the degree that it is important to make the connection explicit, on the grounds that it may suggest additional terms for use in indexing or retrieval.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;causes">
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>causes</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.27</dct:source>
+		<skos:definition>makes something happen or gives rise to some action, condition, or phenomenon as a consequence</skos:definition>
+		<skos:example>A causal relation exists between the concepts action and reaction, nuclear explosion and fall-out.</skos:example>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;depicts">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;describes"/>
+		<rdfs:label>depicts</rdfs:label>
+		<skos:definition>illustrates via an image</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:NamedIndividual rdf:about="&mvf-trm;deprecated">
+		<rdf:type rdf:resource="&mvf-trm;AcceptabilityRating"/>
+		<rdfs:label>deprecated</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.21</dct:source>
+		<skos:definition>term rated as undesired</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;extends">
+		<rdfs:label>extends</rdfs:label>
+		<skos:definition>supplements or augments</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasAcceptabilityRating">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;isDescribedBy"/>
+		<rdfs:label>has acceptability rating</rdfs:label>
+		<rdfs:range rdf:resource="&mvf-trm;AcceptabilityRating"/>
+		<skos:definition>relates to a rating indicating its status with respect to the vocabulary</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasAntonym">
+		<rdf:type rdf:resource="&owl;SymmetricProperty"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>has antonym</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.25</dct:source>
+		<skos:definition>relates a designation to another representing a coordinate concept viewed as its logical complement or opposite</skos:definition>
+		<skos:example>Antonymy exists between the terms encoding and decoding, positive and negative.</skos:example>
+		<skos:note>Designations in the relation of antonymy are called &apos;antonyms&apos;.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasDelimitingCharacteristic">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isCharacterizedBy"/>
+		<rdfs:label>has delimiting characteristic</rdfs:label>
+		<skos:definition>indicates a defining feature of</skos:definition>
+		<skos:note>A delimiting characteristic is a necessary condition for class membership.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasExtension">
+		<rdfs:label>has extension</rdfs:label>
+		<owl:inverseOf rdf:resource="&mvf-trm;extends"/>
+		<skos:definition>specifies something that supplements this entity</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasHomonym">
+		<rdf:type rdf:resource="&owl;SymmetricProperty"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>has homonym</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.29</dct:source>
+		<skos:definition>relates a designation to antoher that has common spelling and pronunciation but represents a different concept, i.e., has different meaning and origin</skos:definition>
+		<skos:example>The term &apos;bark&apos; represents three unrelated concepts: 1) the concept &apos;bark&apos; corresponding to certain vocal repertoires of dogs; 2) the concept &apos;bark&apos; corresponding to the outside coverings of stems of woody plants; 3) the concept &apos;bark&apos; corresponding to some sailing vessels.</skos:example>
+		<skos:note>Designations in the relation of homonymy are called &apos;homonyms&apos;.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasIntension">
+		<rdfs:label>has intension</rdfs:label>
+		<skos:definition>specifies something that explains the entity in terms of meaning</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasMononym">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;isSignifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>has mononym</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.26</dct:source>
+		<skos:definition>has as its singular (only) designation</skos:definition>
+		<skos:note>Mononymic relations between a concept and a term (designation, vocabulary entry) in a given language are those in which a given concept has only one designation. Designations in the relation of mononymy are called &apos;mononyms&apos;.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasSuperordinateConcept">
+		<rdf:type rdf:resource="&owl;TransitiveProperty"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf;hasNarrowerEntry"/>
+		<rdfs:label>has superordinate concept</rdfs:label>
+		<skos:definition>indicates a broader, ancestral concept</skos:definition>
+		<cmns-av:synonym>is narrower transitive than</cmns-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasSynonym">
+		<rdf:type rdf:resource="&owl;SymmetricProperty"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>has synonym</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.23</dct:source>
+		<skos:definition>relates a vocabulary entry (designation) to another in a given natural language representing the same concept</skos:definition>
+		<skos:example>Synonymy exists between &apos;deuterium&apos; and &apos;heavy hydrogen&apos;, between &apos;United Nations&apos; and &apos;UN&apos;.</skos:example>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;isCausedBy">
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>is caused by</rdfs:label>
+		<owl:inverseOf rdf:resource="&mvf-trm;causes"/>
+		<skos:definition>is a consequence of</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;isCoordinateWith">
+		<rdfs:label>is coordinate with</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clauses 3.2.17, 3.2.18</dct:source>
+		<skos:definition>indicates a concept that results from the same criterion of subdivision as another subordinate concept with the same immediate superordinate [parent] concept</skos:definition>
+		<skos:example>Applying &apos;layer of clothing&apos; as a criterion of subdivision to &apos;clothing&apos; yields &apos;outerwear&apos; and &apos;underwear&apos; as specific concepts. These concepts are coordinate concepts in relation to their generic concept &apos;clothing&apos;.</skos:example>
+		<skos:example>For the concept system &apos;computer mouse&apos; according to ISO 704:2009, 5.5.2.2.1, Example 4 the type of characteristic &apos;computer connection&apos; is used as a criterion of subdivision to divide the generic concept &apos;computer mouse into specific concepts such as &apos;cord mouse&apos; and &apos;cordless mouse&apos;.</skos:example>
+		<skos:example>For the concept system &apos;computer&apos; the type of characteristic &apos;function&apos; is used as a criterion of subdivision to divide the comprehensive concept &apos;computer&apos; into partitive concepts such as &apos;main board&apos;, &apos;display adapter&apos;, &apos;power supply&apos;, &apos;storage device&apos; and &apos;input device&apos;.</skos:example>
+		<skos:example>For the concept system &apos;safety sign&apos; according to ISO 3864-1:2011, 5, Table 1, the type of characteristic &apos;geometric shape&apos; is used as a criterion of subdivision to divide the generic concept &apos;safety sign&apos; into specific concepts such as &apos;mandatory action sign&apos; and &apos;safe condition sign&apos;.</skos:example>
+		<skos:note>A criterion of subdivision is a type of characteristic [aspect] according to which a superordinate concept is divided into subordinate concepts.</skos:note>
+		<cmns-av:synonym>is a sibling of</cmns-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;isDepictionOf">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;isDescribedBy"/>
+		<rdfs:label>is depiction of</rdfs:label>
+		<owl:inverseOf rdf:resource="&mvf-trm;depicts"/>
+		<skos:definition>is an illustration of</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;isManagedBy">
+		<rdfs:label>is managed by</rdfs:label>
+		<skos:definition>indicates an entity that administers, oversees, and potentially maintains or operates it</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;isMonosemeFor">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;denotes"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>is monoseme for</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.27</dct:source>
+		<skos:definition>is the sole designation for</skos:definition>
+		<skos:note>Designations in the relation of monosemy are called &apos;monosemes&apos;.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;isPolysemeFor">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;denotes"/>
+		<rdfs:subPropertyOf rdf:resource="&mvf-trm;associates"/>
+		<rdfs:label>is polyseme for</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.28</dct:source>
+		<skos:definition>relates a designation to more than one concept for which it has a different sense (meaning)</skos:definition>
+		<skos:example>The term &apos;bridge&apos; represents three concepts that are related in form and/or function: 1) the concept &apos;bridge&apos; corresponding to structures to carry traffic over a gap; 2) the concept &apos;bridge&apos; corresponding to certain wooden parts of string instruments; 3) the concept &apos;bridge&apos; corresponding to dental plates.</skos:example>
+		<skos:note>Designations in the relation of polysemy are called &apos;polysemes&apos;.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;manages">
+		<rdfs:label>manages</rdfs:label>
+		<owl:inverseOf rdf:resource="&mvf-trm;isManagedBy"/>
+		<skos:definition>administers, oversees and possibly maintains and/or operates</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:NamedIndividual rdf:about="&mvf-trm;obsolete">
+		<rdf:type rdf:resource="&mvf-trm;AcceptabilityRating"/>
+		<rdfs:label>obsolete</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.22</dct:source>
+		<skos:definition>term that is no longer in common use</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&mvf-trm;preferred">
+		<rdf:type rdf:resource="&mvf-trm;AcceptabilityRating"/>
+		<rdfs:label>preferred</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.19</dct:source>
+		<skos:definition>term rated as the primary term for a given concept</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&mvf;Abbreviation">
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
+		<cmns-av:synonym>abbreviated form</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;MVFEntry">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isCharacterizedBy"/>
+				<owl:onClass rdf:resource="&cmns-cls;Aspect"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:onClass rdf:resource="&mvf-trm;Definition"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&mvf-trm;GeneralConcept">
+					</rdf:Description>
+					<rdf:Description rdf:about="&mvf-trm;IndividualConcept">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</owl:equivalentClass>
+		<cmns-av:synonym>concept</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;VocabularyEntry">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:onClass rdf:resource="&mvf-trm;Definition"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:onClass rdf:resource="&mvf;MVFEntry"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasBroaderEntry">
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.15</dct:source>
+		<skos:example>&apos;furniture&apos; is a superordinate concept to &apos;table&apos; and &apos;chair&apos; in a generic relation; &apos;tree&apos; is a superordinate concept to &apos;root&apos; or &apos;branch&apos; in a partitive relation.</skos:example>
+		<skos:note>hasBroaderEntry relates a generic or comprehensive concept to one that is more specific.</skos:note>
+		<cmns-av:synonym>is a broader concept than</cmns-av:synonym>
+		<cmns-av:synonym>is a superordinate concept of</cmns-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasNarrowerEntry">
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.16</dct:source>
+		<skos:note>hasNarrowerEntry relates a specific or partitive concept to one that is more general.</skos:note>
+		<cmns-av:synonym>is a narrower concept than</cmns-av:synonym>
+		<cmns-av:synonym>is a subordinate concept of</cmns-av:synonym>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/MVF/MVFtoSKOSMapping.rdf
+++ b/MVF/MVFtoSKOSMapping.rdf
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
+	<!ENTITY mvf-skos "https://www.omg.org/spec/MVF/MVFtoSKOSMapping/">
+	<!ENTITY mvf-trm "https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY skos-xl "http://www.w3.org/2008/05/skos-xl#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://www.omg.org/spec/MVF/MVFtoSKOSMapping/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
+	xmlns:mvf-skos="https://www.omg.org/spec/MVF/MVFtoSKOSMapping/"
+	xmlns:mvf-trm="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:skos-xl="http://www.w3.org/2008/05/skos-xl#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://www.omg.org/spec/MVF/MVFtoSKOSMapping/">
+		<rdfs:label>Multiple Vocabulary Facility (MVF) MVF to SKOS Ontology</rdfs:label>
+		<dct:abstract>This ontology provides a mapping from the concepts defined in MVF to the Simple Knowledge Organization System (SKOS) W3C Recommendation</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="http://www.w3.org/2008/05/skos-xl"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/20230501/MVFtoSKOSMapping/"/>
+		<cmns-av:copyright>Copyright (c) 2019-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&skos;Collection">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&skos-xl;Label">
+		<rdfs:subClassOf rdf:resource="&cmns-dsg;Name"/>
+	</owl:Class>
+	
+	<owl:DatatypeProperty rdf:about="&skos-xl;literalForm">
+		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
+	</owl:DatatypeProperty>
+	
+	<owl:Class rdf:about="&mvf-trm;ConceptSystem">
+		<owl:equivalentClass rdf:resource="&skos;ConceptScheme"/>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&mvf-trm;hasSuperordinateConcept">
+		<owl:equivalentProperty rdf:resource="&skos;broaderTransitive"/>
+	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&mvf;MVFEntry">
+		<owl:equivalentClass rdf:resource="&skos;Concept"/>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasBroaderEntry">
+		<owl:equivalentProperty rdf:resource="&skos;broader"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasNarrowerEntry">
+		<owl:equivalentProperty rdf:resource="&skos;narrower"/>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/MVF/MetadataMVF.rdf
+++ b/MVF/MetadataMVF.rdf
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
+	<!ENTITY mvf-mod "https://www.omg.org/spec/MVF/MetadataMVF/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://www.omg.org/spec/MVF/MetadataMVF/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
+	xmlns:mvf-mod="https://www.omg.org/spec/MVF/MetadataMVF/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://www.omg.org/spec/MVF/MetadataMVF/">
+		<rdfs:label>Metadata for the IDMP Multiple Vocabulary Facility</rdfs:label>
+		<dct:abstract>The Multiple Vocabulary Facility (MVF) Module includes ontologies that are defined in the Object Management Group (OMG) Multiple Vocabulary Facility (MVF) standard, which supports the definition of controlled vocabularies needed for IDMP. It is included in the IDMP GitHub repository for convenience purposes, and dereferences from the OMG web site. It was approved for publication as a formal OMG standard in March 2023.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2023-07-21T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-07-21T18:00:00</dct:modified>
+		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/MetadataMVF/spec.pistoiaalliance.org/idmp/ontology/MVF/20230701/MetadataMVF/"/>
+		<cmns-av:copyright>Copyright (c) 2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023 Pistoia Alliance, Inc.</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&mvf-mod;MVFModule">
+		<rdf:type rdf:resource="&idmp-chg;Module"/>
+		<rdfs:label>Multiple Vocabulary Facility Module</rdfs:label>
+		<dct:abstract>The Multiple Vocabulary Facility (MVF) Module includes ontologies that are defined in the Object Management Group (OMG) Multiple Vocabulary Facility (MVF) standard, which supports the definition of controlled vocabularies needed for IDMP. It is included in the IDMP GitHub repository for convenience purposes, and dereferences from the OMG web site. It was approved for publication as a formal OMG standard in March 2023.</dct:abstract>
+		<dct:hasPart rdf:resource="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"/>
+		<dct:hasPart rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<dct:hasPart rdf:resource="https://www.omg.org/spec/MVF/MVFtoSKOSMapping/"/>
+		<dct:hasPart rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<cmns-av:copyright>Copyright (c) 2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023 Pistoia Alliance, Inc.</cmns-av:copyright>
+	</owl:NamedIndividual>
+
+</rdf:RDF>

--- a/MVF/MetadataMVF.rdf
+++ b/MVF/MetadataMVF.rdf
@@ -29,7 +29,11 @@
 		<dct:modified rdf:datatype="&xsd;dateTime">2023-07-21T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/MetadataMVF/spec.pistoiaalliance.org/idmp/ontology/MVF/20230701/MetadataMVF/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MVFtoSKOSMapping/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/MVF/20230701/MetadataMVF/"/>
 		<cmns-av:copyright>Copyright (c) 2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>

--- a/MVF/MultipleVocabularyFacility.rdf
+++ b/MVF/MultipleVocabularyFacility.rdf
@@ -1,0 +1,421 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
+	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
+	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
+	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
+	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY mvf "https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
+	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
+	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
+	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
+	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
+	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:mvf="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/">
+		<rdfs:label>Multiple Vocabulary Facility (MVF) Ontology</rdfs:label>
+		<dct:abstract>The MVF ontology consists of three components:
+- a core ontology corresponding to the MVF metamodel (this ontology)
+- an extension representing the subset of the ISO 1087 reference vocabulary used in other ISO standards for vocabulary representation, 
+- an extension that incorporates additional vocabulary from ISO 1087 for terminology science. 
+MVF also reuses several ontologies from the OMG Commons library for specific patterns, including designations, collections, and classifiers.</dct:abstract>
+		<dct:contributor>Davide Sottara, Mayo Clinic</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Evan Wallace, U.S. National Institute of Standards and Technology (NIST)</dct:contributor>
+		<dct:contributor>Pete Rivett, agnos.ai U.K. Ltd</dct:contributor>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/MVF/20230501/MultipleVocabularyFacility/"/>
+		<cmns-av:copyright>Copyright (c) 2019-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Mayo Clinic</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 QuoteWell Insurance Services, LLC</cmns-av:copyright>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&mvf;Abbreviation">
+		<rdfs:subClassOf rdf:resource="&mvf;VocabularyEntry"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;isAbbreviation"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">true</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>abbreviation</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.4.14</dct:source>
+		<skos:definition>vocabulary entry formed by omitting parts from its full form and that represents the same concept</skos:definition>
+		<skos:note>Abbreviations can be created by removing individual words, or can be acronyms, initialisms, or clipped terms.</skos:note>
+		<skos:note>An abbreviation could link directly to an MVF entry. If it is an abbreviation for a vocabulary entry then it must be linked to the MVF entry for that same vocabulary entry.</skos:note>
+		<skos:scopeNote>Good writing practice dictates that both the full form of a term and the abbreviated form be indicated the first time a potentially unfamiliar abbreviated form is used in a text. In general, an abbreviated form should be easy to pronounce.</skos:scopeNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;Community">
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;uses"/>
+				<owl:onClass rdf:resource="&mvf;Vocabulary"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>community</rdfs:label>
+		<skos:definition>group of individuals that share a natural language and have a shared set of terms used to express concepts in their domain of interest</skos:definition>
+		<skos:note>We refer to a set of terms that is distinguished from general use of the natural language as a vernacular. The community may include people that share a profession, are members of the same enterprise or organization or are collaborating on a particular technology.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;MVFDictionary">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
+				<owl:onClass rdf:resource="&mvf;MVFEntry"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
+				<owl:onClass rdf:resource="&mvf;Vocabulary"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>MVF dictionary</rdfs:label>
+		<skos:definition>collection (by reference, or possibly inclusion) of vocabularies that share a set of MVFEntries</skos:definition>
+		<skos:note>Each vocabulary is a container for vocabulary entries that each represent the association of a term in that vocabulary with one of the MVFEntries identified in that dictionary. A modeling environment may include multiple dictionaries, but they must address mutually exclusive concepts. Typically, one dictionary will address concepts of the modeling language metamodel, and another dictionary will address concepts of user-defined modeling elements.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;MVFElement">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasURI"/>
+				<owl:onDataRange rdf:resource="&xsd;anyURI"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasDescription"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasTextualName"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>MVF element</rdfs:label>
+		<skos:definition>abstract entity in a multiple vocabulary facility model or ontology</skos:definition>
+		<cmns-av:explanatoryNote>An MVF element corresponds roughly to an element in category theory, namely one that can be an object of any category, and to &apos;entity&apos; in many top level ontologies.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>Use the Dublin Core &apos;references&apos; annotation for any relevant citations or other references, corresponding to the &apos;reference&apos; property in the MVF metamodel.</cmns-av:usageNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;MVFEntry">
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasBroaderEntry"/>
+				<owl:allValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasContextualEntry"/>
+				<owl:allValuesFrom rdf:resource="&mvf;MVFEntry"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
+				<owl:onClass rdf:resource="&mvf;VocabularyEntry"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasSemanticReference"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;anyURI"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;isIncludedIn"/>
+				<owl:onClass rdf:resource="&mvf;MVFDictionary"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>MVF entry</rdfs:label>
+		<dct:source>ISO 1087 Terminology work and terminology science - Vocabulary, Second edition, 2019-09, clause 3.2.7</dct:source>
+		<skos:definition>unit of knowledge created by a unique combination of characteristics</skos:definition>
+		<skos:note>An MVF entry is linked to one or more model elements that represent that concept in the modeling environment.</skos:note>
+		<skos:note>Concepts [MVF entries] are not necessarily bound to particular natural languages. They are, however, influenced by the social or cultural background which often leads to different categorizations.</skos:note>
+		<skos:note>From an ISO 1087 perspective, this is the concept &apos;concept&apos; as used and designated by the term &apos;concept&apos; in terminology work. It is a very different concept from that designated by other domains such as industrial automation or marketing.</skos:note>
+		<skos:note>Note that instances of a class will all reference the same class name and will all have attributes and associations with the same names. It is possible that not every concept is mapped to an entry in every vocabulary, or that not all of the terms and definitions are associated with model elements in the active modeling environment.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;TermStatus">
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:label>term status</rdfs:label>
+		<skos:definition>classifier for the standing of a term within its vocabulary</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;Vocabulary">
+		<rdfs:subClassOf rdf:resource="&cmns-col;StructuredCollection"/>
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;isUsedBy"/>
+				<owl:onClass rdf:resource="&mvf;Community"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;imports"/>
+				<owl:onClass rdf:resource="&mvf;Vocabulary"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasVocabularyEntry"/>
+				<owl:onClass rdf:resource="&mvf;VocabularyEntry"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasLanguage"/>
+				<owl:onClass rdf:resource="&lcc-lr;Language"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>vocabulary</rdfs:label>
+		<skos:definition>set of representations of concepts (terms and definitions) for the language of a particular speech community that is expressed in a specified natural language</skos:definition>
+		<skos:editorialNote>This representation does not address the ordering of imports, which may require an intervening class that has an attribute that is an ordinal number representing the ordering.</skos:editorialNote>
+		<skos:note>A speech community may create a vocabulary by specializing an existing vocabulary and overriding selected terms, adding terms for new concepts and incorporating the remaining terms and definitions of the existing vocabulary. This mechanism may be employed to introduce synonyms as the primary terms of the specializing community. Both vocabularies should be in the same natural language so that definitions remain meaningful.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;VocabularyEntry">
+		<rdfs:subClassOf rdf:resource="&cmns-dsg;Designation"/>
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
+				<owl:cardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:cardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;hasStatus"/>
+				<owl:onClass rdf:resource="&mvf;TermStatus"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;isAbbreviation"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&mvf;isPreferred"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;boolean"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:onClass rdf:resource="&mvf;MVFEntry"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;isIncludedIn"/>
+				<owl:onClass rdf:resource="&mvf;Vocabulary"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>vocabulary entry</rdfs:label>
+		<skos:definition>element of a vocabulary (designation) that denotes exactly one concept (MVF entry) in the context of that vocabulary</skos:definition>
+		<skos:note>The definition and term(s) are expressed in the natural language associated with that vocabulary and the associated user community.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&mvf;Workspace">
+		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:subClassOf rdf:resource="&mvf;MVFElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&mvf;MVFDictionary"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
+				<owl:onClass rdf:resource="&mvf;Vocabulary"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>workspace</rdfs:label>
+		<skos:definition>a set of consistent MVF dictionaries and vocabularies which can be activated in a modeling environment</skos:definition>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&mvf;abbreviates">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;denotes"/>
+		<rdfs:label>abbreviates</rdfs:label>
+		<rdfs:domain rdf:resource="&mvf;Abbreviation"/>
+		<owl:inverseOf rdf:resource="&mvf;hasAbbreviation"/>
+		<skos:definition>is a shortened designation for a term that is used synonymously with that term in the context of a given vocabulary or dictionary</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasAbbreviation">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;isSignifiedBy"/>
+		<rdfs:label>has abbreviation</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;Abbreviation"/>
+		<owl:inverseOf rdf:resource="&mvf;abbreviates"/>
+		<skos:definition>has a shortened designation used synonymously in the context of the given vocabulary or dictionary</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasBroaderEntry">
+		<rdfs:label>has broader entry</rdfs:label>
+		<skos:definition>has a more general MVF entry than the subject</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasContextualEntry">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
+		<rdfs:label>has contextual entry</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;MVFEntry"/>
+		<skos:definition>scopes in the context of</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasCurrentMVFEntry">
+		<rdfs:subPropertyOf rdf:resource="&mvf;hasMVFEntry"/>
+		<rdfs:label>has current MVF entry</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;MVFEntry"/>
+		<skos:definition>indicates the applicable MVF entry from the active MVF workspace</skos:definition>
+		<skos:note>This property will be implicitly updated when the current workspace changes.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasLanguage">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;uses"/>
+		<rdfs:label>has language</rdfs:label>
+		<rdfs:range rdf:resource="&lcc-lr;Language"/>
+		<skos:definition>has a natural language in which a vocabulary is expressed</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasMVFEntry">
+		<rdfs:label>has MVF entry</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;MVFEntry"/>
+		<skos:altLabel>has multiple vocabulary facility entry</skos:altLabel>
+		<skos:definition>links a model element to the corresponding MVF entry (concept), providing a name and definition for that model element</skos:definition>
+		<skos:note>There could be many of these in different dictionaries.</skos:note>
+		<cmns-av:explanatoryNote>hasMVFEntry is a property used to relate an element in any model to a corresponding MVF entry. It corresponds to the property ElementEntry in the metamodel. That property has a UML Element in its domain, which cannot be modeled in the ontology.</cmns-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasNarrowerEntry">
+		<rdfs:label>has narrower entry</rdfs:label>
+		<owl:inverseOf rdf:resource="&mvf;hasBroaderEntry"/>
+		<skos:definition>has a more specialized MVF entry than the subject</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&mvf;hasSemanticReference">
+		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
+		<rdfs:label>has semantic reference</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>has a relevant reference that provides meaning but is not explicitly part of the vocabulary (i.e., document, web site, or other resource)</skos:definition>
+		<skos:note>This property is string valued as the reference need not be dereferenceable at a URL.</skos:note>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasStatus">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;classifies"/>
+		<rdfs:label>has status</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;TermStatus"/>
+		<skos:definition>associates a rating with respect to readiness or acceptability for usage with a vocabulary or MVF entry</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&mvf;hasTextualName">
+		<rdfs:subPropertyOf rdf:resource="&cmns-txt;hasTextValue"/>
+		<rdfs:label>has textual name</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>indicates a text version of something that an MVF element is known by</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&mvf;hasURI">
+		<rdfs:label>has URI</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;anyURI"/>
+		<skos:definition>links something to a unique sequence of characters that identifies a logical or physical resource on a network</skos:definition>
+		<cmns-av:synonym>has uniform resource identifier</cmns-av:synonym>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;hasVocabularyEntry">
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasMember"/>
+		<rdfs:label>has vocabulary entry</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;VocabularyEntry"/>
+		<skos:definition>has a designation (term) in this vocabulary</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;imports">
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;hasConstituent"/>
+		<rdfs:label>imports</rdfs:label>
+		<skos:definition>contains as an intrinsic part</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&mvf;isAbbreviation">
+		<rdfs:label>is abbreviation</rdfs:label>
+		<rdfs:domain rdf:resource="&mvf;VocabularyEntry"/>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition>whether the term for this vocabulary entry is an shortened form of another</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&mvf;isInVocabulary">
+		<rdfs:subPropertyOf rdf:resource="&cmns-col;isMemberOf"/>
+		<rdfs:label>is in vocabulary</rdfs:label>
+		<rdfs:range rdf:resource="&mvf;Vocabulary"/>
+		<owl:inverseOf rdf:resource="&mvf;hasVocabularyEntry"/>
+		<skos:definition>has containing vocabulary</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&mvf;isPreferred">
+		<rdfs:label>is preferred</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;boolean"/>
+		<skos:definition>is the best term to use in the context of the vocabulary for some concept</skos:definition>
+		<skos:note>The preferred flag is used to select a term (vocabulary entry) if there are multiple vocabulary entries (i.e., synonyms) available to map to a given model element in the current context.</skos:note>
+	</owl:DatatypeProperty>
+
+</rdf:RDF>

--- a/MVF/catalog-v001.xml
+++ b/MVF/catalog-v001.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/" uri="./MultipleVocabularyFacility.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/MVF/MVFtoSKOSMapping/" uri="./MVFtoSKOSMapping.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/" uri="./ISO1087-VocabularyForTermsAndDefinitions.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/" uri="./ISO1087-TerminologyScience.rdf"/>
+</catalog>

--- a/MetadataIDMP.rdf
+++ b/MetadataIDMP.rdf
@@ -9,6 +9,7 @@
 	<!ENTITY idmp-meta-mod "https://spec.pistoiaalliance.org/idmp/ontology/META/MetadataMETA/">
 	<!ENTITY idmp-spec "https://spec.pistoiaalliance.org/idmp/ontology/MetadataIDMP/">
 	<!ENTITY lcc-mod "https://www.omg.org/spec/LCC/MetadataLCC/">
+	<!ENTITY mvf-mod "https://www.omg.org/spec/MVF/MetadataMVF/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -25,6 +26,7 @@
 	xmlns:idmp-meta-mod="https://spec.pistoiaalliance.org/idmp/ontology/META/MetadataMETA/"
 	xmlns:idmp-spec="https://spec.pistoiaalliance.org/idmp/ontology/MetadataIDMP/"
 	xmlns:lcc-mod="https://www.omg.org/spec/LCC/MetadataLCC/"
+	xmlns:mvf-mod="https://www.omg.org/spec/MVF/MetadataMVF/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -36,7 +38,7 @@
 		<dct:abstract>The IDMP metadata specification consists of all metadata describing the various modules and ontologies that make up the IDMP-O ontology and supports the data management and governance program for the Identification of Medicinal Products (IDMP) Ontology project.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-20T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-02-10T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-07-21T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/MetadataEXT/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/MetadataISO/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/MetadataMETA/"/>
@@ -44,7 +46,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/MetadataCMNS/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/MetadataLCC/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230201/MetadataIDMP/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MetadataMVF/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230701/MetadataIDMP/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -58,7 +61,8 @@
 		<dct:hasPart rdf:resource="&idmp-meta-mod;METAModule"/>
 		<dct:hasPart rdf:resource="&cmns-mod;CMNSModule"/>
 		<dct:hasPart rdf:resource="&lcc-mod;LCCModule"/>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:hasPart rdf:resource="&mvf-mod;MVFModule"/>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<dct:title>IDMP Metadata Specification</dct:title>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -44,6 +44,8 @@
     <uri id="7400e59c-5419-42b0-af16-0e88d9b03b34" name="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/" uri="./LCC/Countries/ISO3166-2-SubdivisionCodes.rdf"/>
     <uri id="58399855-1baa-4681-9f75-2a64040bf0a4" name="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-GB/" uri="./LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-GB.rdf"/>
     <uri id="1fb2f70c-0435-49c6-941b-5bf794169d8c" name="https://www.omg.org/spec/LCC/Countries/UN-M49-RegionCodes/" uri="./LCC/Countries/UN-M49-RegionCodes.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/" uri="./MVF/ISO1087-VocabularyForTermsAndDefinitions.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/" uri="./MVF/MultipleVocabularyFacility.rdf"/>
     <uri id="6e92ff46-ce62-4a55-b605-63b70bbb85e7" name="https://spec.pistoiaalliance.org/idmp/ontology/META/MetadataMETA/" uri="./META/MetadataMETA.rdf"/>
     <uri id="454a5d50-a678-48b6-84d8-fe5930313bde" name="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/" uri="./META/ChangeManagement.rdf"/>
     <uri id="0deda5ec-c3ad-4e06-955f-30b6ab96a22f" name="https://spec.pistoiaalliance.org/idmp/ontology/META/ISOConformanceAnnotations/" uri="./META/ISOConformanceAnnotations.rdf"/>


### PR DESCRIPTION
Description: 

1. Add the OMG formal standard ontologies for Multiple Vocabulary Facility to the iDMP GitHub for use as needed for representation of controlled vocabularies
2. Augmented the substances ontology to use the new pattern for controlled vocabularies
3. Augment any concept in the substances ontology that has a datatype code of CD to be a subclass of concept descriptor
4. Augment any concept in the medicinal products ontology that has a datatype code of CD to be a subclass of concept descriptor
5. Fill in missing details for concept descriptors as appropriate (only for those we've already covered)