### PR TITLE
IDMP-655 - Revise the Commons ontologies and related changes for Commons 1.1

### DIFF
--- a/AboutIDMPDev-ReferenceIndividuals.rdf
+++ b/AboutIDMPDev-ReferenceIndividuals.rdf
@@ -40,7 +40,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>

--- a/AboutIDMPDev.rdf
+++ b/AboutIDMPDev.rdf
@@ -40,7 +40,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>

--- a/AboutIDMPProd-ReferenceIndividuals.rdf
+++ b/AboutIDMPProd-ReferenceIndividuals.rdf
@@ -40,7 +40,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>

--- a/AboutIDMPProd.rdf
+++ b/AboutIDMPProd.rdf
@@ -39,7 +39,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>

--- a/CMNS/AboutCommons-ReferenceIndividuals.rdf
+++ b/CMNS/AboutCommons-ReferenceIndividuals.rdf
@@ -25,29 +25,46 @@
         <rdfs:label>About the Commons Ontology Library</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of Commons users. It can be used to load all of the current Commons ontologies, including reference individuals for governments and jurisdictions, using a relative catalog, as needed in Protege or other tools.</dct:abstract>
 		<dct:license rdf:resource="https://opensource.org/licenses/MIT"/>
-		<cmns-av:copyright>Copyright (c) 2021-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2021-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2021-2023 Mayo Clinic</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2019-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Working Ontologist LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2021-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2021-2023 Federated Knowledge LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2021-2023 Mayo Clinic</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
-		<dct:contributor rdf:datatype="&xsd;string">agnos.ai</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">EDM Council, Inc.</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">Mayo Clinic</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">Thematix Partners LLC</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">U.S. Department of Commerce, National Institute of Standards and Technology (NIST)</dct:contributor>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
+		<dct:contributor>Davide Sottara, Mayo Clinic</dct:contributor>
+		<dct:contributor>Dean Allemang, Working Ontologist LLC</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Evan Wallace, U.S. Department of Commerce, National Institute of Standards and Technology (NIST)</dct:contributor>
+		<dct:contributor>Hans Peter de Koenig, DEKonsult</dct:contributor>
+		<dct:contributor>Pete Rivett, Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Roger Burkhart, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Stuart Chalk, University of North Florida</dct:contributor>
 		<dct:references rdf:resource="http://purl.org/dc/terms/"/>
 		<dct:references rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
-		<dct:source>ISO 704:2009 Terminology work - Principles and methods, Fourth edition, 2022-07</dct:source>       
+        <dct:source>ISO 704:2022 Terminology work - Principles and methods, Fourth edition, 2022-07</dct:source>
 		<dct:source>ISO 1087:2019 Terminology work - Vocabulary - Theory and Application, Second edition, 2019-09</dct:source>
-		<dct:source>ISO 5127:2017 Information and documentation - Foundation and vocabulary, Second edition, 2017-05</dct:source>
 		<dct:source>ISO/IEC 11179-3:2013 Information technology - Metadata registries (MDR) - Registry metamodel and basic attributes, Third edition, 2013-02-15</dct:source>
+		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement</dct:source>
+		<dct:source>ISO 12651-2:2014, Electronic document management - Vocabulary - Part 2: Workflow management</dct:source>
+		<dct:source>ISO 14813-1:2015 Intelligent transport systems - Reference model architecture(s) for the ITS sector - Part 1: ITS service domains, service groups and services</dct:source>
+		<dct:source>ISO/IEC 18384-1:2016 Information technology - Reference Architecture for Service Oriented Architecture (SOA RA), Parts 1 and 3</dct:source>
+		<dct:source>ISO 18629-1:2004 Industrial automation systems and integration - Process specification language - Part 1: Overview and basic principles</dct:source>
+		<dct:source>ISO/IEC 19763-8:2015 Information technology - Metamodel framework for interoperability (MFI) - Part 8: Metamodel for role and goal model registration</dct:source>
+		<dct:source>ISO/TS 19807-1:2019 Nanotechnologies - Magnetic nanomaterials - Part 1: Specification of characteristics and measurements for magnetic nanosuspensions</dct:source>
+		<dct:source>ISO 21298:2017 Health informatics - Functional and structural roles</dct:source>
+ 		<dct:source>ISO/TR 21965:2019 Information and documentation - Records management in enterprise architecture</dct:source>
+		<dct:source>ISO 23234:2021 Buildings and civil engineering works - Security - Planning of security measures in the built environment</dct:source>
+		<dct:source>ISO/IEC TR 29119-11:2020, Software and systems engineering - Software testing - Part 11: Guidelines on the testing of AI-based systems</dct:source>
+		<dct:source>ISO 80000-1:2009 Quantities and units - Part 1: General</dct:source>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
 		<dct:source>International Information Centre for Terminology (InfoTerm), see http://www.infoterm.info/</dct:source>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AsianJurisdiction/WesternAsiaGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -68,10 +85,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-        <owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/AboutCommons/"/>
+        <owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/AboutCommons/"/>
     </owl:Ontology>
 
 </rdf:RDF>

--- a/CMNS/AboutCommons.rdf
+++ b/CMNS/AboutCommons.rdf
@@ -24,29 +24,46 @@
     <owl:Ontology rdf:about="https://www.omg.org/spec/Commons/AboutCommons/">
         <rdfs:label>About the Commons Ontology Library</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of Commons users. It can be used to load all of the current Commons ontologies, using a relative catalog, as needed in Protege or other tools.</dct:abstract>
-		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
+		<dct:license rdf:resource="https://opensource.org/licenses/MIT"/>
+		<cmns-av:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2019-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2020-2023 Working Ontologist LLC</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2021-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2021-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2021-2023 Federated Knowledge LLC</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2021-2023 Mayo Clinic</cmns-av:copyright>
-        <cmns-av:copyright>Copyright (c) 2019-2023 Thematix Partners LLC</cmns-av:copyright>
-        <cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
-		<dct:contributor rdf:datatype="&xsd;string">agnos.ai</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">EDM Council, Inc.</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">Mayo Clinic</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">Thematix Partners LLC</dct:contributor>
-		<dct:contributor rdf:datatype="&xsd;string">U.S. Department of Commerce, National Institute of Standards and Technology (NIST)</dct:contributor>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
+		<dct:contributor>Davide Sottara, Mayo Clinic</dct:contributor>
+		<dct:contributor>Dean Allemang, Working Ontologist LLC</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Evan Wallace, U.S. Department of Commerce, National Institute of Standards and Technology (NIST)</dct:contributor>
+		<dct:contributor>Hans Peter de Koenig, DEKonsult</dct:contributor>
+		<dct:contributor>Pete Rivett, Federated Knowledge LLC</dct:contributor>
+		<dct:contributor>Roger Burkhart, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Stuart Chalk, University of North Florida</dct:contributor>
 		<dct:references rdf:resource="http://purl.org/dc/terms/"/>
 		<dct:references rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
-        <dct:source>ISO 704:2009 Terminology work - Principles and methods, Fourth edition, 2022-07</dct:source>       
+        <dct:source>ISO 704:2022 Terminology work - Principles and methods, Fourth edition, 2022-07</dct:source>
 		<dct:source>ISO 1087:2019 Terminology work - Vocabulary - Theory and Application, Second edition, 2019-09</dct:source>
-		<dct:source>ISO 5127:2017 Information and documentation - Foundation and vocabulary, Second edition, 2017-05</dct:source>
 		<dct:source>ISO/IEC 11179-3:2013 Information technology - Metadata registries (MDR) - Registry metamodel and basic attributes, Third edition, 2013-02-15</dct:source>
-        <dct:source>International Information Centre for Terminology (InfoTerm), see http://www.infoterm.info/</dct:source>
+		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement</dct:source>
+		<dct:source>ISO 12651-2:2014, Electronic document management - Vocabulary - Part 2: Workflow management</dct:source>
+		<dct:source>ISO 14813-1:2015 Intelligent transport systems - Reference model architecture(s) for the ITS sector - Part 1: ITS service domains, service groups and services</dct:source>
+		<dct:source>ISO/IEC 18384-1:2016 Information technology - Reference Architecture for Service Oriented Architecture (SOA RA), Parts 1 and 3</dct:source>
+		<dct:source>ISO 18629-1:2004 Industrial automation systems and integration - Process specification language - Part 1: Overview and basic principles</dct:source>
+		<dct:source>ISO/IEC 19763-8:2015 Information technology - Metamodel framework for interoperability (MFI) - Part 8: Metamodel for role and goal model registration</dct:source>
+		<dct:source>ISO/TS 19807-1:2019 Nanotechnologies - Magnetic nanomaterials - Part 1: Specification of characteristics and measurements for magnetic nanosuspensions</dct:source>
+		<dct:source>ISO 21298:2017 Health informatics - Functional and structural roles</dct:source>
+ 		<dct:source>ISO/TR 21965:2019 Information and documentation - Records management in enterprise architecture</dct:source>
+		<dct:source>ISO 23234:2021 Buildings and civil engineering works - Security - Planning of security measures in the built environment</dct:source>
+		<dct:source>ISO/IEC TR 29119-11:2020, Software and systems engineering - Software testing - Part 11: Guidelines on the testing of AI-based systems</dct:source>
+		<dct:source>ISO 80000-1:2009 Quantities and units - Part 1: General</dct:source>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
+		<dct:source>International Information Centre for Terminology (InfoTerm), see http://www.infoterm.info/</dct:source>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -61,10 +78,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/AboutCommons/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/AboutCommons/"/>
     </owl:Ontology>
 
 </rdf:RDF>

--- a/CMNS/DatesAndTimes.rdf
+++ b/CMNS/DatesAndTimes.rdf
@@ -24,16 +24,17 @@
 		<dct:abstract>The dates and times ontology defines commonly used temporal concepts that cover those most frequently needed across domains, with a focus on terminology that is used in business applications. It is designed to be mappable to other date and time ontologies and specifications, such as the W3C Time Ontology in OWL (available at https://www.w3.org/TR/owl-time/), certain temporal elements in BFO 2020 (see https://basic-formal-ontology.org/bfo-2020.html), time concepts defined in schema.org, and the Object Management Group&apos;s Date Time Vocabulary (DTV) specification (available at https://www.omg.org/spec/DTV/), without the corresponding overhead or in some cases, issues. The concepts were originally derived from a number of date and time standards including ISO 8601:2004 Representation of Dates and Times. The ontology itself was derived from the Financial Industry Business Ontology (FIBO) Financial Dates ontology, with minor revisions to better reflect requirements for mapping to other ontologies.</dct:abstract>
 		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Mark Linehan, Thematix Partners LLC</dct:contributor>
-		<dct:contributor>Pete Rivett, agnos.ai U.K. Ltd</dct:contributor>
+		<dct:contributor>Pete Rivett, Federated Knowledge LLC</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20221101/DatesAndTimes/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/DatesAndTimes/"/>
 		<skos:changeNote>https://www.omg.org/spec/Commons/20220501/DatesAndTimes.rdf version of this ontology was modified to eliminate a double space in the scope note on CombinedDateTime (COMMONS-6).</skos:changeNote>
+		<skos:changeNote>https://www.omg.org/spec/Commons/20221101/DatesAndTimes.rdf version of this ontology was revised to add properties supporting start and end time and related concepts (COMMONS-11-8).</skos:changeNote>
 		<skos:note>The dates and times ontology conforms with the OWL 2 DL semantics, and is outside of OWL 2 RL due to the inclusion of exact cardinality constraints on explicit date, explicit duration and time of day. These constraints can be changed to maximum cardinality constraints if needed to support OWL RL rule-based applications that cannot be extended to support them.</skos:note>
-		<cmns-av:copyright>Copyright (c) 2014-2022 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2022 Object Management Group, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2022 Thematix Partners LLC</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2021-2022 agnos.ai U.K. Ltd</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2014-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2021-2023 agnos.ai U.K. Ltd</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<rdfs:Datatype rdf:about="&cmns-dt;CombinedDateTime">
@@ -205,6 +206,35 @@
 		<skos:note>This class is used when a duration is guaranteed to be known when it is created.</skos:note>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&cmns-dt;ExplicitTimePeriod">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;ProperInterval"/>
+		<rdfs:subClassOf rdf:resource="&cmns-dt;TimePeriod"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasDuration"/>
+				<owl:onClass rdf:resource="&cmns-dt;ExplicitDuration"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasEndTime"/>
+				<owl:onClass rdf:resource="&cmns-dt;TimeOfDay"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasStartTime"/>
+				<owl:onClass rdf:resource="&cmns-dt;TimeOfDay"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>explicit time period</rdfs:label>
+		<skos:definition>time period for which the starting time, ending time, and/or duration are required</skos:definition>
+		<skos:note>As with &apos;time period&apos;, any one of {start time, end time, duration} may be omitted because the missing property can be inferred from the other two.</skos:note>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&cmns-dt;ProperInterval">
 		<rdfs:subClassOf rdf:resource="&cmns-dt;TimeInterval"/>
 		<rdfs:label>proper interval</rdfs:label>
@@ -259,25 +289,66 @@
 		<skos:note>The representation similar to xsd:dateTime, but should exclude the date component and time zone. The value of the has time value property roughly corresponds to xsd:time in XML schema datatypes, which is prohibited from use in OWL due to ambiguity in its definition.</skos:note>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&cmns-dt;TimePeriod">
+		<rdfs:subClassOf rdf:resource="&cmns-dt;TimeInterval"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasDuration"/>
+				<owl:onClass rdf:resource="&cmns-dt;Duration"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasEndTime"/>
+				<owl:onClass rdf:resource="&cmns-dt;TimeOfDay"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dt;hasStartTime"/>
+				<owl:onClass rdf:resource="&cmns-dt;TimeOfDay"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>time period</rdfs:label>
+		<skos:definition>time span over some finite window</skos:definition>
+		<skos:note>A time period is defined by at least two of three properties: (1) a start time, (2) an end time, and (3) a duration. If more than one of these properties is missing, the time period may be invalid or unknown.</skos:note>
+		<skos:note>A time period is unknown if either the starting or ending time has no value. If a time period is unknown, then the duration should either be omitted or unknown (have no value).</skos:note>
+	</owl:Class>
+	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
 		<rdfs:label>has date</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;Date"/>
 		<skos:definition>identifies a calendar day, month and year</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasDateOfIssuance">
+		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasStartDate"/>
+		<rdfs:label>has date of issuance</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;Date"/>
+		<skos:definition>links something, such as an agreement, contract, license, or report, to the date it was made available</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasDatePeriod">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
 		<rdfs:label>has date period</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;DatePeriod"/>
 		<skos:definition>identifies a specific window of time, including a start date, end date and/or duration</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasDateTime">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
 		<rdfs:label>has date time</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;DateTime"/>
 		<skos:definition>identifies a specific date and time of day, possibly excluding the time zone</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasDateTimeStamp">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
 		<rdfs:label>has date time stamp</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;DateTimeStamp"/>
 		<skos:definition>identifies a specific date and time of day, explicitly including the time zone</skos:definition>
@@ -304,6 +375,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasDuration">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
 		<rdfs:label>has duration</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;Duration"/>
 		<skos:definition>specifies the time during which something continues</skos:definition>
@@ -326,11 +398,27 @@
 		<skos:note>Negative durations are used to indicate relative dates that are before (rather than after) some other Date.</skos:note>
 	</owl:DatatypeProperty>
 	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasEnd">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
+		<rdfs:label>has end</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;TimeInstant"/>
+		<skos:definition>indicates the final or ending time point associated with something</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasEndDate">
 		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDate"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasEnd"/>
 		<rdfs:label>has end date</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition>indicates the ending date of some date period</skos:definition>
+		<skos:definition>indicates the final or ending date associated with something</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasEndTime">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasEnd"/>
+		<rdfs:label>has end time</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;TimeOfDay"/>
+		<skos:definition>indicates the final or ending time associated with something</skos:definition>
+		<cmns-av:usageNote>Use of the property &apos;hasTimeValue&apos; as a property of the TimeOfDay to record the actual time, or use either the DateTime or DateTimeStamp class with the date zeroed out if the date is not relevant but with the time included.</cmns-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasExplicitDate">
@@ -346,11 +434,42 @@
 		<skos:definition>indicates a date and time associated with an event, measurement, record, or observation</skos:definition>
 	</owl:DatatypeProperty>
 	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasStart">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
+		<rdfs:label>has start</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;TimeInstant"/>
+		<skos:definition>indicates the initial time point associated with something</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&cmns-dt;hasStartDate">
 		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDate"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasStart"/>
 		<rdfs:label>has start date</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition>indicates the initial date of something</skos:definition>
+		<skos:definition>indicates the initial date associated with something</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasStartTime">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasStart"/>
+		<rdfs:label>has end time</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;TimeOfDay"/>
+		<skos:definition>indicates the initial or starting time associated with something</skos:definition>
+		<cmns-av:usageNote>Use of the property &apos;hasTimeValue&apos; as a property of the TimeOfDay to record the actual time, or use either the DateTime or DateTimeStamp class with the date zeroed out if the date is not relevant but with the time included.</cmns-av:usageNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasTime">
+		<rdfs:label>has time</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;TemporalEntity"/>
+		<rdfs:seeAlso rdf:resource="https://w3c.github.io/sdw/time/#time:hasTime"/>
+		<skos:definition>specifies a general time that can be associated with any element</skos:definition>
+		<skos:note>This property corresponds to the property of the same name in the W3C Time Ontology, and can be used to support mapping.</skos:note>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-dt;hasTimePeriod">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasTime"/>
+		<rdfs:label>has time period</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;TimePeriod"/>
+		<skos:definition>identifies a specific window of time, including a starting time, ending time and/or duration</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&cmns-dt;hasTimeValue">

--- a/CMNS/Documents.rdf
+++ b/CMNS/Documents.rdf
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
-	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
-	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -14,10 +11,7 @@
 ]>
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/Documents/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
-	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
-	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -27,55 +21,73 @@
 	
 	<owl:Ontology rdf:about="https://www.omg.org/spec/Commons/Documents/">
 		<rdfs:label>Commons Documents Ontology</rdfs:label>
-		<dct:abstract>This ontology defines high-level concepts for representation of documents, including legal documents and any kind of record, such as a transaction record, purchase history, and payment history.</dct:abstract>
+		<dct:abstract>This ontology defines high-level concepts for representation of documents, including legal documents and records, such as a transaction record, purchase history, or payment history. It is deliberately lightweight in order to accommodate mappings to other document and bibliographic ontologies.</dct:abstract>
+		<dct:contributor>Davide Sottara, Mayo Clinic</dct:contributor>
+		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
+		<dct:contributor>Evan Wallace, U.S. National Institute of Standards and Technology (NIST)</dct:contributor>
+		<dct:contributor>Pete Rivett, Federated Knowledge LLC</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230601/Documents/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/Documents/"/>
+		<skos:note>This ontology was derived from the Financial Industry Business Ontology (FIBO), and generalized for use in other domain areas.</skos:note>
 		<cmns-av:copyright>Copyright (c) 2014-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2014-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Federated Knowledge LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Mayo Clinic</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2023 Thematix Partners LLC</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&cmns-doc;Certificate">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:label>certificate</rdfs:label>
 		<skos:definition>document attesting to the truth of some fact or set of facts</skos:definition>
+		<cmns-av:adaptedFrom>ISO 5127 - Information and documentation - Foundation and vocabulary, Second edition, 2017-05, clause 3.1.1.38</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A certificate may or may not also be a legal document, depending on the issuing authority and how it can be used.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>Certificates, such as electronic certificates, including public keys, may be issued by some certificate authority.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-doc;Document">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-doc;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>document</rdfs:label>
-		<skos:definition>something tangible that records something, such as a recording or a photograph, or a writing that can be used to furnish evidence or information</skos:definition>
-		<skos:note>A document, especially a legal document, may serve to establish one or several facts, and can be relied upon as a proof thereof.</skos:note>
+		<rdfs:seeAlso rdf:resource="https://www.ifla.org/wp-content/uploads/2019/05/assets/cataloguing/frbr/frbroo_v2.2.pdf"/>
+		<skos:definition>unitary expression of some realization of an intellectual or artistic work</skos:definition>
+		<skos:note>See also ISO 25964–1:2011, definition 2.15; ISO 11005:2010, definition 3.1; ISO 15489–1:2016, definition 3.10; IEC 82045–1:2001, definition 3.2.3; ISO 9000:2015, definition 3.7.2</skos:note>
+		<skos:note>The definition of document provided herein roughly corresponds to the concept of an expression in FRBR. A document is a realization of something that typically takes the form of alpha-numeric, musical, or choreographic notation, sound, image, etc., or any combination of such forms. A manifestation of the document must be inscribed, encoded, engraved, recorded, or otherwise imprinted in some medium. The concept of a manifestation of an expression corresponds to the ISO 5127 notion of a document. Documents can differ extensively in form and characteristics.</skos:note>
+		<skos:note>The manifestation of a document (FRBR expression) refers not only to written and printed materials in paper or microform versions (for example, conventional books, journals, diagrams, maps), but also to non-printed media such as machine-readable and digitized records, Internet and intranet resources, films, sound recordings, buildings, sites, monuments, three-dimensional objects or realia [when used to carry some sort of engraving]; and to collections of such items or parts of such items. (Note taken from ISO 25964–1:2011, definition 2.15.) Also, software, since recorded, can be considered a document.</skos:note>
+		<cmns-av:adaptedFrom>&apos;Functional Requirements for Bibliographic Records&apos;, Final Report, IFLA (International Federation of Library Associations and Institutions) Study Group on the Functional Requirements for Bibliographic Records, September 1997 - see https://repository.ifla.org/bitstream/123456789/811/2/ifla-functional-requirements-for-bibliographic-records-frbr.pdf</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 5127 - Information and documentation - Foundation and vocabulary, Second edition, 2017-05, clause 3.1.1.38</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A document, especially a legal document, may serve to establish one or several facts, and can be relied upon as a proof thereof.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>This definition of document corresponds to a subclass of expression in FRBR. The notion of being a unitary expression is the differentiator between an FRBR expression and document in this sense.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-doc;LegalDocument">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:label>legal document</rdfs:label>
-		<skos:definition>document that bears the original, official, or legal form of something, that can be fully attributed to its author, that records and formally expresses a legally enforceable act, process, or contractual duty, obligation, or right and that can be used to furnish decisive evidence for that act, process, or agreement</skos:definition>
+		<skos:definition>document specifying the terms of, or provides evidence for, an agreement, attestation, certification, conditions, permissions, and/or decisions of legal persons, government entities, or courts of law, drawn up in accordance with certain rules that apply in the relevant jurisdiction(s)</skos:definition>
 		<skos:example>Examples include some certificates, deeds, bonds, business documents (such as articles of incorporation, bylaws, partnership agreements), contracts, certain identity documents, wills, trusts, legislative acts, notarial acts, court writs or processes (such as related complaints and pleadings in the context of litigation as well as other documents relevant to some legal issue), and any law passed by a competent legislative body in municipal (domestic) or international law.</skos:example>
-		<skos:note>In order for a document to be legal, it must conform to the laws of the jurisdiction where it will be enforced. Typically, such a document should also be properly signed, witnessed and filed to be considered legal.</skos:note>
+		<skos:note>A legal document bears the original, official, or legal form of something, that can be fully attributed to its author(s), that records and formally expresses a legally enforceable act, process, or contractual duty, obligation, or right and that can be used to furnish decisive evidence for that act, process, or agreement.</skos:note>
+		<skos:note>Many legal documents only become &apos;legal&apos; once they are signed and dated, and possibly notarized.</skos:note>
+		<cmns-av:adaptedFrom>ISO 5127 - Information and documentation - Foundation and vocabulary, Second edition, 2017-05, clause 3.4.6.02</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-doc;Notice">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:label>notice</rdfs:label>
-		<skos:definition>announcement, intimation, or advance warning of something, especially to allow preparations to be made</skos:definition>
+		<skos:definition>announcement, communication, intimation, or advance warning of something, usually, but not necessarily, to allow preparations to be made</skos:definition>
+		<skos:example>registered trademark notice, disclaimer, copyright notice, overdue notice, recall notice</skos:example>
 		<skos:note>Although many notices are delivered electronically, certain legal notices must be given given in writing, often by regular mail or hand delivery, with the sender retaining sufficient proof of having given such notice (e.g., through a certificate of service).</skos:note>
+		<cmns-av:adaptedFrom>ISO 5127 - Information and documentation - Foundation and vocabulary, Second edition, 2017-05</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-doc;Record">
-		<rdfs:subClassOf rdf:resource="&cmns-col;Collection"/>
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:label>record</rdfs:label>
 		<skos:definition>memorialization and objective evidence of activities performed, events occurred, results achieved, or statements made, regardless of its characteristics, media, physical form, or the manner in which it is recorded or stored</skos:definition>
-		<skos:example>Records include accounts, agreements, books, drawings, letters, magnetic/optical disks, memos, micrographics, etc.</skos:example>
 		<skos:note>Records are created or received by an organization in routine transaction of its business or in pursuance of its legal obligations.</skos:note>
 	</owl:Class>
 	
@@ -83,148 +95,53 @@
 		<rdfs:label>reference</rdfs:label>
 		<skos:definition>source that may be used to ascertain, interpret, or understand something</skos:definition>
 		<cmns-av:explanatoryNote>In linguistics, a reference characterizes, provides context for, or specifies the relationship of one linguistic expression to another, i.e., provides the information necessary to interpret the dependent expression.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>References may be rendered in the form of a document, but may also take other forms, such as reference materials, scientific equations, and constants, including in some cases physical things, used as the basis for units of measure.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-doc;ReferenceDocument">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Reference"/>
 		<rdfs:label>reference document</rdfs:label>
