### PR TITLE
GitHub-525 - hasSPORTermDescription is an ObjectProperty

### DIFF
--- a/ISO/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials.rdf
+++ b/ISO/EuropeanJurisdiction/SubstancesProductsOrganisationsReferentials.rdf
@@ -1529,12 +1529,12 @@
 		<skos:definition>indicates the status of the vocabulary term in Substances Products Organisations Referentials (SPOR)</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&idmp-spor;hasSPORTermDescription">
+	<owl:ObjectProperty rdf:about="&idmp-spor;hasSPORTermDescription">
 		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;isDescribedBy"/>
 		<rdfs:label>has SPOR term description</rdfs:label>
 		<rdfs:range rdf:resource="&idmp-spor;SPORTermDescription"/>
 		<skos:definition>provides a language-specific statement describing the term</skos:definition>
-	</owl:DatatypeProperty>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-spor;hasSPORTermName">
 		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;hasName"/>


### PR DESCRIPTION
description: fixed idmp-spor:hasSPORTermDescription to be an owl:ObjectProperty instead of an owl:DatatypeProperty