### PR TITLE
IDMP-661 - Revise the Amlodipine example to match the current patterns for strength and reference strength

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -158,7 +158,7 @@
 		<skos:definition>fully substituted dialkyl 1,4-dihydropyridine-3,5-dicarboxylate derivative, which is used for the treatment of hypertension, chronic stable angina and confirmed or suspected vasospastic angina</skos:definition>
 		<skos:note>It is a long-acting dihydropyridine calcium channel blocker effective in the treatment of angina pectoris and hypertension.</skos:note>
 		<idmp-sub:hasDefiningMolecularFormula rdf:resource="&idmp-amp;AmlodipineMolecularFormula"/>
-		<idmp-sub:hasDefiningMolecularFormulaByMoiety rdf:resource="&idmp-amp;AmlodipineMolecularFormula"/>
+		<idmp-sub:hasDefiningMolecularFormulaByMoiety rdf:resource="&idmp-amp;AmlodipineMolecularFormulaByMoiety"/>
 		<idmp-sub:hasDefiningMolecularWeight rdf:resource="&idmp-amp;AmlodipineMolecularWeight"/>
 		<idmp-sub:hasDefiningNumberOfMoieties rdf:datatype="&xsd;integer">1</idmp-sub:hasDefiningNumberOfMoieties>
 		<idmp-sub:hasDefiningStereochemistry rdf:resource="&idmp-sub;Stereochemistry-Racemic"/>
@@ -182,7 +182,6 @@
 		<rdf:type rdf:resource="&idmp-mprd;PresentationStrength"/>
 		<rdf:type rdf:resource="&idmp-mprd;ReferenceStrength"/>
 		<rdfs:label>amlodipine as reference strength in Amlodipine EMC strength</rdfs:label>
-		<idmp-mprd:hasReferenceIngredientRole rdf:resource="&idmp-amp;AmlodipineAsReferenceSubstance"/>
 		<idmp-mprd:hasReferenceSubstance rdf:resource="&idmp-amp;Amlodipine"/>
 		<cmns-qtu:hasDenominator rdf:resource="&idmp-amp;AmlodipineDenominatorInAmlodipineEMCPresentationStrength"/>
 		<cmns-qtu:hasNumerator rdf:resource="&idmp-amp;AmlodipineNumeratorInAmlodipineEMCPresentationStrength"/>
@@ -193,16 +192,9 @@
 		<rdf:type rdf:resource="&idmp-mprd;PresentationStrength"/>
 		<rdf:type rdf:resource="&idmp-mprd;ReferenceStrength"/>
 		<rdfs:label>amlodipine as reference strength in Norvasc presentation strength</rdfs:label>
-		<idmp-mprd:hasReferenceIngredientRole rdf:resource="&idmp-amp;AmlodipineAsReferenceSubstance"/>
 		<idmp-mprd:hasReferenceSubstance rdf:resource="&idmp-amp;Amlodipine"/>
 		<cmns-qtu:hasDenominator rdf:resource="&idmp-amp;AmlodipineDenominatorInNorvascPresentationStrength"/>
 		<cmns-qtu:hasNumerator rdf:resource="&idmp-amp;AmlodipineNumeratorInNorvascPresentationStrength"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineAsReferenceSubstance">
-		<rdf:type rdf:resource="&idmp-mprd;ActiveIngredientActiveMoietyBasisOfStrength"/>
-		<rdfs:label>amlodipine as reference substance</rdfs:label>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;Amlodipine"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;AmlodipineBesylate">


### PR DESCRIPTION
Definition: cleaned up leftover detail in the Amlodipine example not needed to elucidate the simple case, and that could cause circular reasoning issues, and addressed a wrong reference for the defining molecular formula by moiety