-		<dct:source>ISO/IEC 11179-3 Information technology - Metadata registries (MDR) - Part 3: Registry metamodel and basic attributes, Third edition, 2013-02-15</dct:source>
-		<skos:definition>document that provides pertinent details for consultation about a subject</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-doc;Report">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;hasReportingPeriod"/>
-				<owl:onClass rdf:resource="&cmns-dt;DatePeriod"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;hasReportDateTime"/>
-				<owl:onClass rdf:resource="&cmns-dt;DateTime"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;hasReportDate"/>
-				<owl:onClass rdf:resource="&cmns-dt;ExplicitDate"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;isReportedBy"/>
-				<owl:someValuesFrom rdf:resource="&cmns-doc;ReportingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;isReportedTo"/>
-				<owl:someValuesFrom rdf:resource="&cmns-pts;PartyRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>report</rdfs:label>
-		<skos:definition>document that provides a structured description of something, prepared on ad hoc, periodic, recurring, regular, or as required basis</skos:definition>
-		<cmns-av:explanatoryNote>Reports may refer to specific periods, events, occurrences, or subjects, and may be communicated or presented in oral, electronic, or written form.</cmns-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-doc;ReportingParty">
-		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;authors"/>
-				<owl:someValuesFrom rdf:resource="&cmns-doc;Report"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>reporting party</rdfs:label>
-		<skos:definition>party providing a report, typically in response to some contractual, legal, regulatory or other business requirement</skos:definition>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:intersectionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&cmns-doc;Document">
+					</rdf:Description>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&cmns-doc;isReferredToBy"/>
+						<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+					</owl:Restriction>
+				</owl:intersectionOf>
+			</owl:Class>
+		</owl:equivalentClass>
+		<skos:definition>document that is used as a reference for something</skos:definition>
+		<cmns-av:adaptedFrom>ISO/IEC 11179-3 Information technology - Metadata registries (MDR) - Part 3: Registry metamodel and basic attributes, Third edition, 2013-02-15</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>A reference document is typically one that provides pertinent details for consultation about a subject.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-doc;Specification">
-		<rdfs:subClassOf rdf:resource="&cmns-col;Arrangement"/>
 		<rdfs:label>specification</rdfs:label>
 		<skos:definition>explicit requirement or set of requirements to be satisfied by something, such as a product, material, model, process or system</skos:definition>
 		<cmns-av:abbreviation xml:lang="en">spec</cmns-av:abbreviation>
-		<cmns-av:adaptedFrom>ISO 6707-2:2017 Buildings and civil engineering works - Vocabulary - Part 2: Contract and communication terms, 3.2.22</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 6707-2:2017 Buildings and civil engineering works - Vocabulary - Part 2: Contract and communication terms, clause 3.2.22</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-doc;TechnicalSpecification">
+	<owl:Class rdf:about="&cmns-doc;TechnicalSpecificationDocument">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;ReferenceDocument"/>
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
-		<rdfs:label>technical specification</rdfs:label>
+		<rdfs:label>technical specification document</rdfs:label>
 		<skos:definition>document that sets out detailed requirements to be satisfied by a product, material, process or system and the procedures for checking conformity to these requirements</skos:definition>
 		<skos:note>Technical specifications may evolve from a functional specification and define the technical requirements for the selected solution as part of a business agreement.</skos:note>
-		<cmns-av:adaptedFrom>ISO 10795:2019 Space systems - Programme management and quality - Vocabulary, 3.238</cmns-av:adaptedFrom>
-		<cmns-av:adaptedFrom>ISO 6707-2:2017 Buildings and civil engineering works - Vocabulary - Part 2: Contract and communication terms, 3.2.22</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 10795:2019 Space systems - Programme management and quality - Vocabulary, clause 3.238</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 6707-2:2017 Buildings and civil engineering works - Vocabulary - Part 2: Contract and communication terms, clause 3.2.22</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>A technical specification is a specification expressing technical requirements, such as one for designing and developing a solution to be implemented.</cmns-av:explanatoryNote>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;authors">
-		<rdfs:label>authors</rdfs:label>
-		<skos:definition>creates or originates and is responsible for the content of</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-doc;hasDataSource">
 		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
 		<rdfs:label>has data source</rdfs:label>
 		<skos:definition>relates something, such as an agreement, contract, document, record, report, or process, to a source of data used to analyze, develop, explain, produce, or otherwise create it</skos:definition>
-		<skos:note>Although in many cases an annotation property, such as dct:source, is sufficient for this purpose, there are occasions when a more complete description of a source is required, for which this property may be used.</skos:note>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasDateOfIssuance">
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasStartDate"/>
-		<rdfs:label>has date of issuance</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition>links something, typically an agreement, contract, or report, with the date it was produced or published</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasExpirationDate">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasEndDate"/>
-		<rdfs:label>has expiration date</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition>links something, such as an agreement, contract, report, other document, or perishable item, with a date beyond which it is no longer valid</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasRecord">
-		<rdfs:subPropertyOf rdf:resource="&cmns-col;comprises"/>
-		<rdfs:label>has record</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-doc;Record"/>
-		<skos:definition>links something to a record that pertains to it</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasReportDate">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasExplicitDate"/>
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;hasDateOfIssuance"/>
-		<rdfs:label xml:lang="en">has report date</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
-		<skos:definition xml:lang="en">date on which a report was issued</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasReportDateTime">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDateTime"/>
-		<rdfs:label xml:lang="en">has report date time</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;DateTime"/>
-		<skos:definition xml:lang="en">date and time at which a report was issued</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasReportingPeriod">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDatePeriod"/>
-		<rdfs:label>has reporting period</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;ExplicitDatePeriod"/>
-		<skos:definition>specifies the period for which a report, document, statistical measure or something else, applies</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;hasTerminationDate">
-		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasEndDate"/>
-		<rdfs:label>has termination date</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-dt;Date"/>
-		<skos:definition>links something, typically an agreement, contract, document, or process, with a date on which it was or will be terminated</skos:definition>
+		<cmns-av:usageNote>Although in many cases an annotation property, such as dct:source, is sufficient for this purpose, there are occasions when a more complete description of a source is required, such as to meet data lineage requirements, for which this property may be used.</cmns-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-doc;isAbout">
@@ -232,25 +149,17 @@
 		<skos:definition>indicates the subject or topic of something, such as a document</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-doc;isReportedBy">
-		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasPartyRole"/>
-		<rdfs:label>is reported by</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-pts;PartyRole"/>
-		<skos:definition>indicates the party that authors and provides a report</skos:definition>
+	<owl:ObjectProperty rdf:about="&cmns-doc;isReferredToBy">
+		<rdfs:label>is referred to by</rdfs:label>
+		<owl:inverseOf rdf:resource="&cmns-doc;refersTo"/>
+		<skos:definition>indicates something that is referenced as a source for information or explanation</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-doc;isReportedTo">
-		<rdfs:subPropertyOf rdf:resource="&cmns-pts;hasPartyRole"/>
-		<rdfs:label>is reported to</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-pts;PartyRole"/>
-		<skos:definition>indicates the party to which something is reported</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&cmns-doc;isSpecifiedBy">
+	<owl:ObjectProperty rdf:about="&cmns-doc;isSpecifiedIn">
 		<rdfs:subPropertyOf rdf:resource="&cmns-doc;refersTo"/>
-		<rdfs:label>is specified by</rdfs:label>
+		<rdfs:label>is specified in</rdfs:label>
 		<owl:inverseOf rdf:resource="&cmns-doc;specifies"/>
-		<skos:definition>indicates the source for some fact</skos:definition>
+		<skos:definition>indicates the explicit source for some requirement, fact, or set of facts</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-doc;records">
@@ -265,7 +174,8 @@
 	
 	<owl:ObjectProperty rdf:about="&cmns-doc;specifies">
 		<rdfs:label>specifies</rdfs:label>
-		<skos:definition>states a fact about something</skos:definition>
+		<skos:definition>mentions, names or states something clearly and definitively</skos:definition>
+		<cmns-av:explanatoryNote>Specifies may be used to refer to a requirement, fact, or set of facts.</cmns-av:explanatoryNote>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/CMNS/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf
+++ b/CMNS/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-ge "https://www.omg.org/spec/Commons/GovernmentEntities/">
 	<!ENTITY cmns-ge-eeuj "https://www.omg.org/spec/Commons/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions/">
@@ -14,6 +13,7 @@
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
@@ -25,7 +25,6 @@
 ]>
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-ge="https://www.omg.org/spec/Commons/GovernmentEntities/"
 	xmlns:cmns-ge-eeuj="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions/"
@@ -38,6 +37,7 @@
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
@@ -54,7 +54,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AsianJurisdiction/WesternAsiaGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EasternEuropeGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/EuropeanJurisdiction/NorthernEuropeGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/EuropeanJurisdiction/SouthernEuropeGovernmentEntitiesAndJurisdictions/"/>
@@ -64,6 +63,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
@@ -139,8 +139,8 @@
 		<rdf:type rdf:resource="&cmns-rga;RegulatoryAgency"/>
 		<rdfs:label>European Commission as regulatory agency</rdfs:label>
 		<skos:definition>European Commission in its role as a regulator with shared jurisdiction over the European Union</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&cmns-ge-euj;EuropeanCommission"/>
 		<cmns-rga:hasJurisdiction rdf:resource="&cmns-ge-euj;EuropeanUnionJurisdiction"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&cmns-ge-euj;EuropeanCommission"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&cmns-ge-euj;EuropeanEconomicArea">

--- a/CMNS/GovernmentEntities.rdf
+++ b/CMNS/GovernmentEntities.rdf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-ge "https://www.omg.org/spec/Commons/GovernmentEntities/">
 	<!ENTITY cmns-loc "https://www.omg.org/spec/Commons/Locations/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -18,13 +18,13 @@
 ]>
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/GovernmentEntities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-ge="https://www.omg.org/spec/Commons/GovernmentEntities/"
 	xmlns:cmns-loc="https://www.omg.org/spec/Commons/Locations/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -39,11 +39,11 @@
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/GovernmentEntities/"/>
 		<skos:note>This ontology is derived from the Financial Industry Business Ontology (FIBO) Government Entities ontology.</skos:note>
@@ -142,7 +142,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-ge;Government">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>

--- a/CMNS/MetadataCMNS.rdf
+++ b/CMNS/MetadataCMNS.rdf
@@ -26,10 +26,10 @@
 		<dct:abstract>The Commons (CMNS) Ontology Library Module includes ontologies that are defined in the Object Management Group (OMG) Commons Ontology Library standard, as well as others that are planned for inclusion.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2022-11-16T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-08-13T18:00:00</dct:modified>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-09-20T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/MetadataCMNS/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/MetadataCMNS/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -43,7 +43,6 @@
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -64,6 +63,7 @@
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/StructuredCollections/"/>
 		<dct:hasPart rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>

--- a/CMNS/Organizations.rdf
+++ b/CMNS/Organizations.rdf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -18,13 +18,13 @@
 ]>
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -39,10 +39,10 @@
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/Organizations/"/>
 		<skos:note>This ontology is derived from the Financial Industry Business Ontology (FIBO) Organizations, Formal Organizations, and Legal Persons ontologies.</skos:note>
@@ -108,7 +108,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;hasMember"/>
@@ -199,7 +199,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>

--- a/CMNS/PartiesAndSituations.rdf
+++ b/CMNS/PartiesAndSituations.rdf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-dt "https://www.omg.org/spec/Commons/DatesAndTimes/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -16,12 +16,12 @@
 ]>
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-dt="https://www.omg.org/spec/Commons/DatesAndTimes/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -37,10 +37,10 @@
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/PartiesAndSituations/"/>
 		<skos:note>This ontology was originally designed for use in the Financial Industry Business Ontology (FIBO) for representing complex relationships between parties, such as employment, ownership and control. It has since been extended based on usage in other projects, such as the Pistoia Alliance Identification of Medicinal Products (IDMP) ontology project.</skos:note>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -48,6 +48,7 @@
 		<cmns-av:copyright>Copyright (c) 2020-2023 Working Ontologist LLC</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:usageNote>Note that inference with respect to property chains, which this ontology makes extensive use of, requires a knowledge graph solution that understands these chains, or requires running a reasoner outside of the graph database and asserting the inferences in order to make use of them.</cmns-av:usageNote>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&cmns-pts;Actor">
@@ -58,7 +59,7 @@
 		<cmns-av:adaptedFrom>ISO 14813-1:2015(en), Intelligent transport systems - Reference model architecture(s) for the ITS sector - Part 1: ITS service domains, service groups and services, clause 3.1</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO 23234:2021(en), Buildings and civil engineering works - Security - Planning of security measures in the built environment, clause 3.4</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TR 21965:2019(en), Information and documentation - Records management in enterprise architecture, clause 3.2.1</cmns-av:adaptedFrom>
-		<cmns-av:explanatoryNote>The concept of actor here is in a more linuistic sense, from core semantic theories reflecting actor/undergoer/null roles of an argument in an expression.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>The concept of actor here is in a more linguistic sense, from core semantic theories reflecting actor/undergoer/null roles of an argument in an expression.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-pts;Agent">
@@ -72,7 +73,7 @@
 		<rdfs:label>agent</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.jamesodell.com/WhatIsAnAgent.pdf</rdfs:seeAlso>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.jamesodell.com/WhyShouldWeCareAboutAgents.pdf</rdfs:seeAlso>
-		<owl:disjointWith rdf:resource="&cmns-cmp;Role"/>
+		<owl:disjointWith rdf:resource="&cmns-rlcmp;Role"/>
 		<skos:definition>something autonomous that can adapt to and interact with its environment</skos:definition>
 		<skos:note>Agents can be human beings, organizations, software agents, robots and living things other than plants. They are defined as having the following three important properties: autonomy, interactive behavior, and adaptability. (1) Autonomy - an agent is capable of acting without direct external intervention. This includes software or other agents that have some degree of control over their internal state and can act based on their own experiences. They can also possess their own set of internal responsibilities and capabilities that enable them to act without any external choreography. This definition excludes agents that act on on behalf of (or as a proxy for) some person or thing (see AgentRole). (2) Interactive behavior - they are capable of exchanging communicating with other things in their environment. This includes, in the case of software agents, messages that can support requests for services and other kinds of resources, as well as event detection and notification. They can be synchronous or asynchronous in nature. The interaction can also be conversational in nature, such as negotiating contracts, marketplace-style bidding, or simply making a query. (3) Adaptability - an agent is capable of responding to other agents and/or its environment. Agents can react to communications and events and then respond appropriately. Software agents can be designed to make difficult decisions and even modify their behavior based on their experiences. In other words, they can learn and evolve.</skos:note>
 		<skos:note>Note that this does not necessarily imply that an agent is free to act as it sees fit, without constraint. Rather, an agent in the sense meant here is something which may or may not be subject to controls and constraints but is self-actualizing in its behavior in response to any such constraints.</skos:note>
@@ -80,10 +81,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-pts;AgentRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass rdf:resource="&cmns-pts;Agent"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -109,7 +110,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass rdf:resource="&cmns-pts;Party"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -117,20 +118,13 @@
 		<rdfs:label>party role</rdfs:label>
 		<skos:definition>role played by an organization or individual that may be time bound</skos:definition>
 		<skos:example>Examples include organization member, employee, issuer, owner, partner in a partnership, shareholder, and so forth.</skos:example>
-		<skos:note>Note that there may be cases whre the identity of the party playing the role is not known, as well as cases where in some situation, such as ownership, there may be more than one party playing the role of owner.</skos:note>
+		<skos:note>Note that there may be cases where the identity of the party playing the role is not known, as well as cases where in some situation, such as ownership, there may be more than one party playing the role of owner.</skos:note>
 		<skos:scopeNote>The concept of a party role is used in contexts in which one would call someone a &apos;party to something&apos;, such as party to a contract or to a transaction, a supplier, buyer, customer, student, employee, and so forth. More specific roles such as those that are performed in the context of some activity or process are actors in that situation.</skos:scopeNote>
 		<cmns-av:adaptedFrom>ISO 14813-1:2015(en), Intelligent transport systems - Reference model architecture(s) for the ITS sector - Part 1: ITS service domains, service groups and services, clause 3.1</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO 23234:2021(en), Buildings and civil engineering works - Security - Planning of security measures in the built environment, clause 3.4</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-pts;Situation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-pts;hasObjectRole"/>
-				<owl:onClass rdf:resource="&cmns-cmp;Role"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-pts;holdsDuring"/>
@@ -140,8 +134,15 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-pts;hasObjectRole"/>
+				<owl:onClass rdf:resource="&cmns-rlcmp;Role"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-pts;hasSubjectRole"/>
-				<owl:someValuesFrom rdf:resource="&cmns-cmp;Role"/>
+				<owl:someValuesFrom rdf:resource="&cmns-rlcmp;Role"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>situation</rdfs:label>
@@ -159,7 +160,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-pts;Undergoer">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:label>undergoer</rdfs:label>
 		<skos:definition>something that plays the role of the object or recipient in a situation, i.e., the thing (or party) that the situation impacts, affects, or that otherwise plays a passive recipient / patient or thematic role</skos:definition>
 		<skos:example>Examples include something that is owned or controlled.</skos:example>
@@ -193,7 +194,7 @@
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;hasUndergoer">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates an actor in a given situation to the thing (or party) that they impact under the circumstances</skos:definition>
@@ -202,7 +203,7 @@
 	<owl:ObjectProperty rdf:about="&cmns-pts;experiences">
 		<rdfs:label>experiences</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;undergoes">
 			</rdf:Description>
@@ -213,13 +214,13 @@
 	<owl:ObjectProperty rdf:about="&cmns-pts;experiencesDirectly">
 		<rdfs:label>experiences directly</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;undergoes">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;hasActor">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates something directly to a party that drives a situation involving it</skos:definition>
@@ -228,7 +229,7 @@
 	<owl:ObjectProperty rdf:about="&cmns-pts;experiencesWith">
 		<rdfs:label>experiences with</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;undergoes">
 			</rdf:Description>
@@ -244,7 +245,7 @@
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-pts;hasActor">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates a situation to the person or organization acting in a primary (agentive) role</skos:definition>
@@ -256,7 +257,7 @@
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-pts;hasSubjectRole">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates a situation to something that is acting in a primary (agentive) role</skos:definition>
@@ -272,19 +273,19 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-pts;hasObjectRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has object role</rdfs:label>
 		<rdfs:domain>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&cmns-cmp;Composition">
+					<rdf:Description rdf:about="&cmns-rlcmp;Composition">
 					</rdf:Description>
 					<rdf:Description rdf:about="&cmns-pts;Situation">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:domain>
-		<rdfs:range rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:range rdf:resource="&cmns-rlcmp;Role"/>
 		<skos:definition>identifies a person or thing that is affected by, or is a secondary argument in a specific role with respect to a given relation or situation</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -295,26 +296,26 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-pts;hasPartyRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has party role</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-pts;PartyRole"/>
 		<skos:definition>identifies a specific role played by some person or organization as related to a situation, agreement, contract, policy, regulation, activity or other relationship</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-pts;hasRelatedPartyRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has related party role</rdfs:label>
 		<rdfs:domain rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:range rdf:resource="&cmns-pts;PartyRole"/>
 		<skos:definition>relates a party acting in a specific role directly to another party acting in the same or another role</skos:definition>
-		<skos:note>This property is intended as an abstract property, whose subproperties may or may not be symmetric, but could be inverses of one another.</skos:note>
+		<cmns-av:usageNote>This property is intended as an abstract property, whose subproperties may or may not be symmetric, but could be inverses of one another.</cmns-av:usageNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-pts;hasSubjectRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has subject role</rdfs:label>
 		<rdfs:domain rdf:resource="&cmns-pts;Situation"/>
-		<rdfs:range rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:range rdf:resource="&cmns-rlcmp;Role"/>
 		<skos:definition>identifies the person or thing that is being discussed, described, dealt with, or is the main topic in a specific role with respect to a given situation</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -358,7 +359,7 @@
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;hasActor">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates an undergoer in a given situation to the person or organization that has an impact on them under the circumstances</skos:definition>
@@ -370,20 +371,20 @@
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-pts;hasUndergoer">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates a situation to something that is directly involved in or affected by it</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-pts;isObjectRoleIn">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;isRoleIn"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;isRoleIn"/>
 		<rdfs:label>is object role in</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:domain rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:range>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&cmns-cmp;Composition">
+					<rdf:Description rdf:about="&cmns-rlcmp;Composition">
 					</rdf:Description>
 					<rdf:Description rdf:about="&cmns-pts;Situation">
 					</rdf:Description>
@@ -400,16 +401,16 @@
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-pts;hasObjectRole">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates a situation or constituency to something that is affected by, or is a secondary argument to in a specific role with respect to a given relation or situation</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-pts;isSubjectRoleIn">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;isRoleIn"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;isRoleIn"/>
 		<rdfs:label>is subject role in</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:domain rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:range rdf:resource="&cmns-pts;Situation"/>
 		<owl:inverseOf rdf:resource="&cmns-pts;hasSubjectRole"/>
 		<skos:definition>indicates a situation in which the role is the primary topic</skos:definition>
@@ -418,7 +419,7 @@
 	<owl:ObjectProperty rdf:about="&cmns-pts;playsActivePartyIn">
 		<rdfs:label>plays active party in</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;actsIn">
 			</rdf:Description>
@@ -429,7 +430,7 @@
 	<owl:ObjectProperty rdf:about="&cmns-pts;playsActiveRoleIn">
 		<rdfs:label>plays active role in</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;isSubjectRoleIn">
 			</rdf:Description>
@@ -441,7 +442,7 @@
 		<rdfs:label>plays active role that affects</rdfs:label>
 		<owl:inverseOf rdf:resource="&cmns-pts;isDirectlyAffectedBy"/>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;actsIn">
 			</rdf:Description>
@@ -455,13 +456,13 @@
 		<rdfs:label>plays active role that directly affects</rdfs:label>
 		<owl:inverseOf rdf:resource="&cmns-pts;experiencesDirectly"/>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;actsIn">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;hasUndergoer">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates a person or organization to something they have a direct impact on under the circumstances</skos:definition>
@@ -470,7 +471,7 @@
 	<owl:ObjectProperty rdf:about="&cmns-pts;realizes">
 		<rdfs:label>realizes</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&cmns-pts;isObjectRoleIn">
 			</rdf:Description>

--- a/CMNS/ProductsAndServices.rdf
+++ b/CMNS/ProductsAndServices.rdf
@@ -2,7 +2,6 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-cxtid "https://www.omg.org/spec/Commons/ContextualIdentifiers/">
@@ -13,6 +12,7 @@
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-prd "https://www.omg.org/spec/Commons/ProductsAndServices/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -24,7 +24,6 @@
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/ProductsAndServices/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-cxtid="https://www.omg.org/spec/Commons/ContextualIdentifiers/"
@@ -35,6 +34,7 @@
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-prd="https://www.omg.org/spec/Commons/ProductsAndServices/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -50,7 +50,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
@@ -59,6 +58,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Locations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/ProductsAndServices/"/>
 		<skos:note>This ontology was originally designed for and has been adapted from the Financial Industry Business Ontology (FIBO) Products and Services Ontology.</skos:note>
@@ -108,7 +108,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-prd;Facility">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-prd;provides"/>
@@ -172,7 +172,7 @@
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+						<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 						<owl:hasValue rdf:resource="&cmns-prd;GS1GlobalOffice"/>
 					</owl:Restriction>
 					<rdf:Description rdf:about="&cmns-prd;GS1Member">
@@ -231,7 +231,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-org;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;isMemberOf"/>
@@ -249,7 +249,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Actor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -315,8 +315,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-prd;Producer">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Actor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-prd;produces"/>
@@ -381,8 +381,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-prd;ServiceProvider">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
 		<rdfs:subClassOf rdf:resource="&cmns-pts;AgentRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-prd;provides"/>
@@ -394,10 +394,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-prd;Site">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-prd;situates"/>
@@ -442,8 +442,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-prd;Supplier">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Actor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:label>supplier</rdfs:label>
 		<skos:definition>actor that produces, provides, or furnishes an item or service</skos:definition>
 		<cmns-av:adaptedFrom>GS1 General Specifications, clause 1.4.4; available at https://ref.gs1.org/standards/genspecs/</cmns-av:adaptedFrom>

--- a/CMNS/QuantitiesAndUnits.rdf
+++ b/CMNS/QuantitiesAndUnits.rdf
@@ -31,24 +31,26 @@
 	
 	<owl:Ontology rdf:about="https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 		<rdfs:label>Commons Quantities and Units Ontology</rdfs:label>
