### PR TITLE
AboutIDMPDev-ReferenceIndividuals.rdf alignment with AboutIDMPDev.rdf

### DIFF
--- a/AboutIDMPDev.rdf
+++ b/AboutIDMPDev.rdf
@@ -118,7 +118,7 @@
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11615-MedicinalProducts/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO11616-PharmaceuticalProducts/"/>
 		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/ISO21090-HarmonizedDatatypes/"/>
-
+		<owl:imports rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/MedicalDictionaryForRegulatoryActivities/"/>
 		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/20230901/AboutIDMPDev/"/>
   </owl:Ontology>
 


### PR DESCRIPTION
Description: added the MedDRA ontology to the IDMPDev about file since the common terminology for adverse events ontology depends on it and is in AboutDev