### PR TITLE
IDMP-674 - Exclude shelf life type and special precautions for storage from the SPOR ontology in advance of regeneration of the SPOR lists and vocabulary elements

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -611,7 +611,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;Norvasc-RouteOfAdministration">
-		<rdf:type rdf:resource="&idmp-spor;SPOR-RouteOfAdministration"/>
+		<rdf:type rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
+		<rdf:type rdf:resource="&idmp-mprd;RouteOfAdministration"/>
 		<rdfs:label>Norvasc - route of administration</rdfs:label>
 		<skos:definition>taking a medicinal product by means of swallowing</skos:definition>
 		<idmp-spor:hasSPORTermName>

--- a/EXT/Examples/TerlipressinExample.rdf
+++ b/EXT/Examples/TerlipressinExample.rdf
@@ -350,7 +350,8 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-trlp;TerlipressinAcetateSUN-RouteOfAdministration">
-		<rdf:type rdf:resource="&idmp-spor;SPOR-RouteOfAdministration"/>
+		<rdf:type rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
+		<rdf:type rdf:resource="&idmp-mprd;RouteOfAdministration"/>
 		<rdfs:label>terlipressin acetate SUN - route of administration</rdfs:label>
 		<skos:definition>Injection of a medicinal product into a vein.</skos:definition>
 		<cmns-id:isIdentifiedBy>

--- a/ISO/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials.rdf
+++ b/ISO/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials.rdf
@@ -81,7 +81,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20231001/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials/"/>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials.rdf version of this ontology was modified to eliminate EMA SPOR terms that will be generated rather than hand crafted (IDMP-674).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Provisional"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -877,13 +878,6 @@
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;English"/>
 	</owl:NamedIndividual>
 	
-	<owl:Class rdf:about="&idmp-spor;SPOR-MarketingStatusClassifier">
-		<rdfs:subClassOf rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
-		<rdfs:label>SPOR marketing status classifier</rdfs:label>
-		<skos:definition>classifier and code element that describes the current status of some substance with respect to whether or not it has been placed on the market from a Substances Products Organisations Referentials (SPOR) perspective</skos:definition>
-		<cmns-av:directSource rdf:resource="https://spor.ema.europa.eu/v1/lists/100000072052"/>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-spor;SPOR-RecordStatus">
 		<rdfs:subClassOf rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
 		<rdfs:subClassOf rdf:resource="&mvf;TermStatus"/>
@@ -1141,30 +1135,6 @@
 		<cmns-txt:hasTextValue xml:lang="lv">Provizorisks</cmns-txt:hasTextValue>
 		<mvf:hasLanguage rdf:resource="&lcc-639-1;Latvian"/>
 	</owl:NamedIndividual>
-	
-	<owl:Class rdf:about="&idmp-spor;SPOR-RouteOfAdministration">
-		<rdfs:subClassOf rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
-		<rdfs:subClassOf rdf:resource="&idmp-mprd;RouteOfAdministration"/>
-		<rdfs:label>SPOR route of administration</rdfs:label>
-		<skos:definition>classifier and code element that describes the path by which the pharmaceutical product is taken into or makes contact with the body from a Substances Products Organisations Referentials (SPOR) perspective</skos:definition>
-		<cmns-av:directSource rdf:resource="https://spor.ema.europa.eu/v1/lists/100000073345"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-spor;SPOR-ShelfLifeType">
-		<rdfs:subClassOf rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
-		<rdfs:subClassOf rdf:resource="&idmp-mprd;ShelfLifeType"/>
-		<rdfs:label>SPOR shelf life type</rdfs:label>
-		<skos:definition>classifier and code element that describes the point in the life cycle from manufacturing to administration to a patient that a value for shelf life applies to, including potentially with respect to a specific packaging item, from a Substances Products Organisations Referentials (SPOR) perspective</skos:definition>
-		<cmns-av:directSource rdf:resource="https://spor.ema.europa.eu/v1/lists/100000073343"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-spor;SPOR-SpecialPrecautionsForStorage">
-		<rdfs:subClassOf rdf:resource="&idmp-spor;SPORControlledVocabularyTerm"/>
-		<rdfs:subClassOf rdf:resource="&idmp-mprd;SpecialPrecautionsForStorage"/>
-		<rdfs:label>SPOR special precautions for storage</rdfs:label>
-		<skos:definition>classifier and code element that provides precise instructions for storage of a substance or product, such as the kind of container, temperature restrictions, container management, and other restrictions on the way something must be handled from a Substances Products Organisations Referentials (SPOR) perspective</skos:definition>
-		<cmns-av:directSource rdf:resource="https://spor.ema.europa.eu/v1/lists/100000073344"/>
-	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-spor;SPOR-TermIdentifier-100000000004-100000000012">
 		<rdf:type rdf:resource="&idmp-spor;SPORTermIdentifier"/>

--- a/etc/CQ/Example/uc3_cq3.sparql
+++ b/etc/CQ/Example/uc3_cq3.sparql
@@ -25,7 +25,7 @@ WHERE {
 		?SPORRMSIdentifier a idmp-spor:SPORTermIdentifier;
 			cmns-txt:hasTextValue $SPORRMSId . 
 		
-		?RouteOfAdministration a idmp-spor:SPOR-RouteOfAdministration;
+		?RouteOfAdministration a idmp-mprd:RouteOfAdministration;
 		    idmp-spor:hasSPORTermName   ?RouteOfAdministrationTermName;
 			cmns-id:isIdentifiedBy      ?SPORRMSIdentifier .
 	


### PR DESCRIPTION
Description: Removed SPOR-specific terms from the SPOR ontology that will be generated per the patterns agreed in the IDMP-O wiki for controlled vocabularies