-		<dct:abstract>This ontology provides a core set of concepts for quantities, units, systems of quantities, and systems of units. The most widely accepted, scrutinized, and globally used system of quantities and system of units are the International System of Quantities (ISQ) and the International System of Units (SI). They are formally standardized through [ISO 31] and [IEC 60027]. The harmonization of these two sets of standards into one new set [ISO/IEC 80000] has been published by ISO in 2009 and 2010. This ontology is based on the QUDV model from the Object Management Group (OMG)&apos;s SysML standard and on ISO/IEC 80000-1:2009, which refers normatively to the ISO/IEC Guide 99:2007. It is compatible with and can be mapped directly to the OMG Date Time Vocabulary (DTV) Quantities Ontology, the de-facto QUDT ontology representing Units of Measure, Quantity Kinds, Dimensions and Data Types (see http://www.qudt.org/), the Units of Measurement Ontology (UO) ontology available from the BioPortal (https://bioportal.bioontology.org/ontologies/UO) and others, as well as the QUDV annex of the SysML specification.</dct:abstract>
+		<dct:abstract>This ontology provides a core set of concepts for quantities, units, systems of quantities, and systems of units. The most widely accepted, scrutinized, and globally used system of quantities and system of units are the International System of Quantities (ISQ) and the International System of Units (SI). They are formally standardized through [ISO 31] and [IEC 60027]. The harmonization of these two sets of standards into one new set [ISO/IEC 80000] has been published by ISO in 2009 and 2010. This ontology is based on the Object Management Group (OMG)&apos;s SysML standard and on ISO/IEC 80000-1:2009, which refers normatively to the ISO/IEC Guide 99:2007. It is compatible with and can be mapped directly to the OMG Date Time Vocabulary (DTV) Quantities Ontology, the de-facto QUDT ontology representing Units of Measure, Quantity Kinds, Dimensions and Data Types (see http://www.qudt.org/), the Units of Measurement Ontology (UO) ontology available from the BioPortal (https://bioportal.bioontology.org/ontologies/UO) and others, as well as the quantities and units library in the SysML specification.</dct:abstract>
+		<dct:contributor>Davide Sottara, Mayo Clinic</dct:contributor>
 		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Evan Wallace, U.S. National Institute of Standards and Technology (NIST)</dct:contributor>
 		<dct:contributor>Hans Peter de Koenig, DEKonsult</dct:contributor>
 		<dct:contributor>Roger Burkhart, Thematix Partners LLC</dct:contributor>
 		<dct:contributor>Stuart Chalk, University of North Florida</dct:contributor>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230501/QuantitiesAndUnits/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/QuantitiesAndUnits/"/>
 		<cmns-av:copyright>Copyright (c) 2011-2023 Thematix Partners LLC</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2015-2023 Object Management Group, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2023 DEKonsult</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2023 Mayo Clinic</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2023 University of North Florida</cmns-av:copyright>
 	</owl:Ontology>
 	
@@ -79,7 +81,7 @@
 		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.1</dct:source>
 		<owl:disjointWith rdf:resource="&cmns-qtu;PhysicalUnit"/>
 		<skos:definition>arbitrarily defined unit of measurement, where a relation of the unit to a physical unit of the SI does not exist or is unknown</skos:definition>
-		<skos:note>Arbitrary units represent references to materials or procedures that are defined outside the SI system. A quantity value is arbitrarily assigned to the reference preparation or the result of a measurement procedure, usually specific for a particular substance. This generally precludes comparability of quantity values across different systems and components for this type of units.</skos:note>
+		<skos:note>Arbitrary units represent references to materials or procedures that are defined outside of the SI system. A quantity value is arbitrarily assigned to the reference preparation or the result of a measurement procedure, usually specific for a particular substance. This generally precludes comparability of quantity values across different systems and components for this type of units.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;BaseQuantityKind">
@@ -125,7 +127,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;Constant">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>constant</rdfs:label>
 		<skos:definition>symbol that represents a value that does not change (i.e., is fixed) with respect to a formula or expression</skos:definition>
 	</owl:Class>
@@ -158,6 +160,15 @@
 		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.6</dct:source>
 		<dct:source>ISO 80000-1:2009 Quantities and units - Part 1: General, clause 3.24</dct:source>
 		<skos:definition>ratio of two measurement units for quantities of the same kind</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-qtu;CyclicRatioScale">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;RatioScale"/>
+		<rdfs:label>cyclic ratio scale</rdfs:label>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
+		<skos:definition>measurement scale that represents a ratio scale with a periodic cycle</skos:definition>
+		<skos:example>&apos;cyclic degree&apos; (to express planar angular measures) with modulus = 360 and unit &apos;degree&apos;</skos:example>
+		<skos:example>&apos;hour of day&apos; with modulus = 24 and unit &apos;hour&apos;</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;DerivedQuantityKind">
@@ -319,14 +330,14 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasMaximumPermissiveValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasMinimumPermissiveValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -355,11 +366,12 @@
 		<dct:source rdf:datatype="&xsd;anyURI">https://plato.stanford.edu/entries/measurement-science/</dct:source>
 		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
 		<skos:definition>ordered set of quantity values of quantities of a given kind of quantity used in ranking, according to magnitude, quantities of that kind</skos:definition>
+		<skos:note>Note that the majority of scalar quantities can be expressed by just using a MeasurementUnit directly as its measurement reference. This implies expression of a scalar quantity value on a ratio scale. However, for full coverage of all quantity value expressions, additional explicit measurement scales with additional semantics are needed, such as ordinal scale, interval scale, ratio scale with additional limit values, cyclic ratio scale and logarithmic scale.</skos:note>
 		<cmns-av:synonym>quantity-value scale</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;MeasurementUnit">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;Quantity"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;specializes"/>
@@ -402,7 +414,7 @@
 		<dct:source rdf:datatype="&xsd;anyURI">https://plato.stanford.edu/entries/measurement-science/</dct:source>
 		<dct:source rdf:datatype="&xsd;anyURI">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4589638/</dct:source>
 		<skos:definition>measurement scale that represents objects as belonging to classes that have no particular order</skos:definition>
-		<skos:example>Many nominal scales are qualitative in nature. A common example of a nominal scale is that of gender identity, which is a way of describing one&apos;s persistent inner concept of their gender. While the terminology from a psychological and medical perspective continues to evolve, the scale covers individuals who self identify as male or female as well as those that have an indeterminate perspective, such as transsexual or non-binary.</skos:example>
+		<skos:example>Many nominal scales are qualitative in nature. A common example of a nominal scale is that of gender identity, which is a way of describing one&apos;s persistent inner concept of their gender. While the terminology from a psychological and medical perspective continues to evolve, the scale covers individuals who self identify as male or female as well as those that have a less determinant perspective, such as transsexual or non-binary.</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;OrdinalScale">
@@ -470,30 +482,6 @@
 		<rdfs:label>prefixed unit</rdfs:label>
 		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
 		<skos:definition>conversion-based unit that is defined with respect to another measurement reference unit through a linear conversion relationship with a named prefix that represents a multiple or submultiple of a unit</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-qtu;Quantity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;hasName"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityName"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityKind"/>
-				<owl:someValuesFrom rdf:resource="&cmns-qtu;QuantityKind"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>quantity</rdfs:label>
-		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.24</dct:source>
-		<dct:source>ISO 80000-1:2009 Quantities and units - Part 1: General, clause 3.1</dct:source>
-		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
-		<skos:definition>property of a phenomenon, body, or substance, where the property has a magnitude that can be expressed by means of a number and a reference</skos:definition>
-		<skos:example>second, kilogram, joule, meter</skos:example>
-		<skos:note>A quantity as defined in ISO 80000 is a scalar. However, a vector or a tensor, the components of which are quantities, is also considered to be a quantity.</skos:note>
-		<skos:note>A reference can be a measurement unit, a measurement procedure, a reference material, or a combination of such.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;QuantityDimension">
@@ -602,7 +590,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isNameOf"/>
-				<owl:someValuesFrom rdf:resource="&cmns-qtu;Quantity"/>
+				<owl:someValuesFrom rdf:resource="&cmns-qtu;ScalarQuantity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>quantity name</rdfs:label>
@@ -610,11 +598,83 @@
 		<skos:note>A number of systems of quantities and units encode a quantity, such as a unit of measure, via a generally accepted abbreviation. URIs representing such quantities are very useful in applications that require globally unique, machine readable names, but are less accessible to people. This concept is intended to provide the corresponding name for a given quantity in the context of a specific system of quantities and units for human consumption.</skos:note>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-qtu;QuantityValue">
+	<owl:Class rdf:about="&cmns-qtu;Ratio">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasDenominator"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasNumerator"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>ratio</rdfs:label>
+		<dct:source rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=6688</dct:source>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#r</dct:source>
+		<skos:definition>proportional relationship between two different quantity values that gives rise to a datum of a specific quantity kind</skos:definition>
+		<skos:note>A ratio is a quantity measured with respect to some other quantity, or in mathematics a quotient of two numbers or expressions, arrived at by dividing one by the other.</skos:note>
+		<cmns-av:synonym>rate</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-qtu;RatioScale">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;MeasurementScale"/>
+		<rdfs:label>ratio scale</rdfs:label>
+		<dct:source rdf:datatype="&xsd;anyURI">https://plato.stanford.edu/entries/measurement-science/</dct:source>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
+		<skos:definition>measurement scale that represents quantitative values, allows comparison of differences in values, has a fixed zero value and is invariant under multiplication by a positive number</skos:definition>
+		<skos:example>The Kelvin scale is a ratio scale, as are the familiar scales representing mass in kilograms, length in meters and duration in seconds.</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-qtu;RatioScaleWithAdditionalLimitValues">
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;RatioScale"/>
+		<rdfs:label>ratio scale with additional limit values</rdfs:label>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
+		<skos:definition>measurement scale that that represents a ratio scale that has additional limit values</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-qtu;ReferenceMaterial">
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Reference"/>
+		<rdfs:label>reference material</rdfs:label>
+		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.26</dct:source>
+		<skos:definition>material, sufficiently homogeneous and stable with reference to specified properties, which has been established to be fit for its intended use in measurement or in examination of nominal properties</skos:definition>
+		<skos:note>Some reference materials have assigned quantity values that are metrologically traceable to a measurement unit outside a system of units. Such materials include vaccines to which International Units (IU) have been assigned by the World Health Organization (WHO).</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-qtu;ScalarQuantity">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;hasName"/>
+				<owl:onClass rdf:resource="&cmns-qtu;QuantityName"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityKind"/>
+				<owl:someValuesFrom rdf:resource="&cmns-qtu;QuantityKind"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>scalar quantity</rdfs:label>
+		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.24</dct:source>
+		<dct:source>ISO 80000-1:2009 Quantities and units - Part 1: General, clause 3.1</dct:source>
+		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
+		<skos:definition>property of a phenomenon, body, or substance, where the property has a magnitude that can be expressed by means of a number and a reference</skos:definition>
+		<skos:example>second, kilogram, joule, meter</skos:example>
+		<skos:note>A quantity as defined in ISO 80000 is a scalar. However, a vector or a tensor, the components of which are quantities, is also considered to be a quantity.</skos:note>
+		<skos:note>A reference can be a measurement unit, a measurement procedure, a reference material, or a combination of such.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&cmns-qtu;ScalarQuantityValue">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;expressesTheMagnitudeOf"/>
-				<owl:onClass rdf:resource="&cmns-qtu;Quantity"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantity"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -631,7 +691,7 @@
 				<owl:someValuesFrom rdf:resource="&cmns-qtu;MeasurementUnit"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>quantity value</rdfs:label>
+		<rdfs:label>scalar quantity value</rdfs:label>
 		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clauses 3.1.19, 3.1.25</dct:source>
 		<dct:source>ISO 80000-1:2009 Quantities and units - Part 1: General, clause 3.19</dct:source>
 		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
@@ -644,65 +704,24 @@
 		<cmns-av:synonym>value of a quantity</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-qtu;QuantityValueRange">
+	<owl:Class rdf:about="&cmns-qtu;ScalarQuantityValueRange">
 		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasLowerBound"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasUpperBound"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>quantity value range</rdfs:label>
-		<skos:definition>expression of the lowest possible value and highest possible value for some quantity</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-qtu;Ratio">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;Expression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasDenominator"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasNumerator"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>ratio</rdfs:label>
-		<dct:source rdf:datatype="&xsd;anyURI">https://stats.oecd.org/glossary/detail.asp?ID=6688</dct:source>
-		<dct:source rdf:datatype="&xsd;anyURI">https://www150.statcan.gc.ca/n1/edu/power-pouvoir/glossary-glossaire/5214842-eng.htm#r.</dct:source>
-		<skos:definition>proportional relationship between two different quantity values that gives rise to a datum of a specific quantity kind</skos:definition>
-		<skos:note>A ratio is a quantity measured with respect to some other quantity, or in mathematics a quotient of two numbers or expressions, arrived at by dividing one by the other.</skos:note>
-		<cmns-av:synonym>rate</cmns-av:synonym>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-qtu;RatioScale">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;MeasurementScale"/>
-		<rdfs:label>ratio scale</rdfs:label>
-		<dct:source rdf:datatype="&xsd;anyURI">https://plato.stanford.edu/entries/measurement-science/</dct:source>
-		<dct:source rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/SysML/</dct:source>
-		<skos:definition>measurement scale that represents quantitative values, allows comparison of differences in values, has a fixed zero value and is invariant under multiplication by a positive number</skos:definition>
-		<skos:example>The Kelvin scale is a ratio scale, as are the familiar scales representing mass in kilograms, length in meters and duration in seconds.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&cmns-qtu;ReferenceMaterial">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Reference"/>
-		<rdfs:label>reference material</rdfs:label>
-		<dct:source>ISO 11240 Health informatics - Identification of medicinal products - Data elements and structures for the unique identification and exchange of units of measurement, clause 3.1.26</dct:source>
-		<skos:definition>material, sufficiently homogeneous and stable with reference to specified properties, which has been established to be fit for its intended use in measurement or in examination of nominal properties</skos:definition>
-		<skos:note>Some reference materials have assigned quantity values that are metrologically traceable to a measurement unit outside a system of units. Such materials include vaccines to which International Units (IU) have been assigned by the World Health Organization (WHO).</skos:note>
+		<rdfs:label>scalar quantity value range</rdfs:label>
+		<skos:definition>expression of the lowest possible value and/or highest possible value for some scalar quantity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;SystemOfQuantities">
@@ -800,7 +819,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-qtu;Variable">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>variable</rdfs:label>
 		<skos:definition>symbol that represents a parameter in a formula or expression</skos:definition>
 	</owl:Class>
@@ -814,7 +833,7 @@
 	
 	<owl:ObjectProperty rdf:about="&cmns-qtu;expressesTheMagnitudeOf">
 		<rdfs:label>expresses the magnitude of</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-qtu;Quantity"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantity"/>
 		<skos:definition>specifies the quantity that some quantity value reflects</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -823,9 +842,9 @@
 		<rdfs:range>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&cmns-qtu;QuantityValue">
+					<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValue">
 					</rdf:Description>
-					<rdf:Description rdf:about="&cmns-qtu;QuantityValueRange">
+					<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValueRange">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -841,9 +860,9 @@
 		<rdfs:range>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&cmns-qtu;QuantityValue">
+					<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValue">
 					</rdf:Description>
-					<rdf:Description rdf:about="&cmns-qtu;QuantityValueRange">
+					<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValueRange">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -891,7 +910,7 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasArgument"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasQuantityValue"/>
 		<rdfs:label>has lower bound</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<skos:definition>specifies the quantity value that is the lower value of a pair of values representing a range</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -900,7 +919,7 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasQuantityValue"/>
 		<rdfs:label>has maximum permissive value</rdfs:label>
 		<rdfs:domain rdf:resource="&cmns-qtu;MeasurementScale"/>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<skos:definition>indicates the maximum allowed value for a measurement on the given scale</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -915,7 +934,7 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasQuantityValue"/>
 		<rdfs:label>has minimum permissive value</rdfs:label>
 		<rdfs:domain rdf:resource="&cmns-qtu;MeasurementScale"/>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<skos:definition>indicates the minimum allowed value for a measurement on the given scale</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -926,9 +945,9 @@
 		<rdfs:range>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&cmns-qtu;QuantityValue">
+					<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValue">
 					</rdf:Description>
-					<rdf:Description rdf:about="&cmns-qtu;QuantityValueRange">
+					<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValueRange">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -954,14 +973,14 @@
 	
 	<owl:ObjectProperty rdf:about="&cmns-qtu;hasQuantityValue">
 		<rdfs:label>has quantity value</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<skos:definition>relates something (an expression, formula, etc.) to its magnitude expressed as a number together with its unit of measure (if applicable)</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-qtu;hasQuantityValueRange">
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasExpression"/>
 		<rdfs:label>has quantity value range</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValueRange"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValueRange"/>
 		<skos:definition>relates something (an expression, formula, etc.) to its magnitude expressed as range of numbers together with their unit(s) of measure (if applicable)</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -970,7 +989,7 @@
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasArgument"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-qtu;hasQuantityValue"/>
 		<rdfs:label>has upper bound</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<skos:definition>specifies the quantity value that is the higher value of a pair of values representing a range</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -1006,7 +1025,7 @@
 	<owl:ObjectProperty rdf:about="&cmns-qtu;isValueOf">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;appliesTo"/>
 		<rdfs:label>is value of</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:domain rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<owl:inverseOf rdf:resource="&cmns-qtu;hasQuantityValue"/>
 		<skos:definition>is the measure that the value represents</skos:definition>
 	</owl:ObjectProperty>

--- a/CMNS/RegulatoryAgencies.rdf
+++ b/CMNS/RegulatoryAgencies.rdf
@@ -54,7 +54,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/RegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/RegulatoryAgencies/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
@@ -227,9 +227,9 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-rga;RegulatoryReport">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Report"/>
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:label>regulatory report</rdfs:label>
-		<skos:definition>report required to support operational transparency that demonstrates compliance with some specification, law, policy, restriction, or other rule specified by a regulatory agency</skos:definition>
+		<skos:definition>document required to support operational transparency that demonstrates compliance with some specification, law, policy, restriction, or other rule specified by a regulatory agency</skos:definition>
 		<cmns-av:explanatoryNote>Such a report may be needed for licensing, monitoring, taxation, or for other purposes that demonstrate the integrity, fairness, safety, or other capacity of a given industry, organization, or product.</cmns-av:explanatoryNote>
 	</owl:Class>
 	

--- a/CMNS/RegulatoryAgencies.rdf
+++ b/CMNS/RegulatoryAgencies.rdf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-cxtid "https://www.omg.org/spec/Commons/ContextualIdentifiers/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
@@ -11,6 +10,7 @@
 	<!ENTITY cmns-prd "https://www.omg.org/spec/Commons/ProductsAndServices/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -21,7 +21,6 @@
 ]>
 <rdf:RDF xml:base="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-cxtid="https://www.omg.org/spec/Commons/ContextualIdentifiers/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
@@ -31,6 +30,7 @@
 	xmlns:cmns-prd="https://www.omg.org/spec/Commons/ProductsAndServices/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -44,7 +44,6 @@
 		<dct:abstract>This ontology defines general purpose concepts for representation of regulatory agencies, also known as regulatory authorities or regulators. It was derived from the FIBO Regulatory Agencies, Legal Capacity, and Jurisdictions ontologies and simplified/adapted for broader use.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -53,6 +52,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/RegulatoryAgencies/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -150,7 +150,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Undergoer"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-pts;isAPartyTo"/>
@@ -168,19 +168,19 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Actor"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-prd;issues"/>
+				<owl:someValuesFrom rdf:resource="&cmns-rga;License"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-pts;isAPartyTo"/>
 						<owl:someValuesFrom rdf:resource="&cmns-rga;License"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-prd;issues"/>
-				<owl:someValuesFrom rdf:resource="&cmns-rga;License"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>licensor</rdfs:label>

--- a/CMNS/RolesAndCompositions.rdf
+++ b/CMNS/RolesAndCompositions.rdf
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -11,11 +11,11 @@
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://www.omg.org/spec/Commons/Composites/"
+<rdf:RDF xml:base="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -23,9 +23,9 @@
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://www.omg.org/spec/Commons/Composites/">
-		<rdfs:label>Commons Composites Ontology</rdfs:label>
-		<dct:abstract>This ontology defines the high-level elements of a composition - relating something that is a specification for a &apos;whole&apos;, such as a product or recipe, to its ingredients or constituents, potentially with respect to some context-specific requirements.</dct:abstract>
+	<owl:Ontology rdf:about="https://www.omg.org/spec/Commons/RolesAndCompositions/">
+		<rdfs:label>Commons Roles and Compositions Ontology</rdfs:label>
+		<dct:abstract>This ontology defines the high-level things defining roles, which enable specification of the various participants in something, and the notion of a composition, i.e., relating something that is a specification for a &apos;whole&apos;, such as a product or recipe, to its ingredients or constituents, potentially with respect to some context-specific requirements.</dct:abstract>
 		<dct:contributor>Dean Allemang, Working Ontologist</dct:contributor>
 		<dct:contributor>Elisa Kendall, Thematix Partners LLC</dct:contributor>
 		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
@@ -34,7 +34,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/Composites/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/RolesAndCompositions/"/>
 		<skos:note>This ontology was derived from the Financial Industry Business Ontology (FIBO) and extended based on usage in other projects, such as the Pistoia Alliance Identification of Medicinal Products (IDMP) ontology project.</skos:note>
 		<cmns-av:copyright>Copyright (c) 2020-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2020-2023 Thematix Partners LLC</cmns-av:copyright>
@@ -43,7 +43,7 @@
 		<cmns-av:copyright>Copyright (c) 2023 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&cmns-cmp;Composition">
+	<owl:Class rdf:about="&cmns-rlcmp;Composition">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
@@ -52,8 +52,8 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;hasRole"/>
-				<owl:allValuesFrom rdf:resource="&cmns-cmp;Role"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;hasRole"/>
+				<owl:allValuesFrom rdf:resource="&cmns-rlcmp;Role"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -64,15 +64,15 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>composition</rdfs:label>
-		<dct:source>ISO/IEC 18384-1:2016, Information technology - Reference Architecture for Service Oriented Architecture (SOA RA) - Part 1: Terminology and concepts for SOA, clause 2.5 and ISO/IEC 18384-3:2016, Information technology - Reference Architecture for Service Oriented Architecture (SOA RA) - Part 3: Service Oriented Architecture ontology, clause 8.2</dct:source>
-		<skos:definition>result of assembling a collection of elements for a particular purpose</skos:definition>
-		<cmns-av:explanatoryNote>A composition may be considered a collection depending on whether or not the constituents of the composition are separable, and whether or not those constituents to have separate identity outside of the composition.</cmns-av:explanatoryNote>
-		<cmns-av:explanatoryNote>The elements of a composition may be defined based on the role that such elements play in the composition, such as the roles that various ingredients play in a recipe or pharmaceutical product.</cmns-av:explanatoryNote>
-		<cmns-av:usageNote>The properties hasConstituent and hasRole are included in value restrictions rather than via number restrictions to facilitate use of these properties in complex property chains and other axioms as needed for some applications.</cmns-av:usageNote>
+		<skos:definition>distinct thing resulting from bringing together other things, possibly in specific roles, for a particular purpose</skos:definition>
+		<cmns-av:adaptedFrom>ISO/IEC 18384-1:2016, Information technology - Reference Architecture for Service Oriented Architecture (SOA RA) - Part 1: Terminology and concepts for SOA, clause 2.5 and ISO/IEC 18384-3:2016, Information technology - Reference Architecture for Service Oriented Architecture (SOA RA) - Part 3: Service Oriented Architecture ontology, clause 8.2</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 19807-1:2019(en), Nanotechnologies - Magnetic nanomaterials - Part 1: Specification of characteristics and measurements for magnetic nanosuspensions, clause 3.4</cmns-av:adaptedFrom>
+		<cmns-av:explanatoryNote>The composition may be specified based on the roles that the things play in the composition, such as the roles that various ingredients play in a recipe or pharmaceutical product, and such things may or may not be transformed in some way through the process of combining them. Quantification including the nature and amount of each thing, potentially including the ratio of the quantities, may be required depending kind of composition.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>The properties hasConstituent and hasRole are included in value restrictions rather than via number restrictions to facilitate their use in complex property chains and other axioms as needed for some applications.</cmns-av:usageNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-cmp;FunctionalRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Role"/>
+	<owl:Class rdf:about="&cmns-rlcmp;FunctionalRole">
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:label>functional role</rdfs:label>
 		<skos:definition>role representing an underlying functionality that something, such as a person, organization, process, or service, is expected to perform or deliver</skos:definition>
 		<skos:note>Functional roles can be assigned to be performed during an act.</skos:note>
@@ -80,70 +80,70 @@
 		<cmns-av:adaptedFrom>ISO/IEC 19763-8:2015(en), Information technology - Metamodel framework for interoperability (MFI) - Part 8: Metamodel for role and goal model registration, clause 3.1.2</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-cmp;ProcessRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Role"/>
+	<owl:Class rdf:about="&cmns-rlcmp;ProcessRole">
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:label>process role</rdfs:label>
-		<dct:source>ISO 12651-2:2014(en), Electronic document management - Vocabulary - Part 2: Workflow management, clause 3.33</dct:source>
-		<skos:definition>mechanism that associates workflow participants to a collection of workflow activity(ies)</skos:definition>
+		<skos:definition>role that associates resources and participants to a structured set of activities involving various enterprise entities, that is designed and organised for a given purpose</skos:definition>
+		<cmns-av:adaptedFrom>ISO 12651-2:2014(en), Electronic document management - Vocabulary - Part 2: Workflow management, clause 3.33</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO 18629-1:2004(en), Industrial automation systems and integration - Process specification language - Part 1: Overview and basic principles</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-cmp;Role">
+	<owl:Class rdf:about="&cmns-rlcmp;Role">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>role</rdfs:label>
-		<skos:definition>named specific behavior of an entity participating in a particular context</skos:definition>
+		<skos:definition>named specific behavior of something participating in a particular context</skos:definition>
 		<cmns-av:adaptedFrom>ISO/IEC 19763-8:2015(en), Information technology - Metamodel framework for interoperability (MFI) - Part 8: Metamodel for role and goal model registration, clause 3.1.7</cmns-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&cmns-cmp;StructuralRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Role"/>
+	<owl:Class rdf:about="&cmns-rlcmp;StructuralRole">
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Role"/>
 		<rdfs:label>structural role</rdfs:label>
 		<dct:source>ISO 21298:2017(en), Health informatics - Functional and structural roles, clause 3.26</dct:source>
 		<skos:definition>role specifying relations between entities in the sense of competence, often reflecting organizational or structural relations (hierarchies)</skos:definition>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&cmns-cmp;hasRole">
+	<owl:ObjectProperty rdf:about="&cmns-rlcmp;hasRole">
 		<rdfs:label>has role</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:range rdf:resource="&cmns-rlcmp;Role"/>
 		<skos:definition>identifies something or someone playing a part in something, such as a composition</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-cmp;isManifestedIn">
+	<owl:ObjectProperty rdf:about="&cmns-rlcmp;isManifestedIn">
 		<rdfs:label>is manifested in</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-cmp;Role"/>
-		<owl:inverseOf rdf:resource="&cmns-cmp;manifests"/>
+		<rdfs:domain rdf:resource="&cmns-rlcmp;Role"/>
+		<owl:inverseOf rdf:resource="&cmns-rlcmp;manifests"/>
 		<skos:definition>indicates something in which the role is realized, appears, or occurs</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-cmp;isPlayedBy">
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
+	<owl:ObjectProperty rdf:about="&cmns-rlcmp;isPlayedBy">
 		<rdfs:label>is played by</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-cmp;Role"/>
-		<owl:inverseOf rdf:resource="&cmns-cmp;playsRole"/>
-		<skos:definition>indicates something or someone, such as a person, organization, or other element filling a role</skos:definition>
+		<rdfs:domain rdf:resource="&cmns-rlcmp;Role"/>
+		<owl:inverseOf rdf:resource="&cmns-rlcmp;playsRole"/>
+		<skos:definition>indicates something or someone, such as a person, organization, or other thing filling a role</skos:definition>
 		<skos:example>A party, counterparty, or third party to a contract is played by an organization or person; an issuer of a financial instrument is typically played by an organization; an ingredient in a recipe may be played by a substance.</skos:example>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-cmp;isRoleIn">
+	<owl:ObjectProperty rdf:about="&cmns-rlcmp;isRoleIn">
 		<rdfs:label>is role in</rdfs:label>
-		<rdfs:domain rdf:resource="&cmns-cmp;Role"/>
-		<owl:inverseOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:domain rdf:resource="&cmns-rlcmp;Role"/>
+		<owl:inverseOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<skos:definition>identifies something, such as a composition, situation, or contract, involving the role</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-cmp;manifests">
+	<owl:ObjectProperty rdf:about="&cmns-rlcmp;manifests">
 		<rdfs:label>manifests</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:range rdf:resource="&cmns-rlcmp;Role"/>
 		<skos:definition>indicates a role that realizes, displays, or shows something, typically in some context</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&cmns-cmp;playsRole">
+	<owl:ObjectProperty rdf:about="&cmns-rlcmp;playsRole">
 		<rdfs:label>plays role</rdfs:label>
-		<rdfs:range rdf:resource="&cmns-cmp;Role"/>
+		<rdfs:range rdf:resource="&cmns-rlcmp;Role"/>
 		<skos:definition>indicates a part that someone or something plays under some circumstance</skos:definition>
 		<skos:example>an organization may play the role of employer, issuer, regulatory agency, bank, custodian, manufacturer, vendor, etc.; a person may play the role of employee, examiner, banker, seller, buyer, etc.</skos:example>
 	</owl:ObjectProperty>

--- a/CMNS/StatisticalMeasures.rdf
+++ b/CMNS/StatisticalMeasures.rdf
@@ -61,7 +61,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230601/Statistics/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/Statistics/"/>
 		<skos:note>This ontology was originally designed for and has been adapted from the Financial Industry Business Ontology (FIBO) Analytics Ontology.</skos:note>
 		<cmns-av:copyright>Copyright (c) 2013-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2013-2023 Object Management Group, Inc.</cmns-av:copyright>
@@ -253,7 +253,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-stat;NumericIndexValue">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;isValueOf"/>
@@ -321,7 +321,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&cmns-stat;RatioValue">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasArgument"/>

--- a/CMNS/catalog-v001.xml
+++ b/CMNS/catalog-v001.xml
@@ -5,7 +5,7 @@
 	<uri id="15a1efae-4df1-4736-9b8a-adf3e392fe3d" name="https://www.omg.org/spec/Commons/Classifiers/" uri="./Classifiers.rdf" />
 	<uri id="9a8379a1-2ec9-477c-b4a6-0cf746afacc8" name="https://www.omg.org/spec/Commons/CodesAndCodeSets/" uri="./CodesAndCodeSets.rdf" />
 	<uri id="479347ac-ee5e-4ac2-9565-65285dece0ca" name="https://www.omg.org/spec/Commons/Collections/" uri="./Collections.rdf" />
-	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="./Composites.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="./RolesAndCompositions.rdf"/>
 	<uri id="236fa49c-2305-4cee-b3b4-8b11932b69b4" name="https://www.omg.org/spec/Commons/ContextualDesignators/" uri="./ContextualDesignators.rdf" />
 	<uri id="97fe73fd-23ac-499f-aa10-9ffd83db1220" name="https://www.omg.org/spec/Commons/ContextualIdentifiers/" uri="./ContextualIdentifiers.rdf" />
 	<uri id="c7507de1-ae84-4bb5-b5a8-ff4a1f5e751b" name="https://www.omg.org/spec/Commons/DatesAndTimes/" uri="./DatesAndTimes.rdf" />

--- a/CMNS/catalog-v001.xml
+++ b/CMNS/catalog-v001.xml
@@ -5,7 +5,7 @@
 	<uri id="15a1efae-4df1-4736-9b8a-adf3e392fe3d" name="https://www.omg.org/spec/Commons/Classifiers/" uri="./Classifiers.rdf" />
 	<uri id="9a8379a1-2ec9-477c-b4a6-0cf746afacc8" name="https://www.omg.org/spec/Commons/CodesAndCodeSets/" uri="./CodesAndCodeSets.rdf" />
 	<uri id="479347ac-ee5e-4ac2-9565-65285dece0ca" name="https://www.omg.org/spec/Commons/Collections/" uri="./Collections.rdf" />
-	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Composites/" uri="./Composites.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="./Composites.rdf"/>
 	<uri id="236fa49c-2305-4cee-b3b4-8b11932b69b4" name="https://www.omg.org/spec/Commons/ContextualDesignators/" uri="./ContextualDesignators.rdf" />
 	<uri id="97fe73fd-23ac-499f-aa10-9ffd83db1220" name="https://www.omg.org/spec/Commons/ContextualIdentifiers/" uri="./ContextualIdentifiers.rdf" />
 	<uri id="c7507de1-ae84-4bb5-b5a8-ff4a1f5e751b" name="https://www.omg.org/spec/Commons/DatesAndTimes/" uri="./DatesAndTimes.rdf" />

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -242,7 +242,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateDenominatorInNorvascPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine besylate denominator in Norvasc presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Tablet"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
@@ -278,7 +278,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateNumeratorInNorvascPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine besylate numerator in Norvasc presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">6.94</cmns-qtu:hasNumericValue>
@@ -333,14 +333,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineDenominatorInAmlodipineEMCPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine denominator in Amlodipine EMC presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Tablet"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineDenominatorInNorvascPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine denominator in Norvasc presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Tablet"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
@@ -426,7 +426,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateDenominatorInAmlodipineEMCPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine mesylate monohydrate denominator in Amlodipine EMC presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Tablet"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
@@ -464,7 +464,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateNumeratorInAmlodipineEMCPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine mesylate monohydrate numerator in Amlodipine EMC presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">6.41</cmns-qtu:hasNumericValue>
@@ -526,14 +526,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineNumeratorInAmlodipineEMCPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine numerator in Amlodipine EMC presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">5.0</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineNumeratorInNorvascPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>amlodipine numerator in Norvasc presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">5.0</cmns-qtu:hasNumericValue>

--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -2,7 +2,6 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
@@ -15,6 +14,7 @@
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-amp "https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/">
@@ -46,7 +46,6 @@
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
@@ -59,6 +58,7 @@
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-amp="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/"
@@ -107,7 +107,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
@@ -119,6 +118,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
@@ -172,9 +172,9 @@
 		<rdf:type rdf:resource="&idmp-sub;ActiveMoietyRole"/>
 		<rdfs:label>amlodipine as active moiety</rdfs:label>
 		<skos:definition>amlodipine in the role of an active moiety</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;Amlodipine"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&idmp-narga;RegulatoryContext-FoodAndDrugAdministrationGeneral"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&cmns-ge-euj;EuropeanUnionJurisdiction"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;Amlodipine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineAsReferenceStrengthInAmlodipineEMCStrength">
@@ -202,7 +202,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineAsReferenceSubstance">
 		<rdf:type rdf:resource="&idmp-mprd;ActiveIngredientActiveMoietyBasisOfStrength"/>
 		<rdfs:label>amlodipine as reference substance</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;Amlodipine"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;Amlodipine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylate">
@@ -228,17 +228,17 @@
 		<skos:definition>amlodipine besylate in the role of an active ingredient in the pharmaceutical product, Norvasc, where another substance acts as the reference basis of strength, namely, amlodipine</skos:definition>
 		<idmp-mprd:hasReferenceStrength rdf:resource="&idmp-amp;AmlodipineAsReferenceStrengthInNorvascPresentationStrength"/>
 		<idmp-mprd:hasStrength rdf:resource="&idmp-amp;AmlodipineBesylatePresentationStrengthInNorvasc"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;AmlodipineBesylate"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-amp;NorvascComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;AmlodipineBesylate"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateComposition">
 		<rdf:type rdf:resource="&idmp-sub;SubstanceComposition"/>
 		<rdfs:label>amlodipine besylate composition</rdfs:label>
-		<cmns-cmp:hasRole rdf:resource="&idmp-amp;AmlodipineAsActiveMoiety"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&idmp-narga;RegulatoryContext-FoodAndDrugAdministrationGeneral"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&cmns-ge-euj;EuropeanUnionJurisdiction"/>
 		<cmns-dsg:defines rdf:resource="&idmp-amp;AmlodipineBesylate"/>
+		<cmns-rlcmp:hasRole rdf:resource="&idmp-amp;AmlodipineAsActiveMoiety"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylateDenominatorInNorvascPresentationStrength">
@@ -405,8 +405,8 @@
 		<skos:definition>amlodipine mesylate monohydrate in the role of an active ingredient, where amlodipine acts as the reference basis of strength</skos:definition>
 		<idmp-mprd:hasReferenceStrength rdf:resource="&idmp-amp;AmlodipineAsReferenceStrengthInAmlodipineEMCStrength"/>
 		<idmp-mprd:hasStrength rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrateAsActiveIngredientInAmlodipineEMCPresentationStrength"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrate"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-amp;AmlodipineEMCComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrate"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateAsActiveIngredientInAmlodipineEMCPresentationStrength">
@@ -420,9 +420,9 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateComposition">
 		<rdf:type rdf:resource="&idmp-sub;SubstanceComposition"/>
 		<rdfs:label>amlodipine mesylate monohydrate composition</rdfs:label>
-		<cmns-cmp:hasRole rdf:resource="&idmp-amp;AmlodipineAsActiveMoiety"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&idmp-narga;RegulatoryContext-FoodAndDrugAdministrationGeneral"/>
 		<cmns-dsg:defines rdf:resource="&idmp-amp;AmlodipineMesylateMonohydrate"/>
+		<cmns-rlcmp:hasRole rdf:resource="&idmp-amp;AmlodipineAsActiveMoiety"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineMesylateMonohydrateDenominatorInAmlodipineEMCPresentationStrength">
@@ -582,8 +582,8 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;KentPharmaAsManufacturer">
 		<rdf:type rdf:resource="&idmp-sub;Manufacturer"/>
 		<rdfs:label>Kent Pharma UK Ltd. as manufacturer</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;KentPharmaUKLtd"/>
 		<cmns-prd:produces rdf:resource="&idmp-amp;AmlodipineEMCMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;KentPharmaUKLtd"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;KentPharmaUKLtd">
@@ -639,23 +639,23 @@
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedMedicinalProduct"/>
 		<rdfs:label>Norvasc as authorized medicinal product in Denmark</rdfs:label>
 		<idmp-mprd:hasAuthorization rdf:resource="&idmp-amp;NorvascMarketingAuthorizationInDenmark"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascPackagedMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascPackagedMedicinalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascAsAuthorizedMedicinalProductInGermany">
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedMedicinalProduct"/>
 		<rdfs:label>Norvasc as authorized medicinal product in Germany</rdfs:label>
 		<idmp-mprd:hasAuthorization rdf:resource="&idmp-amp;NorvascMarketingAuthorizationInGermany"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascPackagedMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascPackagedMedicinalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascAsStartingMaterial">
 		<rdf:type rdf:resource="&idmp-sub;StartingMaterialRole"/>
 		<rdfs:label>norvasc tablets as starting material</rdfs:label>
-		<cmns-cmp:isManifestedIn rdf:resource="&idmp-amp;NorvascPackageTablets"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
+		<cmns-rlcmp:isManifestedIn rdf:resource="&idmp-amp;NorvascPackageTablets"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBlister">
@@ -669,14 +669,14 @@
 		<rdf:type rdf:resource="&idmp-mprd;ImmediateContainer"/>
 		<rdfs:label>Norvasc blister As Immediate Container</rdfs:label>
 		<idmp-mprd:immediatelyContains rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBlister"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBlister"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBlisterAsStartingMaterial">
 		<rdf:type rdf:resource="&idmp-sub;StartingMaterialRole"/>
 		<rdfs:label>Norvasc blisters as starting material</rdfs:label>
-		<cmns-cmp:isManifestedIn rdf:resource="&idmp-amp;NorvascPackageTablets"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBlister"/>
+		<cmns-rlcmp:isManifestedIn rdf:resource="&idmp-amp;NorvascPackageTablets"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBlister"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBlisterPackagingMethod">
@@ -696,14 +696,14 @@
 		<rdf:type rdf:resource="&idmp-mprd;OuterPackaging"/>
 		<rdfs:label>Norvasc box as outer packaging</rdfs:label>
 		<idmp-mprd:immediatelyContains rdf:resource="&idmp-amp;NorvascBlister"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBox"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBox"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBoxConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituency"/>
 		<rdfs:label>Norvasc box constituency</rdfs:label>
-		<cmns-cmp:hasRole rdf:resource="&idmp-amp;NorvascBlisterAsImmediateContainer"/>
 		<cmns-dsg:defines rdf:resource="&idmp-amp;NorvascBox"/>
+		<cmns-rlcmp:hasRole rdf:resource="&idmp-amp;NorvascBlisterAsImmediateContainer"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascComposition">
@@ -848,8 +848,8 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascPackagedMedicinalProductConstituency">
 		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituency"/>
 		<rdfs:label>Norvasc packaged medicinal product constituency</rdfs:label>
-		<cmns-cmp:hasRole rdf:resource="&idmp-amp;NorvascBoxAsOuterPackaging"/>
 		<cmns-dsg:defines rdf:resource="&idmp-amp;NorvascPackagedMedicinalProduct"/>
+		<cmns-rlcmp:hasRole rdf:resource="&idmp-amp;NorvascBoxAsOuterPackaging"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascTherapeuticIndicationTextInDenmark">
@@ -891,7 +891,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;PfizerApSAsMarketingAuthorizationHolder">
 		<rdf:type rdf:resource="&idmp-mprd;MarketingAuthorizationHolder"/>
 		<rdfs:label>Pfizer ApS as marketing authorization holder</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;PfizerApS"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;PfizerApS"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;PfizerGmbH">
@@ -903,7 +903,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;PfizerGmbHAsMarketingAuthorizationHolder">
 		<rdf:type rdf:resource="&idmp-mprd;MarketingAuthorizationHolder"/>
 		<rdfs:label>Pfizer GmbH as marketing authorization holder</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;PfizerGmbH"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;PfizerGmbH"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;PfizerInc">
@@ -915,8 +915,8 @@
 	<owl:NamedIndividual rdf:about="&idmp-amp;PfizerLaboratoriesAsManufacturer">
 		<rdf:type rdf:resource="&idmp-sub;Manufacturer"/>
 		<rdfs:label>Pfizer Laboratories as manufacturer</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;PfizerInc"/>
 		<cmns-prd:produces rdf:resource="&idmp-amp;Norvasc-ManufacturedItem"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;PfizerInc"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;PolyvinalChlorideCommonName">

--- a/EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf
+++ b/EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-ge-euj "https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-amp "https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/">
@@ -29,13 +29,13 @@
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/EuropeanUnionClinicalTrialsRegister/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-ge-euj="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-amp="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/"
@@ -69,12 +69,12 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
@@ -113,7 +113,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;AliskirenAsInvestigationalMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<rdfs:label>aliskiren as investigational medicinal product</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-euctr;AliskirenMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-euctr;AliskirenMedicinalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;AliskirenMedicinalProduct">
@@ -125,13 +125,13 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumHydroxideAsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>aluminum hydroxide as an active ingredient</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/bba69d15-f55c-4f0d-8e24-e61b60f2a115"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/bba69d15-f55c-4f0d-8e24-e61b60f2a115"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;AluminumPhosphateAsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>Aluminum Phosphate as an active ingredient</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/beaecfe8-eccb-44ab-b842-ae2cc60ff3e4"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/beaecfe8-eccb-44ab-b842-ae2cc60ff3e4"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;ClinicalTrialAuthorization-2004-002410-11">
@@ -178,26 +178,26 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;DynavaxTechnologiesCorporationAsAuthorizedParty">
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedParty"/>
 		<rdfs:label>Dynavax Technologies Corporation as authorized party</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-euctr;DynavaxTechnologiesCorporation"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-euctr;DynavaxTechnologiesCorporation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;DynavaxTechnologiesCorporationAsMarketingAuthorizationHolder">
 		<rdf:type rdf:resource="&idmp-mprd;MarketingAuthorizationHolder"/>
 		<rdfs:label>Dynavax Technologies Corporation as marketing authorization holder</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-euctr;DynavaxTechnologiesCorporation"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-euctr;DynavaxTechnologiesCorporation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;EngerixBAsAuthorizedMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedMedicinalProduct"/>
 		<rdfs:label>Engerix B as authorized medicinal product</rdfs:label>
 		<idmp-mprd:hasAuthorization rdf:resource="&idmp-euctr;EngerixBMarketingAuthorizationInEuropeanUnion"/>
-		<cmns-cmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/referrals/engerix-b"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/referrals/engerix-b"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;EngerixBAsInvestigationalMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<rdfs:label>Engerix B as investigational medicinal product</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/referrals/engerix-b"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/referrals/engerix-b"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;EngerixBMarketingAuthorizationInEuropeanUnion">
@@ -241,13 +241,13 @@
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedMedicinalProduct"/>
 		<rdfs:label>Fedrix as authorized medicinal product</rdfs:label>
 		<idmp-mprd:hasAuthorization rdf:resource="&idmp-euctr;FendrixMarketingAuthorizationInEuropeanUnion"/>
-		<cmns-cmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/EPAR/fendrix"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/EPAR/fendrix"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;FendrixAsInvestigationalMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<rdfs:label>Fedrix as investigational medicinal product</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/EPAR/fendrix"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/EPAR/fendrix"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;FendrixMarketingAuthorizationInEuropeanUnion">
@@ -270,7 +270,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;GlaxoSmithKlineBiologicalsAsMarketingAuthorizationHolder">
 		<rdf:type rdf:resource="&idmp-mprd;MarketingAuthorizationHolder"/>
 		<rdfs:label>GlaxoSmithKline Biologicals as marketing authorization holder</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-euctr;GlaxoSmithKlineBiologicalsSA"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-euctr;GlaxoSmithKlineBiologicalsSA"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;GlaxoSmithKlineBiologicalsSA">
@@ -281,13 +281,13 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;HepatitisBSurfaceAntigenAsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>hepatitis B surface antigen as an active ingredient</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/e67c9314-1e17-4876-a745-47f27c2169e6"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/e67c9314-1e17-4876-a745-47f27c2169e6"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;HeplisavAsInvestigationalMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<rdfs:label>HEPLISAV as investigational medicinal product</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/withdrawn-applications/heplisav"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://www.ema.europa.eu/en/medicines/human/withdrawn-applications/heplisav"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;HeplisavPharmaceuticalProduct">
@@ -315,13 +315,13 @@
 	<owl:NamedIndividual rdf:about="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/EuropeanUnionClinicalTrialsRegister/MonophosphorylLipidA-1-3-O-desacyl-4&apos;AsActiveIngredient">
 		<rdf:type rdf:resource="&idmp-sub;ActiveIngredient"/>
 		<rdfs:label>1-3-O-desacyl-4&apos; monophosphoryl lipid A as an active ingredient</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/c9925b82-5d36-4e00-b54d-d3b7189625de"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="https://gsrs.ncats.nih.gov/api/v1/substances/c9925b82-5d36-4e00-b54d-d3b7189625de"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;NorvascAsInvestigationalMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<rdfs:label>Norvasc as investigational medicinal product</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascMedicinalProduct"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;NovartisPharmaServicesAG">
@@ -332,7 +332,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;NovartisPharmaServicesAGAuthorizedParty">
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedParty"/>
 		<rdfs:label>Novartis Pharma Services AG as authorized party</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-euctr;NovartisPharmaServicesAG"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-euctr;NovartisPharmaServicesAG"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;SheffieldTeachingHospitalsNHSFoundation">
@@ -343,13 +343,13 @@
 	<owl:NamedIndividual rdf:about="&idmp-euctr;SheffieldTeachingHospitalsNHSFoundationTrustAuthorizedParty">
 		<rdf:type rdf:resource="&idmp-mprd;AuthorizedParty"/>
 		<rdfs:label>Sheffield Teaching Hospitals NHS Foundation Trust as authorized party</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-euctr;SheffieldTeachingHospitalsNHSFoundation"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-euctr;SheffieldTeachingHospitalsNHSFoundation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-euctr;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjectionAsInvestigationalMedicinalProduct">
 		<rdf:type rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<rdfs:label>Terlipressin Acetate SUN 0.12Mg Per Ml Solution For Injection as investigational medicinal product</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjection"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjection"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://www.clinicaltrialsregister.eu/ctr-search/trial/2004-002410-11/DE">

--- a/EXT/Examples/QlairaExample.rdf
+++ b/EXT/Examples/QlairaExample.rdf
@@ -170,16 +170,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -193,16 +193,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -216,16 +216,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -239,16 +239,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -262,16 +262,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -285,16 +285,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -308,16 +308,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -331,16 +331,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -355,16 +355,16 @@
 		<idmp-mprd:hasReferenceStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">3.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasReferenceStrength>
@@ -379,16 +379,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -402,16 +402,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -451,16 +451,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -474,16 +474,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -497,16 +497,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -520,16 +520,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -543,16 +543,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -566,16 +566,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -589,16 +589,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -612,16 +612,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -635,16 +635,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -658,16 +658,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -681,16 +681,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -751,16 +751,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -774,16 +774,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -797,16 +797,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -820,16 +820,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -843,16 +843,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -866,16 +866,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -889,16 +889,16 @@
 		<idmp-mprd:hasStrength>
 			<idmp-mprd:Strength>
 				<cmns-qtu:hasDenominator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasDenominator>
 				<cmns-qtu:hasNumerator>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">50.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
@@ -948,10 +948,10 @@
 		<cmns-col:hasConstituent>
 			<cmns-col:Constituent>
 				<idmp-mprd:hasPackageItemQuantity>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</idmp-mprd:hasPackageItemQuantity>
 				<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 			</cmns-col:Constituent>
@@ -994,10 +994,10 @@
 		<cmns-col:hasConstituent>
 			<cmns-col:Constituent>
 				<idmp-mprd:hasPackageItemQuantity>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">3.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</idmp-mprd:hasPackageItemQuantity>
 				<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 			</cmns-col:Constituent>
@@ -1040,10 +1040,10 @@
 		<cmns-col:hasConstituent>
 			<cmns-col:Constituent>
 				<idmp-mprd:hasPackageItemQuantity>
-					<cmns-qtu:QuantityValue>
+					<cmns-qtu:ScalarQuantityValue>
 						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109"/>
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">6.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:QuantityValue>
+					</cmns-qtu:ScalarQuantityValue>
 				</idmp-mprd:hasPackageItemQuantity>
 				<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 			</cmns-col:Constituent>
@@ -1090,10 +1090,10 @@
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent1">
 		<rdf:type rdf:resource="&cmns-col;Constituent"/>
 		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:QuantityValue>
+			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:QuantityValue>
+			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
 		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem1"/>
 	</owl:NamedIndividual>
@@ -1101,10 +1101,10 @@
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent2">
 		<rdf:type rdf:resource="&cmns-col;Constituent"/>
 		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:QuantityValue>
+			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">5.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:QuantityValue>
+			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
 		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem2"/>
 	</owl:NamedIndividual>
@@ -1112,10 +1112,10 @@
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent3">
 		<rdf:type rdf:resource="&cmns-col;Constituent"/>
 		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:QuantityValue>
+			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">17.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:QuantityValue>
+			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
 		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem3"/>
 	</owl:NamedIndividual>
@@ -1123,10 +1123,10 @@
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent4">
 		<rdf:type rdf:resource="&cmns-col;Constituent"/>
 		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:QuantityValue>
+			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:QuantityValue>
+			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
 		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem4"/>
 	</owl:NamedIndividual>
@@ -1134,10 +1134,10 @@
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent5">
 		<rdf:type rdf:resource="&cmns-col;Constituent"/>
 		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:QuantityValue>
+			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:QuantityValue>
+			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
 		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem5"/>
 	</owl:NamedIndividual>

--- a/EXT/Examples/QlairaExample.rdf
+++ b/EXT/Examples/QlairaExample.rdf
@@ -2,7 +2,6 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
 	<!ENTITY cmns-id "https://www.omg.org/spec/Commons/Identifiers/">
@@ -10,6 +9,7 @@
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
@@ -31,7 +31,6 @@
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/QlairaExample/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
 	xmlns:cmns-id="https://www.omg.org/spec/Commons/Identifiers/"
@@ -39,6 +38,7 @@
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
@@ -69,13 +69,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/20230801/Examples/QlairaExample/"/>
 		<skos:editorialNote>Concepts or properties starting with the https://spec.pistoiaalliance.org/idmp/ontology/ISO/ExtensionTBD/... do indicate that this requires extension to the current IDMP-O version.</skos:editorialNote>
@@ -147,11 +147,11 @@
 		<cmns-col:comprises rdf:resource="&spor-p;00006006-3"/>
 		<cmns-col:comprises rdf:resource="&spor-p;00006006-4"/>
 		<cmns-col:comprises rdf:resource="&spor-p;00006006-5"/>
-		<cmns-cmp:playsRole>
+		<cmns-id:isIdentifiedBy rdf:resource="https://data.pistoiaalliance.org/idmp/EMA_MPID/IE-100000833-00000003"/>
+		<cmns-rlcmp:playsRole>
 			<idmp-mprd:AuthorizedMedicinalProduct>
 			</idmp-mprd:AuthorizedMedicinalProduct>
-		</cmns-cmp:playsRole>
-		<cmns-id:isIdentifiedBy rdf:resource="https://data.pistoiaalliance.org/idmp/EMA_MPID/IE-100000833-00000003"/>
+		</cmns-rlcmp:playsRole>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1">
@@ -183,8 +183,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000076135"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000076135"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000076427">
@@ -206,8 +206,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000076427"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000076427"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000076429">
@@ -229,8 +229,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000076429"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000076429"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000078041">
@@ -252,8 +252,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000078041"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000078041"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000078762">
@@ -275,8 +275,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000078762"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000078762"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000080121">
@@ -298,8 +298,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000080121"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000080121"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000087105">
@@ -321,8 +321,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000087105"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000087105"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000088586">
@@ -344,8 +344,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000088586"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000088586"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000090493">
@@ -369,8 +369,8 @@
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasReferenceStrength>
 		<idmp-mprd:hasReferenceSubstance rdf:resource="&spor-s;100000090493"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000090493"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000090493"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000092217">
@@ -392,8 +392,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000092217"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000092217"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-I-100000093305">
@@ -415,8 +415,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000093305"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000093305"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-1-ProductComposition">
@@ -464,8 +464,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000076135"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000076135"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000076427">
@@ -487,8 +487,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000076427"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000076427"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000078041">
@@ -510,8 +510,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000078041"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000078041"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000078762">
@@ -533,8 +533,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000078762"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000078762"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000080121">
@@ -556,8 +556,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000080121"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000080121"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000087105">
@@ -579,8 +579,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000087105"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000087105"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000087133">
@@ -602,8 +602,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000087133"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000087133"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000088586">
@@ -625,8 +625,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000088586"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000088586"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000090493">
@@ -648,8 +648,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000090493"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000090493"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000092217">
@@ -671,8 +671,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000092217"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000092217"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-I-100000093305">
@@ -694,8 +694,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000093305"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-2-MI-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000093305"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-2-MI-ProductComposition">
@@ -738,11 +738,11 @@
 		<idmp-x:hasAdministrableDoseForm rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000004/terms/100000073665"/>
 		<idmp-uom:hasUnitOfPresentation rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152"/>
 		<cmns-col:isIncludedIn rdf:resource="&spor-p;00006006"/>
-		<cmns-cmp:playsRole>
+		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;00006006-5-ProductComposition"/>
+		<cmns-rlcmp:playsRole>
 			<idmp-mprd:Placebo>
 			</idmp-mprd:Placebo>
-		</cmns-cmp:playsRole>
-		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;00006006-5-ProductComposition"/>
+		</cmns-rlcmp:playsRole>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000076135">
@@ -764,8 +764,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000076135"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000076135"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000078762">
@@ -787,8 +787,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000078762"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000078762"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000080121">
@@ -810,8 +810,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000080121"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000080121"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000087105">
@@ -833,8 +833,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000087105"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000087105"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000088586">
@@ -856,8 +856,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000088586"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000088586"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000092217">
@@ -879,8 +879,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000092217"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000092217"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-I-100000093305">
@@ -902,8 +902,8 @@
 				</cmns-qtu:hasNumerator>
 			</idmp-mprd:Strength>
 		</idmp-mprd:hasStrength>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-s;100000093305"/>
 		<cmns-pts:isRealizedIn rdf:resource="&spor-p;00006006-1-ProductComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-s;100000093305"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/00006006-5-ProductComposition">
@@ -935,15 +935,15 @@
 		<idmp-mprd:contains rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 		<idmp-mprd:isContainedIn rdf:resource="&spor-p;IE-100000833-00000003-0001"/>
 		<cmns-col:comprises rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003529"/>
-		<cmns-cmp:playsRole>
+		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-0001-1-Constituency"/>
+		<cmns-rlcmp:playsRole>
 			<idmp-mprd:OuterPackaging>
 			</idmp-mprd:OuterPackaging>
-		</cmns-cmp:playsRole>
-		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-0001-1-Constituency"/>
+		</cmns-rlcmp:playsRole>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-0001-1-Constituency">
-		<rdf:type rdf:resource="&cmns-cmp;Composition"/>
+		<rdf:type rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:label>Qlaira, 1 x 28 film-coated tablets (Box Constituency)</rdfs:label>
 		<cmns-col:hasConstituent>
 			<cmns-col:Constituent>
@@ -953,7 +953,7 @@
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
 					</cmns-qtu:ScalarQuantityValue>
 				</idmp-mprd:hasPackageItemQuantity>
-				<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
+				<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 			</cmns-col:Constituent>
 		</cmns-col:hasConstituent>
 		<cmns-dsg:defines rdf:resource="&spor-p;IE-100000833-00000003-0001-1"/>
@@ -981,15 +981,15 @@
 		<idmp-mprd:contains rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 		<idmp-mprd:isContainedIn rdf:resource="&spor-p;IE-100000833-00000003-0002"/>
 		<cmns-col:comprises rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003529"/>
-		<cmns-cmp:playsRole>
+		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-0002-1-Constituency"/>
+		<cmns-rlcmp:playsRole>
 			<idmp-mprd:OuterPackaging>
 			</idmp-mprd:OuterPackaging>
-		</cmns-cmp:playsRole>
-		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-0002-1-Constituency"/>
+		</cmns-rlcmp:playsRole>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-0002-1-Constituency">
-		<rdf:type rdf:resource="&cmns-cmp;Composition"/>
+		<rdf:type rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:label>Qlaira, 3 x 28 film-coated tablets (Box Constituency)</rdfs:label>
 		<cmns-col:hasConstituent>
 			<cmns-col:Constituent>
@@ -999,7 +999,7 @@
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">3.0</cmns-qtu:hasNumericValue>
 					</cmns-qtu:ScalarQuantityValue>
 				</idmp-mprd:hasPackageItemQuantity>
-				<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
+				<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 			</cmns-col:Constituent>
 		</cmns-col:hasConstituent>
 		<cmns-dsg:defines rdf:resource="&spor-p;IE-100000833-00000003-0002-1"/>
@@ -1027,15 +1027,15 @@
 		<idmp-mprd:contains rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 		<idmp-mprd:isContainedIn rdf:resource="&spor-p;IE-100000833-00000003-0003"/>
 		<cmns-col:comprises rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003529"/>
-		<cmns-cmp:playsRole>
+		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-0003-1-Constituency"/>
+		<cmns-rlcmp:playsRole>
 			<idmp-mprd:OuterPackaging>
 			</idmp-mprd:OuterPackaging>
-		</cmns-cmp:playsRole>
-		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-0003-1-Constituency"/>
+		</cmns-rlcmp:playsRole>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-0003-1-Constituency">
-		<rdf:type rdf:resource="&cmns-cmp;Composition"/>
+		<rdf:type rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:label>Qlaira, 6 x 28 film-coated tablets (Box Constituency)</rdfs:label>
 		<cmns-col:hasConstituent>
 			<cmns-col:Constituent>
@@ -1045,7 +1045,7 @@
 						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">6.0</cmns-qtu:hasNumericValue>
 					</cmns-qtu:ScalarQuantityValue>
 				</idmp-mprd:hasPackageItemQuantity>
-				<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
+				<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-Blister"/>
 			</cmns-col:Constituent>
 		</cmns-col:hasConstituent>
 		<cmns-dsg:defines rdf:resource="&spor-p;IE-100000833-00000003-0003-1"/>
@@ -1071,11 +1071,11 @@
 		<idmp-mprd:isContainedIn rdf:resource="&spor-p;IE-100000833-00000003-0003-1"/>
 		<cmns-col:comprises rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003200"/>
 		<cmns-col:comprises rdf:resource="https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003222"/>
-		<cmns-cmp:playsRole>
+		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-BlisterConsituency"/>
+		<cmns-rlcmp:playsRole>
 			<idmp-mprd:ImmediateContainer>
 			</idmp-mprd:ImmediateContainer>
-		</cmns-cmp:playsRole>
-		<cmns-dsg:isDefinedIn rdf:resource="&spor-p;IE-100000833-00000003-BlisterConsituency"/>
+		</cmns-rlcmp:playsRole>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituency">
@@ -1095,7 +1095,7 @@
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem1"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem1"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent2">
@@ -1106,7 +1106,7 @@
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">5.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem2"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem2"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent3">
@@ -1117,7 +1117,7 @@
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">17.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem3"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem3"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent4">
@@ -1128,7 +1128,7 @@
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem4"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem4"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent5">
@@ -1139,7 +1139,7 @@
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-cmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem5"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&spor-p;IE-100000833-00000003-ManufacturedItem5"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-ManufacturedItem1">

--- a/EXT/Examples/QlairaExample.ttl
+++ b/EXT/Examples/QlairaExample.ttl
@@ -190,12 +190,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -213,12 +213,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -236,12 +236,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -259,12 +259,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -282,12 +282,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -305,12 +305,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -328,12 +328,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -351,12 +351,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -375,12 +375,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasReferenceStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "3.0"^^xsd:decimal ;
 		] ;
