### PR TITLE
GitHub-434 - cmns-ra:designates is equivalent to cmns-ra:isDesignatedBy

### DIFF
--- a/CMNS/RegistrationAuthorities.rdf
+++ b/CMNS/RegistrationAuthorities.rdf
@@ -45,7 +45,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230601/RegistrationAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230701/RegistrationAuthorities/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -228,7 +228,6 @@
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&cmns-ra;designates">
-		<rdf:type rdf:resource="&owl;SymmetricProperty"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasRelatedPartyRole"/>
 		<rdfs:label>designates</rdfs:label>
 		<rdfs:domain rdf:resource="&cmns-pts;PartyRole"/>


### PR DESCRIPTION
Description: eliminated the symmetric declaration on designates to address reasoning issue