@@ -399,12 +399,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -422,12 +422,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -479,12 +479,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -502,12 +502,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -525,12 +525,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -548,12 +548,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -571,12 +571,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -594,12 +594,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -617,12 +617,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -640,12 +640,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -663,12 +663,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -686,12 +686,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -709,12 +709,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 		] ;
@@ -792,12 +792,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -815,12 +815,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -838,12 +838,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -861,12 +861,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -884,12 +884,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -907,12 +907,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -930,12 +930,12 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:hasStrength [
 		a idmp-mprd:Strength ;
 		cmns-qtu:hasDenominator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 		cmns-qtu:hasNumerator [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/100000110633/terms/100000110655> ;
 			cmns-qtu:hasNumericValue "50.0"^^xsd:decimal ;
 		] ;
@@ -999,7 +999,7 @@ idmp-x:hasLegalStatusOfSupply
 	cmns-col:hasConstituent [
 		a cmns-col:Constituent ;
 		idmp-mprd:hasPackageItemQuantity [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
@@ -1054,7 +1054,7 @@ idmp-x:hasLegalStatusOfSupply
 	cmns-col:hasConstituent [
 		a cmns-col:Constituent ;
 		idmp-mprd:hasPackageItemQuantity [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109> ;
 			cmns-qtu:hasNumericValue "3.0"^^xsd:decimal ;
 		] ;
@@ -1109,7 +1109,7 @@ idmp-x:hasLegalStatusOfSupply
 	cmns-col:hasConstituent [
 		a cmns-col:Constituent ;
 		idmp-mprd:hasPackageItemQuantity [
-			a cmns-qtu:QuantityValue ;
+			a cmns-qtu:ScalarQuantityValue ;
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109> ;
 			cmns-qtu:hasNumericValue "6.0"^^xsd:decimal ;
 		] ;
@@ -1174,7 +1174,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-col:Constituent
 		;
 	idmp-mprd:hasManufacturedItemQuantity [
-		a cmns-qtu:QuantityValue ;
+		a cmns-qtu:ScalarQuantityValue ;
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 	] ;
@@ -1187,7 +1187,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-col:Constituent
 		;
 	idmp-mprd:hasManufacturedItemQuantity [
-		a cmns-qtu:QuantityValue ;
+		a cmns-qtu:ScalarQuantityValue ;
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "5.0"^^xsd:decimal ;
 	] ;
@@ -1200,7 +1200,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-col:Constituent
 		;
 	idmp-mprd:hasManufacturedItemQuantity [
-		a cmns-qtu:QuantityValue ;
+		a cmns-qtu:ScalarQuantityValue ;
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "17.0"^^xsd:decimal ;
 	] ;
@@ -1213,7 +1213,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-col:Constituent
 		;
 	idmp-mprd:hasManufacturedItemQuantity [
-		a cmns-qtu:QuantityValue ;
+		a cmns-qtu:ScalarQuantityValue ;
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 	] ;
@@ -1226,7 +1226,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-col:Constituent
 		;
 	idmp-mprd:hasManufacturedItemQuantity [
-		a cmns-qtu:QuantityValue ;
+		a cmns-qtu:ScalarQuantityValue ;
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 	] ;

--- a/EXT/Examples/QlairaExample.ttl
+++ b/EXT/Examples/QlairaExample.ttl
@@ -6,7 +6,7 @@
 # imports: https://www.omg.org/spec/Commons/AnnotationVocabulary/
 # imports: https://www.omg.org/spec/Commons/Classifiers/
 # imports: https://www.omg.org/spec/Commons/Collections/
-# imports: https://www.omg.org/spec/Commons/Composites/
+# imports: https://www.omg.org/spec/Commons/RolesAndCompositions/
 # imports: https://www.omg.org/spec/Commons/Designators/
 # imports: https://www.omg.org/spec/Commons/Identifiers/
 # imports: https://www.omg.org/spec/Commons/PartiesAndSituations/
@@ -19,7 +19,7 @@
 @prefix cmns-av: <https://www.omg.org/spec/Commons/AnnotationVocabulary/> .
 @prefix cmns-cls: <https://www.omg.org/spec/Commons/Classifiers/> .
 @prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/> .
-@prefix cmns-cmp: <https://www.omg.org/spec/Commons/Composites/> .
+@prefix cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/> .
 @prefix cmns-dsg: <https://www.omg.org/spec/Commons/Designators/> .
 @prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/> .
 @prefix cmns-prd: <https://www.omg.org/spec/Commons/ProductsAndServices/> .
@@ -58,7 +58,7 @@
 		<https://www.omg.org/spec/Commons/AnnotationVocabulary/> ,
 		<https://www.omg.org/spec/Commons/Classifiers/> ,
 		<https://www.omg.org/spec/Commons/Collections/> ,
-		<https://www.omg.org/spec/Commons/Composites/> ,
+		<https://www.omg.org/spec/Commons/RolesAndCompositions/> ,
 		<https://www.omg.org/spec/Commons/Designators/> ,
 		<https://www.omg.org/spec/Commons/Identifiers/> ,
 		<https://www.omg.org/spec/Commons/PartiesAndSituations/> ,
@@ -163,7 +163,7 @@ idmp-x:hasLegalStatusOfSupply
 		spor-p:00006006-5
 		;
 	cmns-id:isIdentifiedBy <https://data.pistoiaalliance.org/idmp/EMA_MPID/IE-100000833-00000003> ;
-	cmns-cmp:playsRole [
+	cmns-rlcmp:playsRole [
 		a idmp-mprd:AuthorizedMedicinalProduct ;
 	] ;
 	.
@@ -200,7 +200,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000076135 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000076135 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -223,7 +223,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000076427 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000076427 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -246,7 +246,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000076429 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000076429 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -269,7 +269,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000078041 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000078041 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -292,7 +292,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000078762 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000078762 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -315,7 +315,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000080121 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000080121 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -338,7 +338,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000087105 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000087105 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -361,7 +361,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000088586 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000088586 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -386,7 +386,7 @@ idmp-x:hasLegalStatusOfSupply
 		] ;
 	] ;
 	idmp-mprd:hasReferenceSubstance spor-s:100000090493 ;
-	cmns-cmp:isPlayedBy spor-s:100000090493 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000090493 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -409,7 +409,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000092217 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000092217 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -432,7 +432,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000093305 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000093305 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -489,7 +489,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000076135 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000076135 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -512,7 +512,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000076427 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000076427 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -535,7 +535,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000078041 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000078041 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -558,7 +558,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000078762 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000078762 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -581,7 +581,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000080121 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000080121 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -604,7 +604,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000087105 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000087105 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -627,7 +627,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000087133 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000087133 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -650,7 +650,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000088586 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000088586 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -673,7 +673,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000090493 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000090493 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -696,7 +696,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000092217 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000092217 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -719,7 +719,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000093305 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000093305 ;
 	cmns-pts:isRealizedIn spor-p:00006006-2-MI-ProductComposition ;
 	.
 
@@ -778,7 +778,7 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-uom:hasUnitOfPresentation <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 	cmns-col:isIncludedIn spor-p:00006006 ;
 	cmns-dsg:isDefinedIn spor-p:00006006-5-ProductComposition ;
-	cmns-cmp:playsRole [
+	cmns-rlcmp:playsRole [
 		a idmp-mprd:Placebo ;
 	] ;
 	.
@@ -802,7 +802,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000076135 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000076135 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -825,7 +825,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000078762 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000078762 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -848,7 +848,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000080121 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000080121 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -871,7 +871,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000087105 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000087105 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -894,7 +894,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000088586 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000088586 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -917,7 +917,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000092217 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000092217 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -940,7 +940,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasNumericValue "50.0"^^xsd:decimal ;
 		] ;
 	] ;
-	cmns-cmp:isPlayedBy spor-s:100000093305 ;
+	cmns-rlcmp:isPlayedBy spor-s:100000093305 ;
 	cmns-pts:isRealizedIn spor-p:00006006-1-ProductComposition ;
 	.
 
@@ -985,7 +985,7 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:isContainedIn spor-p:IE-100000833-00000003-0001 ;
 	cmns-col:comprises <https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003529> ;
 	cmns-dsg:isDefinedIn spor-p:IE-100000833-00000003-0001-1-Constituency ;
-	cmns-cmp:playsRole [
+	cmns-rlcmp:playsRole [
 		a idmp-mprd:OuterPackaging ;
 	] ;
 	.
@@ -993,7 +993,7 @@ idmp-x:hasLegalStatusOfSupply
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-0001-1-Constituency>
 	a
 		owl:NamedIndividual ,
-		cmns-cmp:Composition
+		cmns-rlcmp:Composition
 		;
 	rdfs:label "Qlaira, 1 x 28 film-coated tablets (Box Constituency)" ;
 	cmns-col:hasConstituent [
@@ -1003,7 +1003,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109> ;
 			cmns-qtu:hasNumericValue "1.0"^^xsd:decimal ;
 		] ;
-		cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-Blister ;
+		cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-Blister ;
 	] ;
 	cmns-dsg:defines spor-p:IE-100000833-00000003-0001-1 ;
 	.
@@ -1040,7 +1040,7 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:isContainedIn spor-p:IE-100000833-00000003-0002 ;
 	cmns-col:comprises <https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003529> ;
 	cmns-dsg:isDefinedIn spor-p:IE-100000833-00000003-0002-1-Constituency ;
-	cmns-cmp:playsRole [
+	cmns-rlcmp:playsRole [
 		a idmp-mprd:OuterPackaging ;
 	] ;
 	.
@@ -1048,7 +1048,7 @@ idmp-x:hasLegalStatusOfSupply
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-0002-1-Constituency>
 	a
 		owl:NamedIndividual ,
-		cmns-cmp:Composition
+		cmns-rlcmp:Composition
 		;
 	rdfs:label "Qlaira, 3 x 28 film-coated tablets (Box Constituency)" ;
 	cmns-col:hasConstituent [
@@ -1058,7 +1058,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109> ;
 			cmns-qtu:hasNumericValue "3.0"^^xsd:decimal ;
 		] ;
-		cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-Blister ;
+		cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-Blister ;
 	] ;
 	cmns-dsg:defines spor-p:IE-100000833-00000003-0002-1 ;
 	.
@@ -1095,7 +1095,7 @@ idmp-x:hasLegalStatusOfSupply
 	idmp-mprd:isContainedIn spor-p:IE-100000833-00000003-0003 ;
 	cmns-col:comprises <https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003529> ;
 	cmns-dsg:isDefinedIn spor-p:IE-100000833-00000003-0003-1-Constituency ;
-	cmns-cmp:playsRole [
+	cmns-rlcmp:playsRole [
 		a idmp-mprd:OuterPackaging ;
 	] ;
 	.
@@ -1103,7 +1103,7 @@ idmp-x:hasLegalStatusOfSupply
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-0003-1-Constituency>
 	a
 		owl:NamedIndividual ,
-		cmns-cmp:Composition
+		cmns-rlcmp:Composition
 		;
 	rdfs:label "Qlaira, 6 x 28 film-coated tablets (Box Constituency)" ;
 	cmns-col:hasConstituent [
@@ -1113,7 +1113,7 @@ idmp-x:hasLegalStatusOfSupply
 			cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002109> ;
 			cmns-qtu:hasNumericValue "6.0"^^xsd:decimal ;
 		] ;
-		cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-Blister ;
+		cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-Blister ;
 	] ;
 	cmns-dsg:defines spor-p:IE-100000833-00000003-0003-1 ;
 	.
@@ -1151,7 +1151,7 @@ idmp-x:hasLegalStatusOfSupply
 		<https://spor.ema.europa.eu/rmswi/#/lists/200000003199/terms/200000003222>
 		;
 	cmns-dsg:isDefinedIn spor-p:IE-100000833-00000003-BlisterConsituency ;
-	cmns-cmp:playsRole [
+	cmns-rlcmp:playsRole [
 		a idmp-mprd:ImmediateContainer ;
 	] ;
 	.
@@ -1178,7 +1178,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 	] ;
-	cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem1 ;
+	cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem1 ;
 	.
 
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent2>
@@ -1191,7 +1191,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "5.0"^^xsd:decimal ;
 	] ;
-	cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem2 ;
+	cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem2 ;
 	.
 
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent3>
@@ -1204,7 +1204,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "17.0"^^xsd:decimal ;
 	] ;
-	cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem3 ;
+	cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem3 ;
 	.
 
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent4>
@@ -1217,7 +1217,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 	] ;
-	cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem4 ;
+	cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem4 ;
 	.
 
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-BlisterConsituent5>
@@ -1230,7 +1230,7 @@ idmp-x:hasLegalStatusOfSupply
 		cmns-qtu:hasMeasurementUnit <https://spor.ema.europa.eu/rmswi/#/lists/200000000014/terms/200000002152> ;
 		cmns-qtu:hasNumericValue "2.0"^^xsd:decimal ;
 	] ;
-	cmns-cmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem5 ;
+	cmns-rlcmp:isPlayedBy spor-p:IE-100000833-00000003-ManufacturedItem5 ;
 	.
 
 <https://spor.ema.europa.eu/smswi/#/products//products/IE-100000833-00000003-ManufacturedItem1>

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -2,7 +2,6 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
@@ -15,6 +14,7 @@
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
@@ -44,7 +44,6 @@
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/TerlipressinExample/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
@@ -57,6 +56,7 @@
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
@@ -103,7 +103,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Documents/"/>
@@ -115,6 +114,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
@@ -148,10 +148,10 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;GSKAsManufacturer">
 		<rdf:type rdf:resource="&idmp-sub;Manufacturer"/>
 		<rdfs:label>GSK as manufacturer</rdfs:label>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-trlp;GSKplc"/>
 		<cmns-prd:produces rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjection"/>
 		<cmns-prd:produces rdf:resource="&idmp-trlp;TerlipressinSUN0.1MgPerMlSolutionForInjection"/>
 		<cmns-prd:produces rdf:resource="&idmp-trlp;TerlipressinSUN1MgSolutionForInjection"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-trlp;GSKplc"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;GSKplc">
@@ -196,8 +196,8 @@
 		<skos:definition>terlipressin acetate in the role of an active ingredient in terlipressin acetate SUN solution for injection</skos:definition>
 		<idmp-mprd:hasBasisOfStrengthAsManufactured rdf:resource="&idmp-trlp;TerlipressinAcetateStrengthAsManufacturedInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
 		<idmp-mprd:hasStrength rdf:resource="&idmp-trlp;TerlipressinAcetatePresentationStrengthInTerlipressinAcetateSUN1MgPerAmpouleSolutionForInjection"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUNComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateCommonName">
@@ -218,9 +218,9 @@
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateComposition">
 		<rdf:type rdf:resource="&idmp-sub;SubstanceComposition"/>
 		<rdfs:label>terlipressin acetate composition</rdfs:label>
-		<cmns-cmp:hasRole rdf:resource="&idmp-trlp;TerlipressinAsActiveMoiety"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&cmns-ge-euj;EuropeanUnionJurisdiction"/>
 		<cmns-dsg:defines rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
+		<cmns-rlcmp:hasRole rdf:resource="&idmp-trlp;TerlipressinAsActiveMoiety"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateConcentrationStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection">
@@ -408,8 +408,8 @@
 		<skos:definition>terlipressin acetate in the role of an active ingredient that provides the basis of strength in terlipressin acetate 1 mg per ampoule solution for injection as manufactured, where the entire substance acts as the basis of strength</skos:definition>
 		<idmp-mprd:hasStrength rdf:resource="&idmp-trlp;TerlipressinAcetateConcentrationStrengthInTerlipressinAcetate1MgPerAmpouleSolutionForInjection"/>
 		<idmp-mprd:hasStrength rdf:resource="&idmp-trlp;TerlipressinAcetatePresentationStrengthInTerlipressinAcetateSUN1MgPerAmpouleSolutionForInjection"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjectionComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-trlp;TerlipressinAcetate"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAsActiveIngredientInTerlipressinAcetate1MgPerAmpouleSolutionForInjection">
@@ -418,19 +418,19 @@
 		<skos:definition>terlipressin in the role of an active moiety that provides the reference strength in terlipressin acetate 1 mg per ampoule solution for injection</skos:definition>
 		<idmp-mprd:hasReferenceStrength rdf:resource="&idmp-trlp;TerlipressinAsReferenceConcentrationStrengthInTerlipressinAcetate1MgPerMlSolutionForInjection"/>
 		<idmp-mprd:hasReferenceStrength rdf:resource="&idmp-trlp;TerlipressinAsReferencePresentationStrengthInTerlipressinAcetate1MgPerMlSolutionForInjection"/>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-trlp;Terlipressin"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-trlp;TerlipressinAcetateSUN0.12MgPerMlSolutionForInjectionComposition"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-trlp;TerlipressinSUN0.1MgPerMlSolutionForInjectionComposition"/>
 		<cmns-pts:isRealizedIn rdf:resource="&idmp-trlp;TerlipressinSUN1MgSolutionForInjectionComposition"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-trlp;Terlipressin"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAsActiveMoiety">
 		<rdf:type rdf:resource="&idmp-sub;ActiveMoietyRole"/>
 		<rdfs:label>terlipressin as active moiety</rdfs:label>
 		<skos:definition>terlipressin in the role of an active moiety</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-trlp;Terlipressin"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&idmp-narga;RegulatoryContext-FoodAndDrugAdministrationGeneral"/>
 		<cmns-cxtdsg:isApplicableIn rdf:resource="&cmns-ge-euj;EuropeanUnionJurisdiction"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-trlp;Terlipressin"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAsReferenceConcentrationStrengthInTerlipressinAcetate1MgPerMlSolutionForInjection">

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -233,14 +233,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateDenominatorInTerlipressinAcetate1MgPerAmpouleSolutionForInjectionConcentrationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin acetate denominator in terlipressin acetate 1 mg/1 ampoule solution for injection concentration strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milliliter"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateDenominatorInTerlipressinSUN1MgSolutionForInjectionPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin acetate denominator in terlipressin SUN 1 mg solution for injection presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Ampoule"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
@@ -275,14 +275,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateNumeratorInTerlipressinAcetate1MgPerAmpouleSolutionForInjectionConcentrationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin acetate numerator in terlipressin acetate 1 mg/1 ampoule solution for injection concentration strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">0.12</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateNumeratorInTerlipressinSUN1MgSolutionForInjectionPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin acetate numerator in terlipressin SUN 1 mg solution for injection presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
@@ -469,14 +469,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinDenominatorInTerlipressinAcetate1MgPerMlSolutionForInjectionConcentrationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin denominator in terlipressin acetate 1 mg/ml solution for injection concentration strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milliliter"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinDenominatorInTerlipressinAcetate1MgPerMlSolutionForInjectionPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin denominator in terlipressin acetate 1 mg/ml solution for injection presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Ampoule"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
@@ -512,14 +512,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinNumeratorInTerlipressinAcetate1MgPerMlSolutionForInjectionConcentrationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin numerator in terlipressin acetate 1 mg/ml solution for injection concentration strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">0.1</cmns-qtu:hasNumericValue>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinNumeratorInTerlipressinAcetate1MgPerMlSolutionForInjectionPresentationStrength">
-		<rdf:type rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdf:type rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>terlipressin numerator in terlipressin acetate 1 mg/ml solution for injection presentation strength</rdfs:label>
 		<cmns-qtu:hasMeasurementUnit rdf:resource="&idmp-ucum;Milligram"/>
 		<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">0.85</cmns-qtu:hasNumericValue>

--- a/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities.rdf
+++ b/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities.rdf
@@ -3,7 +3,6 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
@@ -14,6 +13,7 @@
 	<!ENTITY cmns-prd "https://www.omg.org/spec/Commons/ProductsAndServices/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
@@ -32,7 +32,6 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
@@ -43,6 +42,7 @@
 	xmlns:cmns-prd="https://www.omg.org/spec/Commons/ProductsAndServices/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
@@ -69,7 +69,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
@@ -79,6 +78,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/EuropeanJurisdiction/EuropeanRegistrationAuthorities/"/>
@@ -100,8 +100,8 @@
 		<rdfs:label>British Pharmacological Society as registration authority</rdfs:label>
 		<skos:definition>British Pharmacological Society in its role as a Registration Authority (RA)</skos:definition>
 		<cmns-av:abbreviation>BPS RA</cmns-av:abbreviation>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eura;BritishPharmacologicalSociety"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;InternationalUnionOfBasicAndClinicalPharmacologyGuide"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eura;BritishPharmacologicalSociety"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-eura;ChemblDatabase">
@@ -225,8 +225,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>European Chemicals Agency registration authority</rdfs:label>
 		<skos:definition>European Chemicals Agency in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanChemicalsAgency"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanInventoryOfExistingCommercialChemicalSubstances"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanChemicalsAgency"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-eura;EuropeanCommissionFoodAdditivesDatabase">
@@ -252,8 +252,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>European Commission Scientific Committee on Consumer Safety registration authority</rdfs:label>
 		<skos:definition>European Commission Scientific Committee on Consumer Safety in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanCommissionScientificCommitteeOnConsumerSafety"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanCommissionScientificCommitteeOnConsumerSafetyOpinions"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanCommissionScientificCommitteeOnConsumerSafety"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-eura;EuropeanCommunityNumber">
@@ -294,9 +294,9 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>European Directorate for the Quality of Medicines and Healthcare registration authority</rdfs:label>
 		<skos:definition>European Directorate for the Quality of Medicines and Healthcare in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanDirectorateForTheQualityOfMedicinesAndHealthcare"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanCommissionFoodAdditivesDatabase"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanDirectorateForTheQualityOfMedicinesAndHealthcareKnowledgeDatabase"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanDirectorateForTheQualityOfMedicinesAndHealthcare"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-eura;EuropeanInventoryOfExistingCommercialChemicalSubstances">
@@ -340,11 +340,11 @@
 		<skos:definition>European Medicines Agency (EMA) in its role as a Registration Authority (RA), which is a function of the eXtended EudraVigilance Medicinal Product Dictionary (XEVMPD) for registration of substances</skos:definition>
 		<cmns-av:abbreviation>EMA XEVMPD RA</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause A.1.7</cmns-av:adaptedFrom>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanMedicinesAgency"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanPublicAssessmentReports"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanUnionClinicalTrialsRegister"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;ExtendedEudraVigilanceMedicinalProductDictionary"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;SummaryOfProductCharacteristics"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanMedicinesAgency"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-eura;EuropeanMolecularBiologyLaboratory">
@@ -369,8 +369,8 @@
 		<rdfs:label>European Molecular Biology Laboratory European Bioinformatics Institute registration authority</rdfs:label>
 		<skos:definition>European Molecular Biology Laboratory European Bioinformatics Institute in its role as a Registration Authority (RA)</skos:definition>
 		<cmns-av:abbreviation>EMBL-EBI RA</cmns-av:abbreviation>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eura;EuropeanMolecularBiologyLaboratoryEuropeanBioinformaticsInstitute"/>
 		<cmns-ra:manages rdf:resource="&idmp-eura;EuropeanInventoryOfExistingCommercialChemicalSubstances"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eura;EuropeanMolecularBiologyLaboratoryEuropeanBioinformaticsInstitute"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-eura;EuropeanPublicAssessmentReports">

--- a/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies.rdf
+++ b/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies.rdf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-ge "https://www.omg.org/spec/Commons/GovernmentEntities/">
 	<!ENTITY cmns-ge-euj "https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
 	<!ENTITY idmp-eurga "https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies/">
@@ -21,13 +21,13 @@
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-ge="https://www.omg.org/spec/Commons/GovernmentEntities/"
 	xmlns:cmns-ge-euj="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
 	xmlns:idmp-eurga="https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegulatoryAgencies/"
@@ -47,12 +47,12 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/EuropeanJurisdiction/EuropeanRegulatoryAgencies/"/>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
@@ -112,8 +112,8 @@
 		<rdf:type rdf:resource="&idmp-mprd;MedicinesRegulatoryAgency"/>
 		<rdfs:label>European Medicines Agency as medicines regulatory agency</rdfs:label>
 		<skos:definition>European Medicines Agency in its role as a regulator of medicinal products</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanMedicinesAgency"/>
 		<cmns-rga:hasJurisdiction rdf:resource="&cmns-ge-euj;EuropeanEconomicArea"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-eurga;EuropeanMedicinesAgency"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&cmns-ge-euj;EuropeanEconomicArea">

--- a/ISO/ISO11238-RegistrationAuthorities.rdf
+++ b/ISO/ISO11238-RegistrationAuthorities.rdf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
@@ -10,6 +9,7 @@
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
 	<!ENTITY idmp-eura "https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities/">
@@ -29,7 +29,6 @@
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
@@ -38,6 +37,7 @@
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
 	xmlns:idmp-eura="https://spec.pistoiaalliance.org/idmp/ontology/ISO/EuropeanJurisdiction/EuropeanRegistrationAuthorities/"
@@ -67,13 +67,13 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
@@ -109,8 +109,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>Australian National Botanic Gardens registration authority</rdfs:label>
 		<skos:definition>Australian National Botanic Gardens in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-ra;AustralianNationalBotanicGardens"/>
 		<cmns-ra:manages rdf:resource="&idmp-ra;AustralianPlantNameIndex"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-ra;AustralianNationalBotanicGardens"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-ra;AustralianPlantNameIndex">
@@ -282,8 +282,8 @@
 		<rdfs:label>World Health Organization Registration Authority</rdfs:label>
 		<skos:definition>World Health Organization (WHO) in its role as a Registration Authority (RA)</skos:definition>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 4.2.2</cmns-av:adaptedFrom>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-ra;WorldHealthOrganization"/>
 		<cmns-ra:manages rdf:resource="&idmp-ra;AnatomicalTherapeuticChemicalClassificationSystem"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-ra;WorldHealthOrganization"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -104,7 +104,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230502/ISO11238-Substances.rdf version of this ontology was modified to integrate content related to modifications from Figure 15 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-540), to support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), to move deprecated elements to a separate ontology, and to support additional reference information from Figure 16 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-522), addressed punning issues with modification method type, aligned the ontology with the revised basis of strength pattern (IDMP-582), and to add an axiom indicating that certain elements have data that can be used for testing purposes.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11238-Substances.rdf version of this ontology was modified to rename hasSimplifiedMolecularInputLineEntrySpecification to hasSMILES and to incorporate the ability to define controlled vocabularies that may or may not be jurisdiction-specific (IDMP-533).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances.rdf version of this ontology was modified to add structural representations including molfile.</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11238-Substances.rdf version of this ontology was modified to reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), to incorporate additional content for structurally diverse substances (IDMP-635), and to rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, per the Commons 1.1 release (IDMP-655).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11238-Substances.rdf version of this ontology was modified to reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), to incorporate additional content for structurally diverse substances (IDMP-635), and to (1) rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, and (2) rename concepts including Quantity, QuantityValue, and QuantityValueRange to ScalarQuantity, ScalarQuantityValue, and ScalarQuantityValueRange per the Commons 1.1 release (IDMP-655).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -248,21 +248,21 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-sub;hasReferenceQuantityValueRange"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValueRange"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValueRange"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValueRange"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValueRange"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValueRange"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1089,7 +1089,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-sub;hasHalfLife"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1920,7 +1920,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MolecularWeight">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
@@ -2371,7 +2371,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;OpticalRotation">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty>
@@ -2818,7 +2818,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-sub;hasHalfLife"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -5601,7 +5601,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:domain>
-		<rdfs:range rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:range rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<skos:definition>for a single radioactive decay process, the time required for the activity to decrease to half its value by that process</skos:definition>
 		<skos:example>109,77 min (¹⁸F)</skos:example>
 		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.7.7.4</cmns-av:adaptedFrom>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -3,7 +3,6 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-doc "https://www.omg.org/spec/Commons/Documents/">
@@ -15,6 +14,7 @@
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
@@ -37,7 +37,6 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-doc="https://www.omg.org/spec/Commons/Documents/"
@@ -49,6 +48,7 @@
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
@@ -79,7 +79,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Designators/"/>
@@ -90,6 +89,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
@@ -1014,10 +1014,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Ingredient">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;isIncludedIn"/>
@@ -1258,10 +1258,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MaterialRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Material"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1363,17 +1363,17 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ModificationAgent">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass rdf:resource="&idmp-sub;Substance"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Modification"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1500,7 +1500,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-sub;ModificationRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
@@ -1510,7 +1510,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Modification"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1652,10 +1652,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MoietyRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass rdf:resource="&idmp-sub;Moiety"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -1675,7 +1675,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MolecularComposition">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Composition"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
@@ -1818,14 +1818,14 @@
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Undergoer"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;MolecularFragment"/>
+				<owl:onProperty rdf:resource="&cmns-pts;undergoes"/>
+				<owl:someValuesFrom rdf:resource="&idmp-sub;Modification"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-pts;undergoes"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;Modification"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
+				<owl:someValuesFrom rdf:resource="&idmp-sub;MolecularFragment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>molecular fragment role</rdfs:label>
@@ -3478,7 +3478,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-sub;MaterialRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:onClass>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -3496,7 +3496,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -3670,7 +3670,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-sub;MaterialRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Material"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -4196,7 +4196,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;manifests"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;manifests"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;SourceMaterialRole"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -4510,7 +4510,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceComposition">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Composition"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
@@ -4519,7 +4519,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;hasRole"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
+				<owl:someValuesFrom rdf:resource="&idmp-sub;Substance"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;hasRole"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -4530,12 +4536,6 @@
 						</owl:unionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;defines"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;Substance"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>substance composition</rdfs:label>
@@ -5070,10 +5070,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SubstanceRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Substance"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -5234,7 +5234,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 				<owl:onProperty rdf:resource="&cmns-pts;hasObjectRole"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+						<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 						<owl:someValuesFrom rdf:resource="&idmp-sub;Target"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
@@ -5245,7 +5245,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 				<owl:onProperty rdf:resource="&cmns-pts;hasSubjectRole"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+						<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 						<owl:onClass rdf:resource="&idmp-sub;Substance"/>
 						<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 					</owl:Restriction>
@@ -5657,7 +5657,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasIngredient">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;manifests"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;manifests"/>
 		<rdfs:label>has ingredient</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-sub;Ingredient"/>
 		<skos:definition>relates a substance or product composition to an ingredient of that composition</skos:definition>
@@ -5781,7 +5781,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasModificationRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has modification role</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.2.3</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.10.5.2</dct:source>
@@ -5830,14 +5830,14 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 			</rdf:Description>
 			<rdf:Description rdf:about="&idmp-sub;hasMoietyRole">
 			</rdf:Description>
-			<rdf:Description rdf:about="&cmns-cmp;isPlayedBy">
+			<rdf:Description rdf:about="&cmns-rlcmp;isPlayedBy">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
 		<skos:definition>relates a substance directly to a moiety that defines it via a substance composition</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasMoietyRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has moiety role</rdfs:label>
 		<dct:source>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.3.1</dct:source>
 		<dct:source>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.6.3</dct:source>
@@ -6535,7 +6535,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;isIngredientOf">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;isManifestedIn"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 		<rdfs:label>is ingredient of</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-sub;Ingredient"/>
 		<skos:definition>relates an ingredient to a substance or product composition that it is included in</skos:definition>
@@ -6544,7 +6544,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 	<owl:ObjectProperty rdf:about="&idmp-sub;isMoietyOf">
 		<rdfs:label>is moiety of</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-cmp;playsRole">
+			<rdf:Description rdf:about="&cmns-rlcmp;playsRole">
 			</rdf:Description>
 			<rdf:Description rdf:about="&idmp-sub;isMoietyRoleIn">
 			</rdf:Description>
@@ -6556,7 +6556,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-sub;isMoietyRoleIn">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;isRoleIn"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;isRoleIn"/>
 		<rdfs:label>is moiety role in</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-sub;MoietyRole"/>
 		<rdfs:range rdf:resource="&idmp-sub;SubstanceComposition"/>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -104,7 +104,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230502/ISO11238-Substances.rdf version of this ontology was modified to integrate content related to modifications from Figure 15 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-540), to support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), to move deprecated elements to a separate ontology, and to support additional reference information from Figure 16 in ISO 11238, corresponding to clause 6.6 and Figure 8 in the implementation guide (IDMP-522), addressed punning issues with modification method type, aligned the ontology with the revised basis of strength pattern (IDMP-582), and to add an axiom indicating that certain elements have data that can be used for testing purposes.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11238-Substances.rdf version of this ontology was modified to rename hasSimplifiedMolecularInputLineEntrySpecification to hasSMILES and to incorporate the ability to define controlled vocabularies that may or may not be jurisdiction-specific (IDMP-533).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11238-Substances.rdf version of this ontology was modified to add structural representations including molfile.</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11238-Substances.rdf version of this ontology was modified to reflect the migration of some content in Commons from the Parties and Situations ontology to a new Composites ontology at OMG (IDMP-642) and incorporate additional content for structurally diverse substances (IDMP-635).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11238-Substances.rdf version of this ontology was modified to reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), to incorporate additional content for structurally diverse substances (IDMP-635), and to rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, per the Commons 1.1 release (IDMP-655).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -2599,7 +2599,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;isSpecifiedBy"/>
+				<owl:onProperty rdf:resource="&cmns-doc;isSpecifiedIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Substance"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -5826,7 +5826,7 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasMoiety">
 		<rdfs:label>has moiety</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
-			<rdf:Description rdf:about="&cmns-doc;isSpecifiedBy">
+			<rdf:Description rdf:about="&cmns-doc;isSpecifiedIn">
 			</rdf:Description>
 			<rdf:Description rdf:about="&idmp-sub;hasMoietyRole">
 			</rdf:Description>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -109,7 +109,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) integrate content related to modifications from Figure 15 in ISO 11238 (IDMP-540), (2) support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), (3) integrate content related to therapeutic indications in ISO 11615 (IDMP-561), (4) clarify the definition of marketing authorization holder (IDMP-395), (5) refine restrictions between medicinal products and authorized medicinal products (IDMP-550), (6) aligne the ontology with the revised basis of strength pattern (IDMP-582), and (7) loosen a constraint on ingredient with respect to manufactured item (IDMP-602).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) make indication texts as nodes instead of literals (IDMP-591), (2) add the concept of shelf life / storage per Figure 11 in the ISO 11615 specification (IDMP-371), (3) add undesirable effect per Figure 14 in the ISO 11615 specification (IDMP-591), (4) rename &apos;has medical condition&apos; to use a more aligned label with ISO 11615 (IDMP-591), (5) add the concept of route of administration (IDMP-614), and (6) integrate the refined pattern for controlled vocabularies (IDMP-533).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11615-MedicinalProducts.rdf version of this ontology was modified to extend the definition of product role to relate to product specifications in addition to products (IDMP-633).</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11615-MedicinalProducts.rdf version of this ontology was modified to add other therapy specifics (IDMP-639), and to (1) reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), and (1) to rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, and (2) incorporate hasExpirationDate, which was simplified out of the OMG Commons ontology for the Commons 1.1 release (IDMP-655).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11615-MedicinalProducts.rdf version of this ontology was modified to add other therapy specifics (IDMP-639), and to (1) reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), and (1) to rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, (2) incorporate hasExpirationDate, which was simplified out of the OMG Commons ontology, and (3) to rename concepts including Quantity, QuantityValue, and QuantityValueRange to ScalarQuantity, ScalarQuantityValue, and ScalarQuantityValueRange per the Commons 1.1 release (IDMP-655).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -283,7 +283,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasManufacturedItemQuantity"/>
-				<owl:someValuesFrom rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.47</dct:source>
@@ -893,7 +893,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1122,7 +1122,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Dose">
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;QuantityValue"/>
+		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 		<rdfs:label>dose</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.23</dct:source>
 		<skos:definition>specified quantity of a medicine, to be taken at one time or at stated intervals</skos:definition>
@@ -2167,7 +2167,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2246,7 +2246,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:someValuesFrom rdf:resource="&cmns-qtu;QuantityValue"/>
+				<owl:someValuesFrom rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>pharmaceutical product batch</rdfs:label>
@@ -2715,9 +2715,9 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 				<owl:onClass>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&cmns-qtu;QuantityValue">
+							<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValue">
 							</rdf:Description>
-							<rdf:Description rdf:about="&cmns-qtu;QuantityValueRange">
+							<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValueRange">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -2731,9 +2731,9 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 				<owl:onClass>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&cmns-qtu;QuantityValue">
+							<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValue">
 							</rdf:Description>
-							<rdf:Description rdf:about="&cmns-qtu;QuantityValueRange">
+							<rdf:Description rdf:about="&cmns-qtu;ScalarQuantityValueRange">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -102,14 +102,14 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230808/ISO11615-MedicinalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230901/ISO11615-MedicinalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also extended to include concepts such as process, manufacturing process, process identifier, batch, batch identifier, lot, lot number, and others required in support of the regulatory to manufacturing bridge use case.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename product constituency to product composition, which is better understood by the user community, and to move a couple of restrictions from ingredient to substance, including strength and whether or not that substance is potentially allergenic. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate additional manufacturing and packaging details required for UC-2 (IDMP-465), to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to change the status of this ontology to &apos;release&apos; (IDMP-525), to add content related to dose forms (IDMP-531, IDMP-538), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230501/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) integrate content related to modifications from Figure 15 in ISO 11238 (IDMP-540), (2) support isotopes and nuclides as in ISO 11238, Figure 14 (IDMP-539), (3) integrate content related to therapeutic indications in ISO 11615 (IDMP-561), (4) clarify the definition of marketing authorization holder (IDMP-395), (5) refine restrictions between medicinal products and authorized medicinal products (IDMP-550), (6) aligne the ontology with the revised basis of strength pattern (IDMP-582), and (7) loosen a constraint on ingredient with respect to manufactured item (IDMP-602).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230601/ISO11615-MedicinalProducts.rdf version of this ontology was modified to (1) make indication texts as nodes instead of literals (IDMP-591), (2) add the concept of shelf life / storage per Figure 11 in the ISO 11615 specification (IDMP-371), (3) add undesirable effect per Figure 14 in the ISO 11615 specification (IDMP-591), (4) rename &apos;has medical condition&apos; to use a more aligned label with ISO 11615 (IDMP-591), (5) add the concept of route of administration (IDMP-614), and (6) integrate the refined pattern for controlled vocabularies (IDMP-533).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11615-MedicinalProducts.rdf version of this ontology was modified to extend the definition of product role to relate to product specifications in addition to products (IDMP-633).</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11615-MedicinalProducts.rdf version of this ontology was modified to add other therapy specifics (IDMP-639) and to reflect the migration of some content in Commons from the Parties and Situations ontology to a new Composites ontology at OMG (IDMP-642).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11615-MedicinalProducts.rdf version of this ontology was modified to add other therapy specifics (IDMP-639), and to (1) reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), and (1) to rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, and (2) incorporate hasExpirationDate, which was simplified out of the OMG Commons ontology for the Commons 1.1 release (IDMP-655).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -2233,14 +2233,14 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Batch"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;isConstituentOf"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;PhysicalPharmaceuticalProduct"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasExpirationDate"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;hasExpirationDate"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
+				<owl:onProperty rdf:resource="&cmns-col;isConstituentOf"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;PhysicalPharmaceuticalProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -3157,7 +3157,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasContraindication">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
 		<rdfs:label>has contraindication</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;Contraindication"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isContraindicationFor"/>
@@ -3227,6 +3227,14 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.24</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasExpirationDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasEndDate"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasExplicitDate"/>
+		<rdfs:label>has expiration date</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-dt;ExplicitDate"/>
+		<skos:definition>links something, such as an agreement, contract, report, other document, or perishable item, with a date beyond which it is no longer valid</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasFrequencyOfOccurrence">
 		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
 		<rdfs:label>has frequency of occurrence</rdfs:label>
@@ -3281,7 +3289,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasMedication">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
 		<rdfs:label>has medication</rdfs:label>
 		<rdfs:range>
 			<owl:Class>
@@ -3298,7 +3306,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasOtherTherapySpecifics">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
 		<rdfs:label>has other therapy specifics</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;OtherTherapySpecifics"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isOtherTherapySpecificsOf"/>
@@ -3438,7 +3446,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTherapeuticIndication">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
 		<rdfs:label>has therapeutic indication</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;TherapeuticIndication"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isTherapeuticIndicationFor"/>
@@ -3459,7 +3467,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasTherapyRelationshipType">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
 		<rdfs:label>has therapy relationship type</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;TherapyRelationshipType"/>
 		<skos:definition>relates to a classifier of a therapy relationship</skos:definition>
@@ -3479,7 +3487,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasUndesirableEffect">
-		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-doc;isSpecifiedIn"/>
 		<rdfs:label>has undesirable effect</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-mprd;UndesirableEffect"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isUndesirableEffectOf"/>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -3,7 +3,6 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-cxtid "https://www.omg.org/spec/Commons/ContextualIdentifiers/">
@@ -17,6 +16,7 @@
 	<!ENTITY cmns-qtu "https://www.omg.org/spec/Commons/QuantitiesAndUnits/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-stat "https://www.omg.org/spec/Commons/StatisticalMeasures/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
@@ -39,7 +39,6 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-cxtid="https://www.omg.org/spec/Commons/ContextualIdentifiers/"
@@ -53,6 +52,7 @@
 	xmlns:cmns-qtu="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-stat="https://www.omg.org/spec/Commons/StatisticalMeasures/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
@@ -84,7 +84,6 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Classifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/CodesAndCodeSets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualIdentifiers/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/DatesAndTimes/"/>
@@ -97,6 +96,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/StatisticalMeasures/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
@@ -210,14 +210,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:onClass rdf:resource="&idmp-mprd;PharmaceuticalProduct"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:onClass rdf:resource="&idmp-sub;ManufacturedItem"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -231,7 +231,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&cmns-col;isIncludedIn"/>
@@ -353,7 +353,7 @@
 	<owl:Class rdf:about="&idmp-sub;ProcessingMaterialRole">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -375,7 +375,7 @@
 	<owl:Class rdf:about="&idmp-sub;ResultantMaterialRole">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -406,7 +406,7 @@
 	<owl:Class rdf:about="&idmp-sub;StartingMaterialRole">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -476,7 +476,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Moiety"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -621,7 +621,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -854,7 +854,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ContainerConstituency">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Composition"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-col;hasConstituent"/>
@@ -1151,10 +1151,10 @@
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-mprd;ImmediateContainer">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&idmp-mprd;immediatelyContains"/>
@@ -1174,7 +1174,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isRoleIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isRoleIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;ContainerConstituency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1468,16 +1468,16 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;IntermediatePackaging">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProductContainer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isRoleIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isRoleIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;ContainerConstituency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1631,7 +1631,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;AuthorizedParty"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -1696,7 +1696,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Medication">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
@@ -1709,7 +1709,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isManifestedIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isManifestedIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicationTherapy"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1742,7 +1742,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Therapy"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;manifests"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;manifests"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;Medication"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -1783,7 +1783,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;playsRole"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;playsRole"/>
 				<owl:onClass rdf:resource="&idmp-mprd;ProductRole"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -2051,16 +2051,16 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;OuterPackaging">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProductContainer"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isRoleIn"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isRoleIn"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;ContainerConstituency"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2442,7 +2442,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductComposition">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;Composition"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasReferenceStrength"/>
@@ -2479,10 +2479,10 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductRole">
-		<rdfs:subClassOf rdf:resource="&cmns-cmp;FunctionalRole"/>
+		<rdfs:subClassOf rdf:resource="&cmns-rlcmp;FunctionalRole"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cmp;isPlayedBy"/>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -3322,7 +3322,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;hasReferenceIngredientRole">
-		<rdfs:subPropertyOf rdf:resource="&cmns-cmp;hasRole"/>
+		<rdfs:subPropertyOf rdf:resource="&cmns-rlcmp;hasRole"/>
 		<rdfs:label>has reference ingredient role</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-sub;SubstanceRole"/>
 		<skos:definition>indicates a role that the reference substance of an active ingredient in a pharmaceutical or medicinal product plays under certain circumstances</skos:definition>

--- a/ISO/ISO21090-HarmonizedDatatypes.rdf
+++ b/ISO/ISO21090-HarmonizedDatatypes.rdf
@@ -70,7 +70,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/ISO639-1-LanguageCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO21090-HarmonizedDatatypes/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/2023001/ISO21090-HarmonizedDatatypes/"/>
 		<owl:versionInfo>The IDMP MVP version of this ontology is incomplete, and covers only the parts of the ISO 21090 standard required to support the MVP use cases.</owl:versionInfo>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO21090-HarmonizedDatatypes.rdf version of this ontology was modified to incorporate the Multiple Vocabulary Facility (MVF) for consistent representation of controlled vocabularies and code systems, and to align representations of URI-related properties (IDMP-636).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
@@ -444,7 +444,7 @@
 		<rdf:type rdf:resource="&cmns-cds;CodeElement"/>
 		<rdfs:label>datatype code PQ</rdfs:label>
 		<skos:definition>code for a physical quantity</skos:definition>
-		<cmns-av:explanatoryNote>This code denotes a complex concept, i.e., a named individual of type cmns-qtu:QuantityValue that has an inherent unit of measure and numeric value.</cmns-av:explanatoryNote>
+		<cmns-av:explanatoryNote>This code denotes a complex concept, i.e., a named individual of type cmns-qtu:ScalarQuantityValue that has an inherent unit of measure and numeric value.</cmns-av:explanatoryNote>
 		<cmns-col:isMemberOf rdf:resource="&idmp-dtp;ISO21090-CodeSet"/>
 		<cmns-dsg:hasDescription>physical quantity</cmns-dsg:hasDescription>
 		<cmns-txt:hasTextValue>PQ</cmns-txt:hasTextValue>

--- a/ISO/MedicalDictionaryForRegulatoryActivities.rdf
+++ b/ISO/MedicalDictionaryForRegulatoryActivities.rdf
@@ -3,7 +3,6 @@
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
 	<!ENTITY cmns-cds "https://www.omg.org/spec/Commons/CodesAndCodeSets/">
 	<!ENTITY cmns-cls "https://www.omg.org/spec/Commons/Classifiers/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
@@ -11,6 +10,7 @@
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-prd "https://www.omg.org/spec/Commons/ProductsAndServices/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY cmns-txt "https://www.omg.org/spec/Commons/TextDatatype/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
@@ -33,7 +33,6 @@
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
 	xmlns:cmns-cds="https://www.omg.org/spec/Commons/CodesAndCodeSets/"
 	xmlns:cmns-cls="https://www.omg.org/spec/Commons/Classifiers/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
@@ -41,6 +40,7 @@
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-prd="https://www.omg.org/spec/Commons/ProductsAndServices/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:cmns-txt="https://www.omg.org/spec/Commons/TextDatatype/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
@@ -80,6 +80,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/TextDatatype/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
@@ -235,8 +236,8 @@
 		<rdfs:label>MedDRA registration authority</rdfs:label>
 		<skos:definition>Registration authority (RA) for registration of terms or concepts in the Medical Dictionary for Regulatory Activities (MedDRA) played by the MedDRA Maintenance and Support Services Organization (MSSO)</skos:definition>
 		<cmns-av:abbreviation>MedDRA RA</cmns-av:abbreviation>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-meddra;MedDRAMaintenanceAndSupportServicesOrganization"/>
 		<cmns-ra:manages rdf:resource="&idmp-meddra;MedicalDictionaryForRegulatoryActivities"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-meddra;MedDRAMaintenanceAndSupportServicesOrganization"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-meddra;MedDRASystemOrganClass">

--- a/ISO/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities.rdf
+++ b/ISO/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities.rdf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-col "https://www.omg.org/spec/Commons/Collections/">
 	<!ENTITY cmns-cxtdsg "https://www.omg.org/spec/Commons/ContextualDesignators/">
 	<!ENTITY cmns-dsg "https://www.omg.org/spec/Commons/Designators/">
@@ -12,6 +11,7 @@
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-ra "https://www.omg.org/spec/Commons/RegistrationAuthorities/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
 	<!ENTITY idmp-nara "https://spec.pistoiaalliance.org/idmp/ontology/ISO/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities/">
@@ -27,7 +27,6 @@
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-col="https://www.omg.org/spec/Commons/Collections/"
 	xmlns:cmns-cxtdsg="https://www.omg.org/spec/Commons/ContextualDesignators/"
 	xmlns:cmns-dsg="https://www.omg.org/spec/Commons/Designators/"
@@ -38,6 +37,7 @@
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-ra="https://www.omg.org/spec/Commons/RegistrationAuthorities/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
 	xmlns:idmp-nara="https://spec.pistoiaalliance.org/idmp/ontology/ISO/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities/"
@@ -60,7 +60,6 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Collections/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ContextualDesignators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Identifiers/"/>
@@ -69,9 +68,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230901/NorthAmericanJurisdiction/NorthAmericanRegistrationAuthorities/"/>
 		<skos:scopeNote>Note that jurisdiction-specific counterparties and codes are specified in subordinate ontologies supporting those jurisdictions.</skos:scopeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -94,9 +94,9 @@
 		<skos:definition>American Chemical Society (ACS) in its role as a Registration Authority (RA), which is a function of the ACS for registration of substances in the CAS Registry</skos:definition>
 		<cmns-av:abbreviation>ACS RA</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause A.1.2</cmns-av:adaptedFrom>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;AmericanChemicalSociety"/>
 		<cmns-prd:provides rdf:resource="&idmp-nara;ChemicalAbstractsService"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;ChemicalAbstractsServiceRegistry"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;AmericanChemicalSociety"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-nara;CASRegistryNumber">
@@ -224,16 +224,16 @@
 		<rdfs:label>Cosmetic Ingredient Review Registration Authority</rdfs:label>
 		<skos:definition>Cosmetic Ingredient Review (CIR) in its role as a Registration Authority (RA), for content that reflects the review and assessment of the safety of ingredients</skos:definition>
 		<cmns-av:abbreviation>CIR RA</cmns-av:abbreviation>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesFoodAndDrugAdministration"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;CosmeticIngredientReviewDatabase"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesFoodAndDrugAdministration"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;DepartmentOfAgricultureRegistrationAuthority">
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>Department of Agriculture Registration Authority</rdfs:label>
 		<skos:definition>United States Department of Agriculture in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesDepartmentOfAgriculture"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;GermplasmResourcesInformationNetwork"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesDepartmentOfAgriculture"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;DepartmentOfHealthAndHumanServices">
@@ -257,8 +257,8 @@
 		<skos:definition>Food and Drug Administration (FDA) in its role as a Registration Authority (RA), which is a function of the G-SRS for registration of substances in the FDA/USP Global Substance Registry System</skos:definition>
 		<cmns-av:abbreviation>FDA G-SRS RA</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause A.1.5</cmns-av:adaptedFrom>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesFoodAndDrugAdministration"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;GlobalSubstanceRegistrationSystem"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesFoodAndDrugAdministration"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;GermplasmResourcesInformationNetwork">
@@ -366,8 +366,8 @@
 		<rdfs:label>Integrated Taxonomic Information System Registration Authority</rdfs:label>
 		<skos:definition>Integrated Taxonomic Information System (ITIS) in its role as a Registration Authority (RA), which is multi-agency organization that involves specialists from around the world to assemble scientific names and their taxonomic relationships, and distribute that data through publicly available software</skos:definition>
 		<cmns-av:abbreviation>ITIS</cmns-av:abbreviation>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;IntegratedTaxonomicInformationSystemOrganization"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;IntegratedTaxonomicInformationSystem"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;IntegratedTaxonomicInformationSystemOrganization"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-nara;IntegratedTaxonomicInformationSystemTaxonomicSerialNumber">
@@ -480,8 +480,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>National Cancer Institute registration authority</rdfs:label>
 		<skos:definition>National Cancer Institute in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;NationalCancerInstitute"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;NationalCancerInstituteThesaurus"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;NationalCancerInstitute"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;NationalCancerInstituteThesaurus">
@@ -567,8 +567,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>National Center For Biotechnology Information registration authority</rdfs:label>
 		<skos:definition>National Center For Biotechnology Information in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;NationalCenterForBiotechnologyInformation"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;NationalCenterForBiotechnologyInformationTaxonomyDatabase"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;NationalCenterForBiotechnologyInformation"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;NationalCenterForBiotechnologyInformationTaxonomyDatabase">
@@ -652,8 +652,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>National Library of Medicine Registration Authority</rdfs:label>
 		<skos:definition>National Library of Medicine (NLM) in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;NationalLibraryOfMedicine"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;MedicalSubjectHeadings"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;NationalLibraryOfMedicine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;NationalPlantDataTeam">
@@ -677,8 +677,8 @@
 		<rdfs:label>OMx Personal Health Analytics, Inc. as registration authority</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.drugbank.com/"/>
 		<skos:definition>OMx Personal Health Analytics in its role as the registration authority for the DrugBank Online repository</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;OMxPersonalHealthAnalyticsInc"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;DrugBank"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;OMxPersonalHealthAnalyticsInc"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-nara;OrphanDrugProductDesignationDatabase">
@@ -824,8 +824,8 @@
 		<rdf:type rdf:resource="&cmns-ra;RegistrationAuthority"/>
 		<rdfs:label>Veterans Health Administration Registration Authority</rdfs:label>
 		<skos:definition>Veterans Health Administration in its role as a Registration Authority (RA)</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-nara;VeteransHealthAdministration"/>
 		<cmns-ra:manages rdf:resource="&idmp-nara;NationalDrugFileReferenceTerminology"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-nara;VeteransHealthAdministration"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/ISO/NorthAmericanJurisdiction/NorthAmericanRegulatoryAgencies.rdf
+++ b/ISO/NorthAmericanJurisdiction/NorthAmericanRegulatoryAgencies.rdf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY cmns-av "https://www.omg.org/spec/Commons/AnnotationVocabulary/">
-	<!ENTITY cmns-cmp "https://www.omg.org/spec/Commons/Composites/">
 	<!ENTITY cmns-ge "https://www.omg.org/spec/Commons/GovernmentEntities/">
 	<!ENTITY cmns-org "https://www.omg.org/spec/Commons/Organizations/">
 	<!ENTITY cmns-pts "https://www.omg.org/spec/Commons/PartiesAndSituations/">
 	<!ENTITY cmns-rga "https://www.omg.org/spec/Commons/RegulatoryAgencies/">
+	<!ENTITY cmns-rlcmp "https://www.omg.org/spec/Commons/RolesAndCompositions/">
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY idmp-chg "https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/">
 	<!ENTITY idmp-mprd "https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/">
@@ -20,11 +20,11 @@
 ]>
 <rdf:RDF xml:base="https://spec.pistoiaalliance.org/idmp/ontology/ISO/NorthAmericanJurisdiction/NorthAmericanRegulatoryAgencies/"
 	xmlns:cmns-av="https://www.omg.org/spec/Commons/AnnotationVocabulary/"
-	xmlns:cmns-cmp="https://www.omg.org/spec/Commons/Composites/"
 	xmlns:cmns-ge="https://www.omg.org/spec/Commons/GovernmentEntities/"
 	xmlns:cmns-org="https://www.omg.org/spec/Commons/Organizations/"
 	xmlns:cmns-pts="https://www.omg.org/spec/Commons/PartiesAndSituations/"
 	xmlns:cmns-rga="https://www.omg.org/spec/Commons/RegulatoryAgencies/"
+	xmlns:cmns-rlcmp="https://www.omg.org/spec/Commons/RolesAndCompositions/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:idmp-chg="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"
 	xmlns:idmp-mprd="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"
@@ -45,13 +45,13 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Composites/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/GovernmentEntities/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/Organizations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/NorthAmericanJurisdiction/NorthAmericanRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230901/NorthAmericanJurisdiction/NorthAmericanRegulatoryAgencies/"/>
 		<skos:scopeNote>Note that jurisdiction-specific counterparties and codes are specified in subordinate ontologies supporting those jurisdictions.</skos:scopeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
@@ -112,11 +112,11 @@
 		<rdf:type rdf:resource="&idmp-mprd;MedicinesRegulatoryAgency"/>
 		<rdfs:label>United States Food and Drug Administration as medicines regulatory agency</rdfs:label>
 		<skos:definition>United States Food and Drug Administration in its role as a regulator of medicinal products</skos:definition>
-		<cmns-cmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesFoodAndDrugAdministration"/>
 		<cmns-rga:hasJurisdiction rdf:resource="&idmp-narga;RegulatoryContext-ActiveMoietyForFoodAndDrugAdministrationExclusivity"/>
 		<cmns-rga:hasJurisdiction rdf:resource="&idmp-narga;RegulatoryContext-FoodAndDrugAdministrationGeneral"/>
 		<cmns-rga:hasJurisdiction rdf:resource="&idmp-narga;RegulatoryContext-PatentExclusivity"/>
 		<cmns-rga:hasJurisdiction rdf:resource="&idmp-narga;UnitedStatesJurisdiction"/>
+		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-narga;UnitedStatesFoodAndDrugAdministration"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-narga;UnitedStatesJurisdiction">

--- a/ISO/catalog-v001.xml
+++ b/ISO/catalog-v001.xml
@@ -10,7 +10,7 @@
     <uri id="2666a665-1eb3-4861-853e-46b7e2884b11" name="https://www.omg.org/spec/Commons/Classifiers/" uri="../CMNS/Classifiers.rdf"/>
     <uri id="487852bc-e93c-4a48-819a-f85c628a7827" name="https://www.omg.org/spec/Commons/CodesAndCodeSets/" uri="../CMNS/CodesAndCodeSets.rdf"/>
     <uri id="d272bce4-9d8a-4133-88bd-6740c438bfad" name="https://www.omg.org/spec/Commons/Collections/" uri="../CMNS/Collections.rdf"/>
-	<uri id="4636ca20-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/Composites/" uri="../CMNS/Composites.rdf"/>
+	<uri id="4636ca20-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="../CMNS/Composites.rdf"/>
     <uri id="0b266894-0db9-4694-9b71-5afc0b196a88" name="https://www.omg.org/spec/Commons/ContextualDesignators/" uri="../CMNS/ContextualDesignators.rdf"/>
     <uri id="15503e2f-9e50-4441-80dd-1412b4fa48b2" name="https://www.omg.org/spec/Commons/ContextualIdentifiers/" uri="../CMNS/ContextualIdentifiers.rdf"/>
     <uri id="d79377c3-b5f9-4225-872c-70c4009a4375" name="https://www.omg.org/spec/Commons/DatesAndTimes/" uri="../CMNS/DatesAndTimes.rdf"/>

--- a/ISO/catalog-v001.xml
+++ b/ISO/catalog-v001.xml
@@ -10,7 +10,7 @@
     <uri id="2666a665-1eb3-4861-853e-46b7e2884b11" name="https://www.omg.org/spec/Commons/Classifiers/" uri="../CMNS/Classifiers.rdf"/>
     <uri id="487852bc-e93c-4a48-819a-f85c628a7827" name="https://www.omg.org/spec/Commons/CodesAndCodeSets/" uri="../CMNS/CodesAndCodeSets.rdf"/>
     <uri id="d272bce4-9d8a-4133-88bd-6740c438bfad" name="https://www.omg.org/spec/Commons/Collections/" uri="../CMNS/Collections.rdf"/>
-	<uri id="4636ca20-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="../CMNS/Composites.rdf"/>
+	<uri id="4636ca20-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="../CMNS/RolesAndCompositions.rdf"/>
     <uri id="0b266894-0db9-4694-9b71-5afc0b196a88" name="https://www.omg.org/spec/Commons/ContextualDesignators/" uri="../CMNS/ContextualDesignators.rdf"/>
     <uri id="15503e2f-9e50-4441-80dd-1412b4fa48b2" name="https://www.omg.org/spec/Commons/ContextualIdentifiers/" uri="../CMNS/ContextualIdentifiers.rdf"/>
     <uri id="d79377c3-b5f9-4225-872c-70c4009a4375" name="https://www.omg.org/spec/Commons/DatesAndTimes/" uri="../CMNS/DatesAndTimes.rdf"/>

--- a/MetadataIDMP.rdf
+++ b/MetadataIDMP.rdf
@@ -37,8 +37,8 @@
 		<rdfs:label>Metadata for the IDMP Metadata Ontology</rdfs:label>
 		<dct:abstract>The IDMP metadata specification consists of all metadata describing the various modules and ontologies that make up the IDMP-O ontology and supports the data management and governance program for the Identification of Medicinal Products (IDMP) Ontology project.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2022-09-20T18:00:00</dct:issued>
-		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:modified rdf:datatype="&xsd;dateTime">2023-07-21T18:00:00</dct:modified>
+		<dct:license rdf:datatype="&xsd;anyURI">https://opensource.org/licenses/MIT</dct:license>
+		<dct:modified rdf:datatype="&xsd;dateTime">2023-09-20T18:00:00</dct:modified>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/EXT/MetadataEXT/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/MetadataISO/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/META/MetadataMETA/"/>
@@ -47,13 +47,13 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/MetadataCMNS/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/MetadataLCC/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MetadataMVF/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230701/MetadataIDMP/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230901/MetadataIDMP/"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&idmp-spec;IDMPMetadataSpecification">
-		<rdf:type rdf:resource="&cmns-doc;TechnicalSpecification"/>
+		<rdf:type rdf:resource="&cmns-doc;TechnicalSpecificationDocument"/>
 		<rdfs:label>IDMP metadata specification</rdfs:label>
 		<dct:abstract>The IDMP metadata specification consists of all metadata describing the various modules and ontologies that make up the IDMP-O ontology and supports the data management and governance program for the Identification of Medicinal Products (IDMP) Ontology project.</dct:abstract>
 		<dct:hasPart rdf:resource="&idmp-ext-mod;EXTModule"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -10,7 +10,7 @@
     <uri id="55e54f5b-afdf-4b3e-8224-02ec39b4d7f4" name="https://www.omg.org/spec/Commons/Classifiers/" uri="./CMNS/Classifiers.rdf"/>
     <uri id="7a55f9af-d670-4a71-a73a-921f01a8eae8" name="https://www.omg.org/spec/Commons/CodesAndCodeSets/" uri="./CMNS/CodesAndCodeSets.rdf"/>
     <uri id="6c7cccd9-6b54-41ed-8a46-0d975cadfb20" name="https://www.omg.org/spec/Commons/Collections/" uri="./CMNS/Collections.rdf"/>
-	<uri id="547f8d1a-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="./CMNS/Composites.rdf"/>
+	<uri id="547f8d1a-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="./CMNS/RolesAndCompositions.rdf"/>
     <uri id="13647242-d44a-41c3-a6bf-441543da5783" name="https://www.omg.org/spec/Commons/ContextualDesignators/" uri="./CMNS/ContextualDesignators.rdf"/>
     <uri id="7050ad44-6375-4465-8ba9-a773c400cf6a" name="https://www.omg.org/spec/Commons/ContextualIdentifiers/" uri="./CMNS/ContextualIdentifiers.rdf"/>
     <uri id="5cf045a8-2900-4db3-8f24-df9fb90bb620" name="https://www.omg.org/spec/Commons/DatesAndTimes/" uri="./CMNS/DatesAndTimes.rdf"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -10,7 +10,7 @@
     <uri id="55e54f5b-afdf-4b3e-8224-02ec39b4d7f4" name="https://www.omg.org/spec/Commons/Classifiers/" uri="./CMNS/Classifiers.rdf"/>
     <uri id="7a55f9af-d670-4a71-a73a-921f01a8eae8" name="https://www.omg.org/spec/Commons/CodesAndCodeSets/" uri="./CMNS/CodesAndCodeSets.rdf"/>
     <uri id="6c7cccd9-6b54-41ed-8a46-0d975cadfb20" name="https://www.omg.org/spec/Commons/Collections/" uri="./CMNS/Collections.rdf"/>
-	<uri id="547f8d1a-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/Composites/" uri="./CMNS/Composites.rdf"/>
+	<uri id="547f8d1a-3da2-11ee-be56-0242ac120002" name="https://www.omg.org/spec/Commons/RolesAndCompositions/" uri="./CMNS/Composites.rdf"/>
     <uri id="13647242-d44a-41c3-a6bf-441543da5783" name="https://www.omg.org/spec/Commons/ContextualDesignators/" uri="./CMNS/ContextualDesignators.rdf"/>
     <uri id="7050ad44-6375-4465-8ba9-a773c400cf6a" name="https://www.omg.org/spec/Commons/ContextualIdentifiers/" uri="./CMNS/ContextualIdentifiers.rdf"/>
     <uri id="5cf045a8-2900-4db3-8f24-df9fb90bb620" name="https://www.omg.org/spec/Commons/DatesAndTimes/" uri="./CMNS/DatesAndTimes.rdf"/>

--- a/etc/CQ/Example/uc1_cq1.sparql
+++ b/etc/CQ/Example/uc1_cq1.sparql
@@ -1,6 +1,6 @@
 # UC1-CQ 1: What substances have a common active moiety <$ActiveMoiety>?
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 PREFIX rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:        <http://www.w3.org/2000/01/rdf-schema#>
@@ -21,9 +21,9 @@ WHERE {
   	} UNION {
     	# Use the $ActiveMoiety in a role for composition that defines a substance.
     	[] cmns-dsg:defines ?Substance ;
-      	 	cmns-cmp:hasRole [
+      	 	cmns-rlcmp:hasRole [
       			a idmp-sub:ActiveMoietyRole ;
-    			cmns-cmp:isPlayedBy $ActiveMoiety
+    			cmns-rlcmp:isPlayedBy $ActiveMoiety
     	] .
   	}
      

--- a/etc/CQ/Example/uc1_cq2.sparql
+++ b/etc/CQ/Example/uc1_cq2.sparql
@@ -1,6 +1,6 @@
 # UC1-CQ 2: What is the active moiety of <substance>?
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 PREFIX rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:        <http://www.w3.org/2000/01/rdf-schema#>
@@ -21,9 +21,9 @@ WHERE {
   	} UNION {
     	# Find the Active Moiety using it in a role of a substance composition that defines the $Substance.
     	[] cmns-dsg:defines $Substance ;
-      	 	cmns-cmp:hasRole [
+      	 	cmns-rlcmp:hasRole [
       			a idmp-sub:ActiveMoietyRole ;
-    			cmns-cmp:isPlayedBy ?ActiveMoiety
+    			cmns-rlcmp:isPlayedBy ?ActiveMoiety
     	] .
   	}
      

--- a/etc/CQ/Example/uc1_cq3-1.sparql
+++ b/etc/CQ/Example/uc1_cq3-1.sparql
@@ -1,6 +1,6 @@
 # UC1-CQ 3-1:  What is the basis of strength for <substance x> in <product y>?
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-qtu: <https://www.omg.org/spec/Commons/QuantitiesAndUnits/>
 PREFIX idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
@@ -30,7 +30,7 @@ WHERE {
   	[] 	cmns-dsg:defines $Product ;
       	idmp-mprd:hasActiveIngredient [ 
     		idmp-mprd:hasStrength ?BasisOfStrength ;
-  			cmns-cmp:isPlayedBy $Substance ] .
+  			cmns-rlcmp:isPlayedBy $Substance ] .
   
   	# Get the Basis of Strength's numerator value and unit
   	?BasisOfStrength cmns-qtu:hasNumerator [

--- a/etc/CQ/Example/uc1_cq3.sparql
+++ b/etc/CQ/Example/uc1_cq3.sparql
@@ -1,6 +1,6 @@
 # UC1-CQ 3:  What are the products that contain substances with common active moiety <active moiety x>?
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-qtu:    <https://www.omg.org/spec/Commons/QuantitiesAndUnits/>
 PREFIX idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
@@ -22,9 +22,9 @@ WHERE {
         } UNION {
         # Use the $ActiveMoiety in a role for composition that defines a substance.
         [] cmns-dsg:defines ?Substance ;
-                cmns-cmp:hasRole [
+                cmns-rlcmp:hasRole [
                        a idmp-sub:ActiveMoietyRole ;
-                       cmns-cmp:isPlayedBy $ActiveMoiety
+                       cmns-rlcmp:isPlayedBy $ActiveMoiety
         ] .
         } UNION {
     BIND($ActiveMoiety AS ?Substance)
@@ -37,7 +37,7 @@ WHERE {
         # Using Shortcut 
         ?Product cmns-dsg:isDefinedIn|^cmns-dsg:defines [ ?hasRole 
             [ 
-                cmns-cmp:isPlayedBy ?Substance;
+                cmns-rlcmp:isPlayedBy ?Substance;
                 a/rdfs:subClassOf* idmp-sub:Ingredient
             ] 
         ]
@@ -60,7 +60,7 @@ WHERE {
         ?IngredientUri rdf:type ?ingredientType .
                 
         # Ingredient to Specified Substance
-        ?IngredientUri cmns-cmp:isPlayedBy ?specifiedSubstanceUri .
+        ?IngredientUri cmns-rlcmp:isPlayedBy ?specifiedSubstanceUri .
 
         # connect product COmposition to Ingredient
         ?productCompositionUri idmp-sub:hasIngredient ?IngredientUri .

--- a/etc/CQ/Example/uc1_cq6.sparql
+++ b/etc/CQ/Example/uc1_cq6.sparql
@@ -11,7 +11,7 @@ prefix cmns-txt:    <https://www.omg.org/spec/Commons/TextDatatype/>
 prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> 
 prefix idmp-mprd: <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 prefix cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
-prefix cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+prefix cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 prefix cmns-pts: <https://www.omg.org/spec/Commons/PartiesAndSituations/>
 
 SELECT DISTINCT ?MedicinalProduct (SAMPLE(?MedicinalProductLabel) AS ?MedicinalProductName)
@@ -23,7 +23,7 @@ WHERE {
 	$Substance idmp-sub:hasActiveMoiety $ActiveMoiety .
 
  	#Find Medicinal Products that play a role of Authorized or Investigational Medicinal Products 
-  	$AuthorizationRole cmns-cmp:isPlayedBy ?MedicinalProduct .
+  	$AuthorizationRole cmns-rlcmp:isPlayedBy ?MedicinalProduct .
 	?MedicinalProduct a idmp-mprd:MedicinalProduct .
 	{ $AuthorizationRole a idmp-mprd:AuthorizedMedicinalProduct} union { $AuthorizationRole a idmp-mprd:InvestigationalMedicinalProduct } .
   	?MedicinalProduct cmns-col:comprises $PharmaceuticalProduct .
@@ -32,12 +32,12 @@ WHERE {
 		# Find pharmaceutical products that have $Substance as an Ingredient 
 		$PharmaceuticalProduct ^cmns-dsg:defines|cmns-dsg:isDefinedIn $ProductComposition .
 		$SubstanceInIngredientRole cmns-pts:isRealizedIn $ProductComposition .
-		$SubstanceInIngredientRole cmns-cmp:isPlayedBy $Substance .
+		$SubstanceInIngredientRole cmns-rlcmp:isPlayedBy $Substance .
 	} UNION {
   		# Find other medicinal products that contain substances with $ActiveMoiety
     	$PharmaceuticalProduct ^cmns-dsg:defines|cmns-dsg:isDefinedIn $ProductComposition .
 		$SubstanceInIngredientRole cmns-pts:isRealizedIn $ProductComposition .
-		$SubstanceInIngredientRole cmns-cmp:isPlayedBy $SubstanceSharingMoiety .
+		$SubstanceInIngredientRole cmns-rlcmp:isPlayedBy $SubstanceSharingMoiety .
     	$SubstanceSharingMoiety  idmp-sub:hasActiveMoiety $ActiveMoiety .
   	}
     

--- a/etc/CQ/Example/uc1_cq7.sparql
+++ b/etc/CQ/Example/uc1_cq7.sparql
@@ -1,7 +1,7 @@
 # CQ 7: Which manufactured items contain substance <x> as ingredient of type “active”?
 prefix cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
 prefix cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-prefix cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+prefix cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 prefix cmns-qtu:    <https://www.omg.org/spec/Commons/QuantitiesAndUnits/>
 prefix idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/> 
 prefix idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
@@ -19,7 +19,7 @@ WHERE {
         ?ManufacturedItem rdf:type/rdfs:subClassOf* idmp-sub:ManufacturedItem ;
             cmns-dsg:isDefinedIn[
                 idmp-sub:hasIngredient [
-                    cmns-cmp:isPlayedBy [
+                    cmns-rlcmp:isPlayedBy [
                         cmns-qtu:specializes $SUBSTANCE
                     ]
                 ]
@@ -29,7 +29,7 @@ WHERE {
         ?ManufacturedItem a/rdfs:subClassOf* idmp-sub:ManufacturedItem ;
             cmns-dsg:isDefinedIn [
                 idmp-mprd:hasActiveIngredient [
-                    cmns-cmp:isPlayedBy $SUBSTANCE
+                    cmns-rlcmp:isPlayedBy $SUBSTANCE
                 ]
             ] .
     }

--- a/etc/CQ/Example/uc1_cq8.sparql
+++ b/etc/CQ/Example/uc1_cq8.sparql
@@ -2,7 +2,7 @@
 
 prefix cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
 prefix cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-prefix cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+prefix cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 prefix idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 prefix idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> 
@@ -21,7 +21,7 @@ WHERE {
 	 ] .
 
   	# Find Manufactured Items and that have the role of Investigational Medicinal product
-    ?InvestigationalMedicinalProduct cmns-cmp:isPlayedBy $MedicinalProduct .
+    ?InvestigationalMedicinalProduct cmns-rlcmp:isPlayedBy $MedicinalProduct .
     ?InvestigationalMedicinalProduct rdf:type idmp-mprd:InvestigationalMedicinalProduct .
 
 	# Optionally, get the name of the Medicinal Product

--- a/etc/CQ/Example/uc2_cq1-2.sparql
+++ b/etc/CQ/Example/uc2_cq1-2.sparql
@@ -1,7 +1,7 @@
 #UC2 CQ 1.2 	In which production/manufacturing steps is substance <S> used?
 
 PREFIX cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
-PREFIX cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 PREFIX rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -19,15 +19,15 @@ WHERE {
     # Substance directly plays a roll of a Material 
   	$MaterialRole  
       a/rdfs:subClassOf* idmp-sub:MaterialRole ;
-      cmns-cmp:isManifestedIn ?ProcessStep ;
-      cmns-cmp:isPlayedBy $Substance .
+      cmns-rlcmp:isManifestedIn ?ProcessStep ;
+      cmns-rlcmp:isPlayedBy $Substance .
       
   } UNION  {
     # Substance comprises something that is used as a material
     $MaterialRole  
       a/rdfs:subClassOf* idmp-sub:MaterialRole ;
-      cmns-cmp:isManifestedIn ?ProcessStep ;
-      cmns-cmp:isPlayedBy [ cmns-col:comprises $Substance ]
+      cmns-rlcmp:isManifestedIn ?ProcessStep ;
+      cmns-rlcmp:isPlayedBy [ cmns-col:comprises $Substance ]
   }
   
     # Make sure that we only return actual process steps

--- a/etc/CQ/Example/uc2_cq1.sparql
+++ b/etc/CQ/Example/uc2_cq1.sparql
@@ -1,7 +1,7 @@
 #UC2-CQ 1: In which manufactured item is substance <$Substance> used?
 
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 PREFIX rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:        <http://www.w3.org/2000/01/rdf-schema#>
@@ -16,7 +16,7 @@ WHERE {
 
 	# Find products that include the manufactured item based on their composition
 	?ManufacturedItem cmns-dsg:isDefinedIn [ $Role [
-            cmns-cmp:isPlayedBy $Substance
+            cmns-rlcmp:isPlayedBy $Substance
         ]
     ] .
   

--- a/etc/CQ/Example/uc2_cq1a.sparql
+++ b/etc/CQ/Example/uc2_cq1a.sparql
@@ -1,7 +1,7 @@
 #UC2-CQ 1a: In which products (as active, excipient, packaging) is substance <$TargetSubstance> found?
 
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 PREFIX rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -16,7 +16,7 @@ WHERE {
 
     [] cmns-dsg:defines ?Product ;
     $Role [
-        cmns-cmp:isPlayedBy $TargetSubstance
+        cmns-rlcmp:isPlayedBy $TargetSubstance
     ] .
   
       # Make sure that we only return actual substances

--- a/etc/CQ/Example/uc2_cq1b.sparql
+++ b/etc/CQ/Example/uc2_cq1b.sparql
@@ -6,7 +6,7 @@ PREFIX rdfs:        <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX cmns-prd: 	<https://www.omg.org/spec/Commons/ProductsAndServices/>
 PREFIX cmns-dsg:   <https://www.omg.org/spec/Commons/Designators/>
 PREFIX cmns-col: <https://www.omg.org/spec/Commons/Collections/>
-PREFIX cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX idmp-mprd: <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 
 
@@ -62,7 +62,7 @@ WHERE {
     	$IntermediatePackaging idmp-mprd:contains $PharmaceuticalProduct . 
     	$PharmaceuticalProductComposition cmns-dsg:defines $PharmaceuticalProduct .
     	$PharmaceuticalProductComposition idmp-mprd:hasActiveIngredient[
-			cmns-cmp:isPlayedBy $Substance
+			cmns-rlcmp:isPlayedBy $Substance
 		] .
 		# Make sure that we only return actual substances
 		?StockKeepingUnit a/rdfs:subClassOf* cmns-prd:StockKeepingUnit .
@@ -80,7 +80,7 @@ WHERE {
     	$IntermediatePackaging idmp-mprd:contains $PharmaceuticalProduct . 
     	$PharmaceuticalProductComposition cmns-dsg:defines $PharmaceuticalProduct .
     	$PharmaceuticalProductComposition idmp-mprd:hasActiveIngredient[
-			cmns-cmp:isPlayedBy $Substance
+			cmns-rlcmp:isPlayedBy $Substance
 		] .
 		# Make sure that we only return actual substances
 		?StockKeepingUnit a/rdfs:subClassOf* cmns-prd:StockKeepingUnit .
@@ -96,7 +96,7 @@ WHERE {
     	$IntermediatePackaging idmp-mprd:contains $PharmaceuticalProduct . 
     	$PharmaceuticalProductComposition cmns-dsg:defines $PharmaceuticalProduct .
     	$PharmaceuticalProductComposition idmp-mprd:hasActiveIngredient[
-			cmns-cmp:isPlayedBy [ 
+			cmns-rlcmp:isPlayedBy [ 
 				^idmp-sub:isActiveMoietyOf|idmp-sub:hasActiveMoiety $Substance 
 			]
 		] .
@@ -116,7 +116,7 @@ WHERE {
     	$IntermediatePackaging idmp-mprd:contains $PharmaceuticalProduct . 
     	$PharmaceuticalProductComposition cmns-dsg:defines $PharmaceuticalProduct .
        	$PharmaceuticalProductComposition idmp-mprd:hasActiveIngredient[
-			cmns-cmp:isPlayedBy [ 
+			cmns-rlcmp:isPlayedBy [ 
 				^idmp-sub:isActiveMoietyOf|idmp-sub:hasActiveMoiety $Substance 
 			]
 		] .

--- a/etc/CQ/Example/uc2_cq2-1.sparql
+++ b/etc/CQ/Example/uc2_cq2-1.sparql
@@ -1,7 +1,7 @@
 #UC2 CQ 2.1 	Which Marketing Authorization Number(s) does a sellable article (Material in ERP) have?
 PREFIX cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
 PREFIX cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
-PREFIX cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-id: <https://www.omg.org/spec/Commons/Identifiers/>
 PREFIX idmp-mprd:   <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/>
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
@@ -16,7 +16,7 @@ WHERE {
 	# Example for AMPLODIPINE: <https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/AmlodipineExample/NorvascMedicinalProduct>
     BIND( uc2_cq2-1_parameter_1 AS $SellalbeArticle )
 
-    $AuthorizedMedicinalProduct cmns-cmp:isPlayedBy $SellalbeArticle .
+    $AuthorizedMedicinalProduct cmns-rlcmp:isPlayedBy $SellalbeArticle .
     $AuthorizedMedicinalProduct idmp-mprd:hasAuthorization $Authorization .
     $Authorization cmns-cxtdsg:isApplicableIn ?Jurisdiction . 
     ?MarketingAuthorizationNumber cmns-id:identifies $Authorization 

--- a/etc/CQ/Example/uc3_cq1-1.sparql
+++ b/etc/CQ/Example/uc3_cq1-1.sparql
@@ -7,7 +7,7 @@ PREFIX idmp-ra: <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Reg
 PREFIX idmp-sub:    <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
 PREFIX idmp-phprd: <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/> 
 PREFIX cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
-PREFIX cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-ctxdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
 PREFIX cmns-dsg:   <https://www.omg.org/spec/Commons/Designators/>
 PREFIX cmns-id: <https://www.omg.org/spec/Commons/Identifiers/>
@@ -36,11 +36,11 @@ WHERE {
 		} UNION {
 			?TherapeuticIndication cmns-ctxdsg:isApplicableIn ?AuthorizedMedicinalProduct .
 			?AuthorizedMedicinalProduct a idmp-mprd:AuthorizedMedicinalProduct .
-		    ?AuthorizedMedicinalProduct (cmns-cmp:isPlayedBy|^cmns-cmp:playsRole) ?MedicinalProduct  .
+		    ?AuthorizedMedicinalProduct (cmns-rlcmp:isPlayedBy|^cmns-rlcmp:playsRole) ?MedicinalProduct  .
 		} UNION {
 			?TherapeuticIndication cmns-ctxdsg:isApplicableIn ?InvestigationalMedicinalProduct .
 			?InvestigationalMedicinalProduct a idmp-mprd:InvestigationalMedicinalProduct .
-		    ?InvestigationalMedicinalProduct (cmns-cmp:isPlayedBy|^cmns-cmp:playsRole) ?MedicinalProduct  .
+		    ?InvestigationalMedicinalProduct (cmns-rlcmp:isPlayedBy|^cmns-rlcmp:playsRole) ?MedicinalProduct  .
 		}
 	
 		
@@ -49,7 +49,7 @@ WHERE {
         ?Product ^cmns-dsg:defines|cmns-dsg:isDefinedIn ?ProductComposition .
     	?Product ^cmns-dsg:defines|cmns-dsg:isDefinedIn ?ProductComposition .
 		?SubstanceInIngredientRole cmns-pts:isRealizedIn ?ProductComposition .
-		?SubstanceInIngredientRole cmns-cmp:isPlayedBy ?Substance .
+		?SubstanceInIngredientRole cmns-rlcmp:isPlayedBy ?Substance .
 
 		# Make sure that we only return actual substances
         ?Substance a/rdfs:subClassOf* idmp-sub:Substance .

--- a/etc/CQ/Example/uc3_cq2.sparql
+++ b/etc/CQ/Example/uc3_cq2.sparql
@@ -1,7 +1,7 @@
 #UC3 CQ 2 	What ingredient role (excipient, ...) played by a substance <S> is part of what (authorized, investigational) medicinal product that has a therapeutic indication indicated by a MedDRA ID <I>?
 
 PREFIX cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
-PREFIX cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-ctxdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
 PREFIX cmns-dsg:   <https://www.omg.org/spec/Commons/Designators/>
 PREFIX cmns-id: <https://www.omg.org/spec/Commons/Identifiers/>
@@ -33,12 +33,12 @@ WHERE {
 		{
 			?TherapeuticIndication cmns-ctxdsg:isApplicableIn ?ProductRole .
 			?ProductRole a idmp-mprd:AuthorizedMedicinalProduct .
-		    ?ProductRole (cmns-cmp:isPlayedBy|^cmns-cmp:playsRole) ?MedicinalProduct  .
+		    ?ProductRole (cmns-rlcmp:isPlayedBy|^cmns-rlcmp:playsRole) ?MedicinalProduct  .
 			idmp-mprd:AuthorizedMedicinalProduct rdfs:label ?ProductRoleType .
 		} UNION {
 			?TherapeuticIndication cmns-ctxdsg:isApplicableIn ?ProductRole .
 			?ProductRole a idmp-mprd:InvestigationalMedicinalProduct .
-		    ?ProductRole (cmns-cmp:isPlayedBy|^cmns-cmp:playsRole) ?MedicinalProduct  .
+		    ?ProductRole (cmns-rlcmp:isPlayedBy|^cmns-rlcmp:playsRole) ?MedicinalProduct  .
 			idmp-mprd:InvestigationalMedicinalProduct rdfs:label ?ProductRoleType .
 		}
 	
@@ -48,7 +48,7 @@ WHERE {
         ?Product ^cmns-dsg:defines|cmns-dsg:isDefinedIn ?ProductComposition .
     	?Product ^cmns-dsg:defines|cmns-dsg:isDefinedIn ?ProductComposition .
 		?SubstanceInIngredientRole cmns-pts:isRealizedIn ?ProductComposition .
-		?SubstanceInIngredientRole cmns-cmp:isPlayedBy ?Substance .
+		?SubstanceInIngredientRole cmns-rlcmp:isPlayedBy ?Substance .
 		
 		# Find most specific ingredient role
 		?SubstanceInIngredientRole a/rdfs:subClassOf* ?IngredientClass .

--- a/etc/CQ/Example/uc3_cq3.sparql
+++ b/etc/CQ/Example/uc3_cq3.sparql
@@ -1,5 +1,5 @@
 #UC3 CQ 3 	Has a substance <S> with a specific ingredient role <R> been part of an approved medicinal product <P> dosed by route of administration <A>?
-PREFIX cmns-cmp:    <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp:    <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-col:    <https://www.omg.org/spec/Commons/Collections/>
 PREFIX cmns-ctxdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
 PREFIX cmns-dsg:    <https://www.omg.org/spec/Commons/Designators/>
@@ -35,7 +35,7 @@ WHERE {
 		?PharmaceuticalProduct idmp-mprd:hasRouteOfAdministration ?RouteOfAdministration ;
 		    ^cmns-col:comprises ?MedicinalProduct .
 			
-        ?MedicinalProduct (cmns-cmp:playsRole|^cmns-cmp:isPlayedBy) ?AuthorizedMedicinalProduct .
+        ?MedicinalProduct (cmns-rlcmp:playsRole|^cmns-rlcmp:isPlayedBy) ?AuthorizedMedicinalProduct .
 		?AuthorizedMedicinalProduct a idmp-mprd:AuthorizedMedicinalProduct .
 
 
@@ -44,7 +44,7 @@ WHERE {
   	    # Find the substance that is part of product composition which defines Product that is comprised of MedicinalProduct
 		?PharmaceuticalProduct ^cmns-dsg:defines|cmns-dsg:isDefinedIn ?ProductComposition .
     	?SubstanceInIngredientRole cmns-pts:isRealizedIn ?ProductComposition .
-		?SubstanceInIngredientRole cmns-cmp:isPlayedBy ?Substance .
+		?SubstanceInIngredientRole cmns-rlcmp:isPlayedBy ?Substance .
 		
 		# Find most specific ingredient role
 		?SubstanceInIngredientRole a/rdfs:subClassOf* ?IngredientClass .

--- a/etc/transformation/GSRS/gsrs-public-data-relationships.rqg
+++ b/etc/transformation/GSRS/gsrs-public-data-relationships.rqg
@@ -1,7 +1,7 @@
 PREFIX iter: <http://w3id.org/sparql-generate/iter/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
-PREFIX cmns-cmp: <https://www.omg.org/spec/Commons/Composites/>
+PREFIX cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 PREFIX cmns-pts: <https://www.omg.org/spec/Commons/PartiesAndSituations/>
 PREFIX idmp-ra:  <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-RegistrationAuthorities/>
 PREFIX idmp-sub:  <https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11238-Substances/>
@@ -12,18 +12,18 @@ GENERATE {
     ?Substance ?SubstancesRelationshipProperty ?RelatedSubstance .
 
     # Has Active Moiety Role and Concept
-    ?RelatedSubstanceAssociatedWithActiveMoietyRole cmns-cmp:playsRole ?ActiveMoietyRole .
+    ?RelatedSubstanceAssociatedWithActiveMoietyRole cmns-rlcmp:playsRole ?ActiveMoietyRole .
 
     # Is Active Moiety Of
     # ?RelatedSubstance ?IsActiveMoietyOfProperty ?Substance .
 
     ?ActiveMoietyRole a ?MoietyRole ;
         cmns-cxtdsg:isApplicableIn ?RegulatoryContext;
-        cmns-cmp:isPlayedBy ?RelatedSubstanceAssociatedWithActiveMoietyRole ;
-        cmns-cmp:isManifestedIn ?SubstanceAssociatedWithActiveMoietyRole ;
+        cmns-rlcmp:isPlayedBy ?RelatedSubstanceAssociatedWithActiveMoietyRole ;
+        cmns-rlcmp:isManifestedIn ?SubstanceAssociatedWithActiveMoietyRole ;
         .
 
-    ?SubstanceAssociatedWithActiveMoietyRole cmns-cmp:manifests ?ActiveMoietyRole .
+    ?SubstanceAssociatedWithActiveMoietyRole cmns-rlcmp:manifests ?ActiveMoietyRole .
 
     ?RegulatoryContext cmns-cxtdsg:appliesTo ?ActiveMoietyRole .
 


### PR DESCRIPTION
Description:
1. Integrate updated dates and times ontology, which adds concepts including time period, explicit time period, and a number of properties (monotonically - i.e., in a backwards compatible way with the prior version,
2. Integrate changes to the Documents ontology, including addressing some of the simplifications made by OMG, such as moving Specification to the top of the class hierarchy, renaming isSpecifiedBy to isSpecifiedIn, and so forth,
3. Integrate changes to the QuantitiesAndUnits ontology to rename 'Quantity' to 'ScalarQuantity', 'QuantityValue' to 'ScalarQuantityValue' and 'QuantityValueRange' to 'ScalarQuantityValueRange' in anticipation of integrating tensor and vector quantities in 2024,
4. Renamed the Composites ontology to RolesAndCompositions per the latest update to the Commons library (no semantic changes, strictly ontology prefix and IRI)