### PR TITLE
IDMP-383 - ISO11615: Document the ISO IDMP conformance level as annotations in the IDMP-O where deviations exist

### DIFF
--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -6981,6 +6981,20 @@ In all these cases, a new ID shall be issued, that is, &apos;Human Albumin, Plas
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 7.4</cmns-av:directSource>
 	</owl:DatatypeProperty>
 	
+	<owl:DatatypeProperty rdf:about="&idmp-sub;hasEffectiveDate">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dt;hasDateValue"/>
+		<rdfs:label>has effective date</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>indicates the date on which something, such as an event, substance, or product, takes place or is effective</skos:definition>
+		<skos:example>20110219</skos:example>
+		<skos:note>The date when the substance was effective should be provided in line with the ISO 8601 date format. This shall be defined when the substance is generated or modified.</skos:note>
+		<idmp-sub:hasBusinessRules>The value may be implicitly derived.</idmp-sub:hasBusinessRules>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-TS"/>
+		<cmns-av:adaptedFrom>ISO/TS 19844:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11238 for data elements and structures for the unique identification and exchange of regulated information on substances, clause 6.12.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>The effective date is mandatory from a version perspective in ISO 11238, but may be optional or conditional when used in conjuction with other concepts.</cmns-av:usageNote>
+	</owl:DatatypeProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-sub;hasFivePrimeSubstanceIdentifier">
 		<rdfs:subPropertyOf rdf:resource="&idmp-sub;hasRelatedSubstanceIdentifier"/>
 		<rdfs:label>has five prime substance identifier</rdfs:label>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -126,6 +126,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-sub;SubstanceRole"/>
 		<rdfs:label>active ingredient</rdfs:label>
 		<skos:definition>ingredient present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adaptedFrom>Inxight Drugs, National Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
 		<cmns-av:synonym>active pharmacological ingredient</cmns-av:synonym>
 	</owl:Class>
@@ -147,6 +148,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient that is any additive in the product</skos:definition>
 		<skos:note>Use only when there is no described pharmacological action and classification as merely &apos;inactive&apos; ingredient is not appropriate.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Adjuvant">
@@ -157,7 +159,7 @@
 		<rdfs:seeAlso rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C2140"/>
 		<skos:definition>ingredient that potentiates the immune response to an antigen and/or modulates it towards the desired immune response</skos:definition>
 		<skos:note>An adjuvant is an agent that enhances the activity or therapeutic effect of another pharmacologic substance without having much, if any, therapeutic impact by itself.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:explanatoryNote>An adjuvant is defined as a component of a mixture in the ISO 11238 standard rather than as a role that such a component (substance) plays, thus this definition is non-conformant. It does, however, conform with its use as an ingredient in ISO 11615/TS 20443.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -400,6 +402,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient that is the base of a preparation</skos:definition>
 		<skos:example>water, vaseline, ethanol</skos:example>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ChemicalElement">
@@ -456,6 +459,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient added to alter the color appearance</skos:definition>
 		<skos:prefLabel xml:lang="en-US">color ingredient</skos:prefLabel>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ConformanceLevel">
@@ -521,6 +525,7 @@
 		<rdfs:label xml:lang="en-US">contaminant ingredient</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient whose presence is not intended but may not be reasonably avoided given the circumstances of the mixture&apos;s nature or origin</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;CopolymerConnectivity">
@@ -633,8 +638,7 @@
 		<rdfs:label>excipient</rdfs:label>
 		<dct:source>Chemical Entities of Biological Interest Ontology, see http://purl.obolibrary.org/obo/CHEBI_75324</dct:source>
 		<skos:definition>pharmacological role of a generally pharmacologically inactive substance that is formulated with the active ingredient of a medication</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:explanatoryNote>An excipient is not explicitly defined in the ISO 11238 standard (although clause 8.5 states that an excipient is a non-active ingredient intended to be used in the medicinal product), which this definition conforms with although it is modeled as a role in this ontology.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>bulking agent</cmns-av:synonym>
 		<cmns-av:synonym>filler</cmns-av:synonym>
@@ -647,6 +651,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient added to alter the taste of the product</skos:definition>
 		<skos:prefLabel xml:lang="en-US">flavor ingredient</skos:prefLabel>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Gene">
@@ -1178,7 +1183,7 @@
 		<rdfs:subClassOf rdf:resource="&idmp-sub;SubstanceRole"/>
 		<rdfs:label>inactive ingredient</rdfs:label>
 		<skos:definition>ingredient of a given formulation (most frequently, an excipient) that does not exhibit pharmacological activity</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adaptedFrom>Inxight Drugs, National Center for Advancing Translational Sciences, National Institutes of Health, derived from Definitions, available at https://drugs.ncats.io/about</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>Substances are classified based on their effect on disease progression for a specific disease or condition. In this case, a condition is only related to such compound via the formulation used to affect (treat or diagnose) this condition.</cmns-av:explanatoryNote>
 	</owl:Class>
@@ -1217,7 +1222,7 @@
 		<rdfs:label>ingredient</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of a substance that is specifically part of or used in the preparation of some manufactured item, pharmaceutical product, medication, or drug</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:synonym>pharmacological role</cmns-av:synonym>
 		<cmns-av:usageNote>An ingredient is defined as a material in the ISO 11238 standard rather than as a role, which would make the model inconsistent. Thus this concept is consistent in terms of its name but not in terms of its definition.</cmns-av:usageNote>
 		<cmns-av:usageNote>Note that any inactive ingredient that is described as &apos;ingredient not otherwise specified&apos; in the ISO/TS 20443 implementation guide will simply be classified as an ingredient at this level in the hierarchy in the ontology, or as an inactive ingredient without other differentiation.</cmns-av:usageNote>
@@ -1638,6 +1643,7 @@
 		<skos:definition>role of an inactive ingredient which, as a whole, lends a spatial structure to the product, which structure is meaningful to the delivery of the pharmacologically active ingredients near the target site</skos:definition>
 		<skos:example>For example, a collagen matrix used as a base for transplanting skin cells.</skos:example>
 		<skos:note>Such ingredient has a function other than merely delivering the pharmacologically active substances into a systemic compartment (such as, for example, an ordinary capsule would have.)</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Mixture">
@@ -3636,6 +3642,7 @@ For the description of nucleic acids, the following information can be used to a
 		<rdfs:label xml:lang="en-US">preservative ingredient</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient added to delay the risk of the product&apos;s spoiling</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;ProcessingMaterialRole">
@@ -4817,7 +4824,9 @@ For the description of nucleic acids, the following information can be used to a
 		<rdfs:label xml:lang="en-US">stabilizer ingredient</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of an inactive ingredient added to to keep the mixture homogenic (e.g. prevent the phases of an emulsion to separate)</skos:definition>
+		<skos:prefLabel xml:lang="en-GB">stabiliser ingredient</skos:prefLabel>
 		<skos:prefLabel xml:lang="en-US">stabilizer ingredient</skos:prefLabel>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;StartingMaterialRole">

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -1443,7 +1443,7 @@
 		<rdfs:label>manufacturer</rdfs:label>
 		<skos:definition>functional role of a party that produces finished products from raw materials or components using tools, machinery, labor, and chemical or physical transformation</skos:definition>
 		<skos:note>In the context of ISO 11238, the definition refers to a company responsible for the manufacturing of the substance. From a more general ISO IDMP perspective, a manufacturer refers to an organization that holds the authorization for the manufacturing process.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
 		<cmns-av:adaptedFrom>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.39</cmns-av:adaptedFrom>
 		<cmns-av:synonym>establishment</cmns-av:synonym>
 	</owl:Class>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -4391,7 +4391,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;appliesTo"/>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:onClass rdf:resource="&idmp-mprd;Therapy"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -1370,6 +1370,24 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<cmns-av:synonym>depth</cmns-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;DiameterCharacteristic">
+		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>diameter characteristic</rdfs:label>
+		<dct:source rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001334</dct:source>
+		<skos:definition>length physical characteristic which is equal to the length of any straight line segment that passes through the center of a circle and whose endpoints are on the circular boundary.</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.7</cmns-av:adaptedFrom>
+		<cmns-av:synonym>diameter</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;DiscreteManufacturingProcess">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;ManufacturingProcess"/>
 		<rdfs:label>discrete manufacturing process</rdfs:label>
@@ -1429,24 +1447,6 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:label>dose</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.23</dct:source>
 		<skos:definition>specified quantity of a medicine, to be taken at one time or at stated intervals</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-mprd;ExternalDiameterCharacteristic">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>external diameter characteristic</rdfs:label>
-		<dct:source rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001334</dct:source>
-		<skos:definition>length physical characteristic which is equal to the length of any straight line segment that passes through the center of a circle and whose endpoints are on the circular boundary.</skos:definition>
-		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.7</cmns-av:adaptedFrom>
-		<cmns-av:synonym>external diameter</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;GenderPopulationCharacteristic">
@@ -3175,24 +3175,6 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<cmns-av:synonym xml:lang="en-US">medicines regulatory agency (organization)</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-mprd;NominalVolumeCharacteristic">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>nominal volume characteristic</rdfs:label>
-		<skos:definition>3-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s amount of 3-dimensional space it occupies</skos:definition>
-		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.6</cmns-av:adaptedFrom>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000918</cmns-av:adaptedFrom>
-		<cmns-av:synonym>nominal volume</cmns-av:synonym>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-mprd;OrphanDesignation">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
@@ -4543,6 +4525,24 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>undesirable effect text</rdfs:label>
 		<skos:definition>textual description of an undesirable effect of a medicinal product</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;VolumeCharacteristic">
+		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>volume characteristic</rdfs:label>
+		<skos:definition>3-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s amount of 3-dimensional space it occupies</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.6</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000918</cmns-av:adaptedFrom>
+		<cmns-av:synonym>volume</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;WeightCharacteristic">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -1950,7 +1950,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>intermediate packaging</rdfs:label>
-		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.29</dct:source>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clauses 3.1.29 and 9.6</dct:source>
 		<skos:definition>container between the outer packaging and the immediate container</skos:definition>
 	</owl:Class>
 	
@@ -2068,6 +2068,20 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Authorization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
+				<owl:onClass rdf:resource="&idmp-mprd;ManufacturingAuthorizationReferenceNumber"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasEffectiveDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasAuthorizedParty"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Manufacturer"/>
 			</owl:Restriction>
@@ -2096,6 +2110,23 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<skos:note>Such authorization may be required for both total and partial manufacture and for the various processes of dividing up, packaging or presentation. However, such authorization may not be required for preparation, dividing up, changes in packaging or presentation where these processes are carried out, solely for retail supply, by pharmacists in dispensing pharmacies or by persons legally authorized in a region to carry out such processes.</skos:note>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.39</cmns-av:directSource>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;ManufacturingAuthorizationReferenceNumber">
+		<rdfs:subClassOf rdf:resource="&cmns-cds;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;ManufacturingAuthorization"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-GB">manufacturing authorisation reference number</rdfs:label>
+		<rdfs:label xml:lang="en-US">manufacturing authorization reference number</rdfs:label>
+		<skos:definition>reference number of the authorization for manufacturing or equivalent</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause H.2.1.2</cmns-av:adaptedFrom>
+		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.5.2.3.3</cmns-av:directSource>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ManufacturingOrBusinessOperation">
@@ -2228,8 +2259,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&idmp-mprd;MarketingAuthorizationApplication"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MarketingAuthorizationApplication"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-GB">marketing authorisation application identifier</rdfs:label>
@@ -2253,6 +2283,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:label xml:lang="en-GB">marketing authorisation holder</rdfs:label>
 		<rdfs:label xml:lang="en-US">marketing authorization holder</rdfs:label>
 		<skos:definition>authorized party role of a legal entity (organization) that holds the authorization for marketing a medicinal product in a region</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.41</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause B.1</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -2336,8 +2367,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
-				<owl:onClass rdf:resource="&idmp-mprd;MarketingAuthorizationProcedure"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MarketingAuthorizationProcedure"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-GB">marketing authorisation procedure identifier</rdfs:label>
@@ -2485,14 +2515,16 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 	<owl:Class rdf:about="&idmp-mprd;MassBasedStrength">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Strength"/>
 		<rdfs:label>mass-based strength</rdfs:label>
-		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.7.2.5.3</dct:source>
-		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) ...</skos:definition>
+		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass)</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.7.2.5.3</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicalCondition">
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Situation"/>
 		<rdfs:label>medical condition</rdfs:label>
 		<skos:definition>situation in which a patient experiences a pathological condition or disorder that impairs the body&apos;s normal functioning or its parts and is characterized by specific symptoms and/or signs</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicalDevice">
@@ -2541,6 +2573,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 — control of conception, and which does not achieve its principal intended action in or on the human body by pharmacological, immunological or metabolic means, but which may be assisted in its function by such means</skos:definition>
 		<skos:example>Some examples of devices in the context of pharmaceutical products are drug delivery systems, drug-eluting stents, insulin pumps, glucose meters, and diagnostic test kits.</skos:example>
 		<skos:note>Devices may be of several types such as separate administration devices, an integral administration device or a part of a medicinal product. Where a medicinal product is combined with a medical device and where the pharmacological, immunological or metabolic action should be considered as the principal mode of action, the medical device is presented as part of the pharmaceutical product.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adoptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clauses 3.1.49 and 9.6.2.12</cmns-av:adoptedFrom>
 		<cmns-av:explanatoryNote>The FDA further clarifies this definition to say that such a device does not achieve its primary intended purposes through chemical action within or on the body of a man or other animals and which is not dependent upon being metabolized for the achievement of its primary intended purposes.</cmns-av:explanatoryNote>
 		<cmns-av:synonym>device</cmns-av:synonym>
@@ -2553,7 +2586,6 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<skos:definition>unique identifier allocated to a specific batch of a medical device</skos:definition>
 		<skos:note>At implementation, any batch number and expiry date for a device in a packaged medicinal product will be related to a particular batch or batches of that packaged medicinal product (as described using the BAID1), but for simplification at a conceptual level, the &apos;many-to-many&apos; relationship that this would give has been omitted.</skos:note>
 		<skos:note>This class can be used to describe the batch number and/or expiry date of a device in a packaged medicinal product.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:synonym>device batch identifier</cmns-av:synonym>
 	</owl:Class>
 	
@@ -2609,6 +2641,9 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>medication</rdfs:label>
 		<skos:definition>role of a substance or product that is used in the treatment of a disease or symptom</skos:definition>
+		<skos:note>Reference to a specific medication, which can be expressed as an active substance, medicinal product or class of medicinal products, as part of a specific indication or contraindication in accordance with the regulated product information shall be specified using an appropriate controlled vocabulary [see medication classifier].</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
+		<cmns-av:adoptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.9.2.6.3</cmns-av:adoptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicationClassifier">
@@ -2627,7 +2662,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>medication classifier</rdfs:label>
-		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.6.3</dct:source>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.6.3, Figure 14</dct:source>
 		<skos:definition>classifier for a medication by active substance or medicinal product(s)</skos:definition>
 		<skos:note>Reference to a specific medication, which can be expressed as an active substance, Medicinal Product or class of Medicinal Products, as part of a specific indication or contraindication in accordance with the regulated product information shall be specified using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
 		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
@@ -2643,6 +2678,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>medication therapy</rdfs:label>
 		<skos:definition>therapy in which a medication is administered to the patient</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:synonym>therapy with medication</cmns-av:synonym>
 	</owl:Class>
 	
@@ -2893,8 +2929,39 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<cmns-av:synonym>product cross-reference</cmns-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;MedicinalProductHeaderIdentifier">
+		<rdfs:subClassOf rdf:resource="&cmns-id;Identifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;identifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;MedicinalProductHeaderRecord"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>medicinal product header identifier</rdfs:label>
+		<skos:definition>unique identifier allocated to a specific version of a header [record], i.e., a record specifying the versioning of the core identifiers related to a medicinal product in a region, as well as the characteristics associated with the medicinal product and the documentation that supports the versioning</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-II"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.3. Figure 6</cmns-av:adaptedFrom>
+		<cmns-av:synonym>identifier</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;MedicinalProductHeaderRecord">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Record"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:onClass rdf:resource="&idmp-mprd;MedicinalProductHeaderIdentifier"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-sub;hasEffectiveDate"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;describes"/>
@@ -2906,6 +2973,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:note>Regional guidance might contain additional criteria which may warrant a new version of a regulated document as it relates to the characteristics of a medicinal product, including potentially language-specific versions.</skos:note>
 		<skos:note>The characteristics of an authorized medicinal product as defined herein shall be versioned within a regulated document, as applicable. For a given version, some characteristics of the medicinal product have changed but are not different to a sufficient extent to warrant the assignment of a new primary identifier. However, the difference(s) are required to be recorded and tracked against the MPID/PCID.</skos:note>
 		<skos:note>This is also a record to track against previous versions of a regulated document, including but not limited to language-specific variations, regardless of whether the revisions warrant a new primary identifier (primary identifier reference shall be listed as an example of a change within a regulated document).</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 6</cmns-av:adaptedFrom>
 		<cmns-av:synonym>header</cmns-av:synonym>
 		<cmns-av:usageNote>A given medicinal product will have exactly 1 &apos;header&apos;, although a given &apos;header&apos; may apply to multiple medicinal products.</cmns-av:usageNote>
@@ -2986,6 +3055,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>collection of records submitted to a medicines regulatory agency that may be used to provide confidential detailed information about facilities, processes, or articles used in the manufacturing, processing, packaging, and storing of one or more human drugs</skos:definition>
 		<skos:example>Pharmacovigilance System Master File</skos:example>
 		<skos:note>This may be either an invented name not liable to be confused with the common name, or a common or a scientific name accompanied by a trade mark or any other applicable descriptor.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 6</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>https://www.fda.gov/drugs/guidances-drugs/drug-master-files-guidelines</cmns-av:adaptedFrom>
 		<cmns-av:synonym>master file</cmns-av:synonym>
@@ -3008,6 +3078,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>medicinal product master file holder</rdfs:label>
 		<skos:definition>authorized role of a legal entity (organization) that holds a master file for a given medicinal product</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 6</cmns-av:adaptedFrom>
 		<cmns-av:synonym xml:lang="en">master file holder</cmns-av:synonym>
 		<cmns-av:synonym xml:lang="en-GB">master file holder (organisation)</cmns-av:synonym>
@@ -3060,6 +3131,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label xml:lang="en">medicinal product name locale</rdfs:label>
 		<skos:definition>context in which a given medicinal product name applies</skos:definition>
 		<skos:note>The country and optionally the region where the medicinal product name of a medicinal product is authorized shall be specified in the official language as applicable.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, Figure 6</cmns-av:adaptedFrom>
 		<cmns-av:synonym xml:lang="en">Country / Language</cmns-av:synonym>
@@ -3093,6 +3165,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>medicines regulatory agency</rdfs:label>
 		<skos:definition>institutional body that, according to the legal system under which it has been established, is responsible for the granting of marketing authorizations, clinical trial authorizations and manufacturing authorizations for medicinal products</skos:definition>
 		<skos:note>In certain regions, the role of the institutional body, which according to the legal system grants the marketing authorization of medicinal products, may be complemented by an additional institutional body responsible for the evaluation and supervision of medicinal products. For example, in the EU, the European Commission is the institutional body that grants the marketing authorization of medicinal products and the European Medicines Agency is the body responsible for the evaluation and supervision of medicinal products.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.56</cmns-av:directSource>
 		<cmns-av:synonym xml:lang="en-GB">medicines regulatory agency (organisation)</cmns-av:synonym>
 		<cmns-av:synonym xml:lang="en-US">medicines regulatory agency (organization)</cmns-av:synonym>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -355,6 +355,8 @@
 				<owl:onDataRange rdf:resource="&xsd;boolean"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.47</dct:source>
+		<skos:note>Material is more specifically defined in ISO 11615 to be a &apos;substance or specified substance of which a certain packaging or device is made. This definition applies to a medicinal product package item (container), package (component) and device.</skos:note>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MechanicalIngredient">
@@ -638,13 +640,36 @@
 	
 	<owl:Class rdf:about="&idmp-mprd;AdministrableDoseForm">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;PharmaceuticalDoseForm"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;AdministrableDoseFormClassifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>administrable dose form</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.2</dct:source>
 		<skos:definition>pharmaceutical dose form for administration to the patient, after any necessary transformation of the manufactured items and their corresponding manufactured dose forms has been carried out</skos:definition>
 		<skos:note>Administered dose form and pharmaceutical administrable dose form are synonyms of administrable dose form.</skos:note>
 		<skos:note>The administrable dose form is identical to the manufactured dose form in cases where no transformation of the manufactured item is necessary (i.e. where the manufactured item is equal to the pharmaceutical product).</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:synonym>administered dose form</cmns-av:synonym>
 		<cmns-av:synonym>pharmaceutical administrable dose form</cmns-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;AdministrableDoseFormClassifier">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;AdministrableDoseForm"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>administrable dose form classifier</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure 13</dct:source>
+		<skos:definition>classifier for the pharmaceutical dose form for administration to the patient, after any necessary transformation of the manufactured items and their corresponding manufactured dose forms has been carried out</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AgeClassifier">
@@ -667,6 +692,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:synonym>age</cmns-av:synonym>
+		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AgePopulationCharacteristic">
@@ -733,6 +759,7 @@
 	<owl:Class rdf:about="&idmp-mprd;AttachedDocument">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;ReferenceDocument"/>
 		<rdfs:label>attached document</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.2.2.11, 11.3.2.6 and Figure 6</dct:source>
 		<skos:definition>document that provides additional information about something</skos:definition>
 	</owl:Class>
 	
@@ -752,6 +779,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>authorization</rdfs:label>
 		<skos:definition>situation in which a party authorizes someone to act on their behalf or to have other responsibilities or capabilities under certain conditions for some period of time</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AuthorizedMedicinalProduct">
@@ -779,6 +807,12 @@
 		</rdfs:subClassOf>
 		<rdfs:label>authorized medicinal product</rdfs:label>
 		<skos:definition>role of a medicinal product that has been authorized for some purpose in some jurisdiction</skos:definition>
+		<skos:note>The unique identification of authorized medicinal Products and the description of their main characteristics shall apply the following principles:
+a) the assignment of a unique medicinal product identifier (MPID) to reliably recognize, monitor and trace the use of medicinal products;
+b) the assignment of a unique medicinal product package identifier (PCID) to reliably recognize and trace medicinal products as packaged for sale or supply;
+c) the assignment of a unique medicinal product batch identifier (BAID1) to reliably recognize and trace a manufacturer&apos;s batch number, which appears on the outer packaging of the medicinal product, in compliance with the requirements of the marketing authorization;
+d) the assignment of a unique medicinal product batch identifier (BAID2) to reliably recognize and trace a batch number on the immediate packaging of the medicinal product, where this is not the outer packaging, in compliance with the requirements of the marketing authorization.</skos:note>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 6.2, 8, and Figures 5, 6 and Annex A</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AuthorizedParty">
@@ -791,6 +825,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>authorized party</rdfs:label>
 		<skos:definition>party that has been given the responsibility to act on behalf of another party or to have other responsibilities or capabilities under some set of guidelines</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AuthorizingParty">
@@ -803,6 +838,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>authorizing party</rdfs:label>
 		<skos:definition>party that delegates some role, authority, capability, or control to another party</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Batch">
@@ -965,7 +1001,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -980,7 +1016,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -685,8 +685,7 @@
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 8.2.2.4 and Figure 14</dct:source>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure F.1, clause F.2.7.1</dct:source>
 		<skos:definition>qualitative classifier for a range of ages, specified in terms of a controlled vocabulary</skos:definition>
-		<skos:example>adult</skos:example>
-		<skos:example>elderly</skos:example>
+		<skos:example>Adults (18 to &lt; 65)</skos:example>
 		<skos:note>The age group of the specific population for an indication, undesirable effect, or a contraindication as authorized for the medicinal product in accordance with the regulated medicinal product information can be specified using an appropriate controlled terminology.</skos:note>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
@@ -760,7 +759,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-doc;ReferenceDocument"/>
 		<rdfs:label>attached document</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.2.2.11, 11.3.2.6 and Figure 6</dct:source>
-		<skos:definition>document that provides additional information about something</skos:definition>
+		<skos:definition>document officially submitted to a medicines regulatory agency</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Authorization">
@@ -845,6 +844,12 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf rdf:resource="&cmns-col;Constituent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasExpirationDate"/>
+				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;isOutputOf"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;BatchManufacturingProcess"/>
 			</owl:Restriction>
@@ -924,15 +929,29 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-id;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ClinicalTrialIdentifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>clinical trial</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.11</dct:source>
 		<dct:source>National Cancer Institute Thesaurus, see http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C71104</dct:source>
 		<skos:definition>investigation in human subjects intended to discover or verify the clinical, pharmacological and/or other pharmacodynamic effects of an investigational product(s), and/or to identify any adverse reactions to an investigational medicinal product(s), and/or to study absorption, distribution, metabolism and excretion of investigational medicinal product(s) with the object of ascertaining its safety and/or efficacy</skos:definition>
 		<skos:note>A clinical trial is a research study that prospectively assigns human participants or groups of humans to one or more health-related interventions to evaluate the effects on health outcomes.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ClinicalTrialAuthorization">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Authorization"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-doc;refersTo"/>
+				<owl:onClass rdf:resource="&idmp-mprd;ClinicalTrialIdentifier"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasAuthorizingParty"/>
@@ -955,6 +974,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:label xml:lang="en-US">clinical trial authorization</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.12</dct:source>
 		<skos:definition>approval given by a medicines regulatory agency to conduct a clinical trial in a region</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ClinicalTrialIdentifier">
@@ -968,8 +988,11 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>clinical trial identifier</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.74</dct:source>
 		<rdfs:seeAlso rdf:resource="https://clinicaltrials.gov/"/>
-		<skos:definition>sequence of characters uniquely identifying a clinical trial</skos:definition>
+		<skos:definition>identifier assigned to a clinical trial by a medicines regulatory agency in a region for tracking purposes</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:synonym>registration number</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ColorCharacteristic">
@@ -981,11 +1004,15 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>color characteristic</rdfs:label>
+		<rdfs:label xml:lang="en-US">color characteristic</rdfs:label>
+		<rdfs:label xml:lang="en-GB">colour characteristic</rdfs:label>
 		<skos:definition>composite chromatic physical characteristic composed of hue, saturation and intensity parts</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.9</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_0000014</cmns-av:adaptedFrom>
+		<cmns-av:synonym xml:lang="en-US">color</cmns-av:synonym>
 		<cmns-av:synonym>color</cmns-av:synonym>
+		<cmns-av:synonym xml:lang="en-GB">colour</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;CombinedPharmaceuticalDoseForm">
@@ -1043,7 +1070,10 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Strength"/>
 		<rdfs:label>concentration</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.7.2.5.3</dct:source>
-		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) ...</skos:definition>
+		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass)</skos:definition>
+		<skos:note>For solid dose forms, strength (concentration) is generally the same as strength (presentation) and therefore is not required to be expressed separately; the strength (presentation) only is required.</skos:note>
+		<skos:note>When required for expression of strength, the unit of presentation shall be specified in accordance with ISO 11239 and its resulting terminology. The controlled term and a term identifier for the unit of presentation shall be specified in the associated manufactured item or pharmaceutical product. For strength expressed using standard units, the unit of measure symbol and the symbol identifier as defined in ISO 11240 and its resulting controlled vocabulary shall be specified.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:synonym>strength (concentration)</cmns-av:synonym>
 	</owl:Class>
 	
@@ -1286,6 +1316,11 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>contraindication text</rdfs:label>
 		<skos:definition>textual description of the contraindications of a medicinal product</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.3.3 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:synonym>contraindications text</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;DataCarrierIdentifier">
@@ -1326,6 +1361,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>depth characteristic</rdfs:label>
 		<skos:definition>1-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s downward or backward or inward dimension</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.4</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001595</cmns-av:adaptedFrom>
 		<cmns-av:synonym>depth</cmns-av:synonym>
@@ -1343,6 +1379,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:label>diameter characteristic</rdfs:label>
 		<dct:source rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001334</dct:source>
 		<skos:definition>length physical characteristic which is equal to the length of any straight line segment that passes through the center of a circle and whose endpoints are on the circular boundary.</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.7</cmns-av:adaptedFrom>
 		<cmns-av:synonym>diameter</cmns-av:synonym>
 	</owl:Class>
@@ -1407,30 +1444,18 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<skos:definition>specified quantity of a medicine, to be taken at one time or at stated intervals</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-mprd;Gender">
-		<rdfs:subClassOf rdf:resource="&cmns-cls;Aspect"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;characterizes"/>
-				<owl:someValuesFrom rdf:resource="&idmp-sub;IndividualOrganism"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>gender</rdfs:label>
-		<skos:definition>biological sex of an organism or for humans the characteristics of women, men, girls and boys that are socially constructed</skos:definition>
-		<cmns-av:adaptedFrom>WHO Gender and Health https://www.who.int/health-topics/gender</cmns-av:adaptedFrom>
-		<cmns-av:usageNote>ISO IDMP recommends the use of ISO 5128 concept descriptors for this</cmns-av:usageNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-mprd;GenderPopulationCharacteristic">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;PopulationCharacteristic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;Gender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:label>gender population characteristic</rdfs:label>
-		<skos:definition>classifier for a statistical population based on the gender (sex) of its members</skos:definition>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5.5</dct:source>
+		<skos:definition>classifier for a statistical population based on the biological sex of an organism or for humans the characteristics of women, men, girls and boys that are socially constructed</skos:definition>
+		<skos:note>The gender of the specific population for an indication or a contraindication in accordance with the regulated product information shall be specified using ISO/IEC 5218.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
+		<cmns-av:adaptedFrom>WHO Gender and Health https://www.who.int/health-topics/gender</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;HeightCharacteristic">
@@ -1444,6 +1469,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>height characteristic</rdfs:label>
 		<skos:definition>1-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s vertical dimension of extension</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.2</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000119</cmns-av:adaptedFrom>
 		<cmns-av:synonym>height</cmns-av:synonym>
@@ -1469,21 +1495,26 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:label>ISO 20443 code set</rdfs:label>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/68041.html</rdfs:seeAlso>
 		<skos:definition>set of controlled vocabularies and codes for reporting of medicinal product-related information specified in the ISO/TS 20443 guidelines</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&idmp-mprd;Image">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;describes"/>
-				<owl:onClass rdf:resource="&owl;Thing"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;NonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onProperty rdf:resource="&mvf-trm;depicts"/>
+				<owl:minCardinality rdf:datatype="&xsd;NonNegativeInteger">0</owl:minCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>image</rdfs:label>
 		<skos:definition>visual representation of something</skos:definition>
-		<skos:note>In ISO 11615, an image is a physical characteristic. This is not correct.</skos:note>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.11</cmns-av:adaptedFrom>
+		<skos:note>The format of the image attachment shall be specified by regional implementations. The format of the image shall follow ISO 12639 and shall be held in an ED data type.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Optional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ED"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.6.2.9.5, 9.6.2.17, 9.6.2.20.5, 9.6.2.21.1 and 9.6.2.21.11</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause C.3.14.9</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>In ISO 11615, an image is modeled as a physical characteristic. This is not correct from an ontological perspective.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ImmediateContainer">
@@ -1516,10 +1547,9 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>immediate container</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.27</dct:source>
-		<skos:definition>immediate packaging in which a manufactured item or pharmaceutical product is contained and with which it is in direct contact</skos:definition>
-		<skos:note>A pharmaceutical dose form can fulfil the role of an immediate container, e.g. a capsule containing a powder for inhalation; the capsule in this case is not a container.</skos:note>
-		<skos:note>An alternative, compatible definition of immediate container (&apos;immediate packaging) is given in Directive 92/27/EEC.</skos:note>
-		<skos:note>An immediate container can be fitted with or have integrated into it an administration device and/or closure.</skos:note>
+		<skos:definition>packaging in which a manufactured item or pharmaceutical product is contained and with which it is in direct contact</skos:definition>
+		<skos:note>An immediate container can be fitted with or have integrated into it an administration device and/or closure. A pharmaceutical dose form can fulfil the role of an immediate container, e.g. a capsule containing a powder for inhalation; the capsule in this case is not a container. An alternative, compatible definition of immediate container (&apos;immediate packaging&apos;) is given in Directive 92/27/EEC.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Imprint">
@@ -1533,7 +1563,9 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>imprint</rdfs:label>
 		<skos:definition>stamp or impress on a surface</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.10</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause C.3.14.10</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;IndicationAsDiseaseSymptomProcedure">
@@ -2439,17 +2471,12 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicalDeviceBatchIdentifier">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;BatchNumber"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasExpirationDate"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>medical device batch identifier</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.6.2.15</dct:source>
 		<skos:definition>unique identifier allocated to a specific batch of a medical device</skos:definition>
 		<skos:note>At implementation, any batch number and expiry date for a device in a packaged medicinal product will be related to a particular batch or batches of that packaged medicinal product (as described using the BAID1), but for simplification at a conceptual level, the &apos;many-to-many&apos; relationship that this would give has been omitted.</skos:note>
 		<skos:note>This class can be used to describe the batch number and/or expiry date of a device in a packaged medicinal product.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:synonym>device batch identifier</cmns-av:synonym>
 	</owl:Class>
 	
@@ -2682,16 +2709,10 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;PharmaceuticalProductBatchNumber"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>medicinal product batch identifier for immediate packaging</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.52</dct:source>
 		<skos:definition>unique identifier allocated to a specific batch of a medicinal product, which appears on the immediate packaging, where this is not the outer packaging</skos:definition>
-		<skos:editorialNote>For more explicit modeling of the semantics we should consider creating a property chain that links the BAID1 through the pharmaceutical product batch identifier, through the pharmaceutical product batch to its expiration date rather than using a disconnected date (future update).</skos:editorialNote>
+		<skos:editorialNote>For more explicit modeling of the semantics we should consider creating a property chain that links the BAID1 through the pharmaceutical product batch identifier, through the pharmaceutical product batch to its expiration date (future update).</skos:editorialNote>
 		<skos:note>It is constructed by using the batch number assigned by the manufacturer and the expiration date. This is for indexing purposes and to contribute to improving patient safety by allowing for the unique identification of a medicinal product based at the level of the immediate container.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:abbreviation>BAID2</cmns-av:abbreviation>
@@ -2707,16 +2728,10 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;PharmaceuticalProductBatchNumber"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-col;comprises"/>
-				<owl:someValuesFrom rdf:resource="&cmns-dt;ExplicitDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>medicinal product batch identifier for outer packaging</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.51</dct:source>
 		<skos:definition>unique identifier allocated to a specific batch of a medicinal product, which appears on the outer packaging of the medicinal product</skos:definition>
-		<skos:editorialNote>For more explicit modeling of the semantics we should consider creating a property chain that links the BAID1 through the pharmaceutical product batch identifier, through the pharmaceutical product batch to its expiration date rather than using a disconnected date (future update).</skos:editorialNote>
+		<skos:editorialNote>For more explicit modeling of the semantics we should consider creating a property chain that links the BAID1 through the pharmaceutical product batch identifier, through the pharmaceutical product batch to its expiration date (future update).</skos:editorialNote>
 		<skos:note>It is constructed by using the batch number assigned by the manufacturer and the expiration date. This is for indexing purposes and to contribute to improving patient safety by allowing for the unique identification of a medicinal product at the package level.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:abbreviation>BAID1</cmns-av:abbreviation>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -669,7 +669,7 @@
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure 13</dct:source>
 		<skos:definition>classifier for the pharmaceutical dose form for administration to the patient, after any necessary transformation of the manufactured items and their corresponding manufactured dose forms has been carried out</skos:definition>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
-		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AgeClassifier">
@@ -691,7 +691,7 @@
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:synonym>age</cmns-av:synonym>
-		<cmns-av:usageNote>No controlled vocabulary or code list is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AgePopulationCharacteristic">
@@ -1064,6 +1064,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.5, 9.9.2.2.3.5 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>For a much more comprehensive treatise on the concept of comorbidity, including distinctions based on (1) the nature of the health condition, (2) the relative importance of the co-occurring conditions, (3) the chronology of presentation of the conditions, and (4) expanded conceptualizations, see https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2713155/.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Concentration">
@@ -1303,6 +1304,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.3.3 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ContraindicationText">
@@ -1435,6 +1437,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.4 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Dose">
@@ -1456,6 +1459,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>WHO Gender and Health https://www.who.int/health-topics/gender</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;HeightCharacteristic">
@@ -1589,8 +1593,10 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<skos:note>The underlying disease, symptom or procedure that is the indication for treatment or contraindication should be specified as it is referenced in the regulated product information using an appropriate controlled reference terminology. The controlled term and the controlled term identifier should be specified.</skos:note>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.2.3 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&idmp-mprd;IngredientRole-ACTI">
@@ -1847,17 +1853,86 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.6 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Interaction">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&idmp-mprd;InteractionClassifier"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
+				<owl:onClass rdf:resource="&idmp-mprd;InteractionClassifier"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasInteractionText"/>
+				<owl:onClass rdf:resource="&idmp-mprd;InteractionText"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>interaction</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://ichgcp.net/1-glossary"/>
 		<rdfs:seeAlso rdf:resource="https://www.ema.europa.eu/en/documents/scientific-guideline/guideline-investigation-drug-interactions-revision-1_en.pdf"/>
 		<skos:definition>specification of a change in the effect of a medicinal product when it is taken with another substance, such as another medicinal product, food, alcohol, or herbal product</skos:definition>
 		<skos:note>The change can be an increase or decrease in the effectiveness or side effects of the medicinal product. Medicinal product interactions can have different mechanisms, such as affecting the absorption, distribution, metabolism, or excretion of the medicinal product, or interfering with its target site. Medicinal product interactions can be beneficial or harmful, depending on the situation and the desired outcome of the treatment. They may be with respect to other medicinal products or other forms of interactions as described in the regulated product information.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.7</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.5</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>This class can be used to describe the interactions of the Medicinal Product (with other Medicinal Products) and other forms of interactions as described in the regulated product information.</cmns-av:usageNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;InteractionClassifier">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;Interaction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;Interaction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>interaction classifier</rdfs:label>
+		<skos:definition>classifier for the type of interaction with the regulated product</skos:definition>
+		<skos:note>The type of interaction in line with the regulated product information can be described using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.2.6 and Figure 14</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;InteractionText">
+		<rdfs:subClassOf rdf:resource="&cmns-doc;Document"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-txt;hasTextValue"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>interaction text</rdfs:label>
+		<skos:definition>textual description of a change in the effect of a medicinal product when it is taken with another substance, such as another medicinal product, food, alcohol, or herbal product</skos:definition>
+		<skos:note>The text of the interaction in accordance with the regulated product information shall be provided.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.7</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.5</cmns-av:adaptedFrom>
+		<cmns-av:synonym>interactions text</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;IntermediatePackaging">
@@ -2294,6 +2369,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause B.1</cmns-av:adaptedFrom>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.3.2 and Figure 7</cmns-av:directSource>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MarketingStatusReason">
@@ -2358,6 +2434,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause B.1</cmns-av:adaptedFrom>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.3.2 and Figure 7</cmns-av:directSource>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MarketingStatusRecord">
@@ -2553,6 +2630,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.6.3</dct:source>
 		<skos:definition>classifier for a medication by active substance or medicinal product(s)</skos:definition>
 		<skos:note>Reference to a specific medication, which can be expressed as an active substance, Medicinal Product or class of Medicinal Products, as part of a specific indication or contraindication in accordance with the regulated product information shall be specified using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;MedicationTherapy">
@@ -3895,6 +3973,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause C.3.7</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>NCI Thesaurus, see https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&amp;version=23.06d&amp;ns=ncit&amp;code=C70855</cmns-av:adaptedFrom>
 		<cmns-av:explanatoryNote>The shelf life type shall be specified using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</cmns-av:explanatoryNote>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;SmallToMediumEnterprise">
@@ -3932,6 +4011,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>classifier describing additional storage conditions for a medicinal product or package item, if any</skos:definition>
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Optional"/>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause C.3.7</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Sponsor">
@@ -4004,6 +4084,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.9.2.4.3 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;TargetPopulation">
@@ -4197,6 +4278,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>classifier for a the relationship to a therapy or therapy specification</skos:definition>
 		<skos:note>The type of relationship between the Medicinal Product indication or contraindication and a specific other therapy shall be specified using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.6.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;TherapySpecification">
@@ -4307,6 +4389,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 3.1.82, 9.9.2.4.3 and Figure 14</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.2</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;UndesirableEffectText">
@@ -4659,6 +4742,18 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:range rdf:resource="&idmp-mprd;Interaction"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isInteractionFor"/>
 		<skos:definition>relates a product to a change in the effect of a medicinal product when it is taken with another substance, such as another medicinal product, food, alcohol, or herbal product</skos:definition>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.7</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.5</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasInteractionText">
+		<rdfs:subPropertyOf rdf:resource="&cmns-dsg;isDescribedBy"/>
+		<rdfs:label>has interaction text</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;Interaction"/>
+		<rdfs:range rdf:resource="&idmp-mprd;InteractionText"/>
+		<skos:definition>provides a description of the interaction in accordance with the regulated product information</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.7</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause F.5</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -1006,12 +1006,12 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">color characteristic</rdfs:label>
 		<rdfs:label xml:lang="en-GB">colour characteristic</rdfs:label>
-		<skos:definition>composite chromatic physical characteristic composed of hue, saturation and intensity parts</skos:definition>
+		<skos:definition>composite chromatic physical characteristic composed of hue, saturation and intensity</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.9</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_0000014</cmns-av:adaptedFrom>
 		<cmns-av:synonym xml:lang="en-US">color</cmns-av:synonym>
-		<cmns-av:synonym>color</cmns-av:synonym>
 		<cmns-av:synonym xml:lang="en-GB">colour</cmns-av:synonym>
 	</owl:Class>
 	
@@ -1363,27 +1363,11 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>depth characteristic</rdfs:label>
 		<skos:definition>1-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s downward or backward or inward dimension</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.4</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001595</cmns-av:adaptedFrom>
 		<cmns-av:synonym>depth</cmns-av:synonym>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-mprd;DiameterCharacteristic">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>diameter characteristic</rdfs:label>
-		<dct:source rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001334</dct:source>
-		<skos:definition>length physical characteristic which is equal to the length of any straight line segment that passes through the center of a circle and whose endpoints are on the circular boundary.</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.7</cmns-av:adaptedFrom>
-		<cmns-av:synonym>diameter</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;DiscreteManufacturingProcess">
@@ -1447,6 +1431,24 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<skos:definition>specified quantity of a medicine, to be taken at one time or at stated intervals</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;ExternalDiameterCharacteristic">
+		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>external diameter characteristic</rdfs:label>
+		<dct:source rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001334</dct:source>
+		<skos:definition>length physical characteristic which is equal to the length of any straight line segment that passes through the center of a circle and whose endpoints are on the circular boundary.</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.7</cmns-av:adaptedFrom>
+		<cmns-av:synonym>external diameter</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;GenderPopulationCharacteristic">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;PopulationCharacteristic"/>
 		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
@@ -1473,6 +1475,7 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>height characteristic</rdfs:label>
 		<skos:definition>1-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s vertical dimension of extension</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.2</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000119</cmns-av:adaptedFrom>
@@ -1567,7 +1570,8 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:label>imprint</rdfs:label>
 		<skos:definition>stamp or impress on a surface</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NamingConformant"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.10</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause C.3.14.10</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -3171,6 +3175,24 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<cmns-av:synonym xml:lang="en-US">medicines regulatory agency (organization)</cmns-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;NominalVolumeCharacteristic">
+		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
+				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>nominal volume characteristic</rdfs:label>
+		<skos:definition>3-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s amount of 3-dimensional space it occupies</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.6</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000918</cmns-av:adaptedFrom>
+		<cmns-av:synonym>nominal volume</cmns-av:synonym>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;OrphanDesignation">
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
@@ -3981,12 +4003,34 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	
 	<owl:Class rdf:about="&idmp-mprd;Scoring">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;ManufacturedItem">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;PackageItem">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;MedicalDevice">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>scoring</rdfs:label>
-		<skos:definition>debossed line that runs across the planar surface of a tablet</skos:definition>
+		<skos:definition>classifier for a debossed line that runs across the planar surface of a tablet</skos:definition>
 		<skos:note>Scoring is the process of creating a groove or mark on a tablet to facilitate splitting it into equal parts. Scoring can help patients adjust their dosage, reduce costs, or improve swallowing of the tablet. However, scoring also requires careful evaluation and labeling to ensure the safety and efficacy of the drug product.</skos:note>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.12</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>Nomenclature, Labeling, and Data for Evaluation, FDA Guidance for Industry, March 2013.</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Shape">
@@ -4000,7 +4044,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>shape</rdfs:label>
 		<skos:definition>morphological physical characteristic inhering in a bearer by virtue of the bearer&apos;s ratios of distances between its features (points, edges, surfaces and also holes etc).</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.8</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_0000052</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -4089,7 +4134,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>small to medium enterprise</rdfs:label>
 		<skos:definition>classifier indicating that an entity has been certified based on its size in order to receive authorization for something under special rules</skos:definition>
-		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:abbreviation>SME</cmns-av:abbreviation>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.3.2.4</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -4174,6 +4219,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.7.2.5.3</dct:source>
 		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass)</skos:definition>
 		<skos:note>For solid dose forms, strength (concentration) is generally the same as strength (presentation) and therefore is not required to be expressed separately; the strength (presentation) only is required.</skos:note>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:explanatoryNote>When required for expression of strength, the unit of presentation shall be specified in accordance with ISO 11239 and its resulting terminology. The controlled term and a term identifier for the unit of presentation shall be specified in the associated manufactured item or pharmaceutical product. For strength expressed using standard units, the unit of measure symbol and the symbol identifier as defined in ISO 11240 and its resulting controlled vocabulary shall be specified.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -4235,6 +4282,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>target population</rdfs:label>
 		<skos:definition>collection of patients or consumers for which the indication of a medicinal product is authorized or is under investigation</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.81</cmns-av:adaptedFrom>
 		<cmns-av:synonym>population specifics</cmns-av:synonym>
 	</owl:Class>
@@ -4338,29 +4386,32 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>therapeutic indication text</rdfs:label>
 		<skos:definition>textual description of the therapeutic indications of a medicinal product</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Therapy">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Process"/>
 		<rdfs:label>therapy</rdfs:label>
-		<skos:definition>treatment of a patient</skos:definition>
+		<skos:definition>action or administration of therapeutic agents to produce an effect that is intended to alter the course of a pathologic process</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<cmns-av:adaptedFrom>NCI Thesaurus, see the entry for treatment, C15368</cmns-av:adaptedFrom>
+		<cmns-av:synonym>treatment</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;TherapyRelationship">
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;Context"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;TherapyRelationshipType"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;appliesTo"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&idmp-mprd;TherapySpecification">
-							</rdf:Description>
-							<rdf:Description rdf:about="&idmp-mprd;Therapy">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:onClass rdf:resource="&idmp-mprd;Therapy"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>therapy relationship</rdfs:label>
@@ -4374,7 +4425,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:allValuesFrom rdf:resource="&idmp-mprd;TherapyRelationship"/>
+				<owl:onClass rdf:resource="&idmp-mprd;TherapyRelationship"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>therapy relationship type</rdfs:label>
@@ -4382,21 +4434,6 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:note>The type of relationship between the Medicinal Product indication or contraindication and a specific other therapy shall be specified using an appropriate controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.6.2</cmns-av:adaptedFrom>
 		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&idmp-mprd;TherapySpecification">
-		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;Therapy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>therapy specification</rdfs:label>
-		<skos:definition>specification of how a therapy is applied</skos:definition>
-		<cmns-av:synonym>therapeutic method</cmns-av:synonym>
-		<cmns-av:synonym>therapeutic procedure</cmns-av:synonym>
-		<cmns-av:synonym>therapy</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;UndesirableEffect">
@@ -4508,22 +4545,6 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>textual description of an undesirable effect of a medicinal product</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-mprd;VolumeCharacteristic">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-qtu;hasQuantityValue"/>
-				<owl:onClass rdf:resource="&cmns-qtu;ScalarQuantityValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>volume characteristic</rdfs:label>
-		<skos:definition>3-D extent physical characteristic inhering in a bearer by virtue of the bearer&apos;s amount of 3-dimensional space it occupies</skos:definition>
-		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.6</cmns-av:adaptedFrom>
-		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000918</cmns-av:adaptedFrom>
-		<cmns-av:synonym>volume</cmns-av:synonym>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-mprd;WeightCharacteristic">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
 		<rdfs:subClassOf>
@@ -4535,6 +4556,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>weight characteristic</rdfs:label>
 		<skos:definition>physical characteristic inhering in a bearer that has mass near a gravitational body</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.5</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000000128</cmns-av:adaptedFrom>
 		<cmns-av:synonym>weight</cmns-av:synonym>
@@ -4551,6 +4574,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>width characteristic</rdfs:label>
 		<skos:definition>1-D extent physical characteristic which is equal to the distance from one side of an object to another side which is opposite</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.3</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_000001595</cmns-av:adaptedFrom>
 		<cmns-av:synonym>width</cmns-av:synonym>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -3225,6 +3225,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>outer packaging</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.57</dct:source>
 		<skos:definition>external container in which a medicinal product is supplied</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:explanatoryNote>The manufactured item or pharmaceutical product is not in direct contact with the outer packaging except where the outer packaging also serves as the immediate container. An alternative, compatible definition of outer packaging is given in Directive 92/27/EEC.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -3289,6 +3290,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>package identifier</rdfs:label>
 		<skos:definition>unique identifier allocated in addition to any existing authorisation/approval number at package level as ascribed by a Medicines Regulatory Agency in a region</skos:definition>
 		<skos:note>The PCID shall use a common segment pattern related to a package of a Medicinal Product, which when each segment is valued, shall define a specific PCID concept. The pattern is: a) MPID for the Medicinal Product; b) package description code segment, which refers to a unique identifier for each package.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-ModelConformant"/>
 		<cmns-av:abbreviation>PCID</cmns-av:abbreviation>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 8.3, 9.6.2.2.1</cmns-av:directSource>
 		<cmns-av:synonym>packaged medicinal product identifier</cmns-av:synonym>
@@ -3358,6 +3361,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>package item</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.58</dct:source>
 		<skos:definition>individual, distinct item contained in a packaged medicinal product that acts as a container for one or more manufactured item(s)</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:explanatoryNote>The manufactured item or pharmaceutical product is not in direct contact with the outer packaging except where the outer packaging also serves as the immediate container. An alternative, compatible definition of outer packaging is given in Directive 92/27/EEC.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -3528,6 +3532,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>pharmaceutical product characteristic</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.8</dct:source>
 		<skos:definition>aspect of a pharmaceutical product that describes that product, such as its onset of action</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;PharmaceuticalProductIdentifier">
@@ -3591,6 +3596,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>pharmaceutical product or combination of pharmaceutical products that may be administered to human beings (or animals) for treating or preventing disease, with the aim/purpose of making a medical diagnosis or to restore, correct or modify physiological functions</skos:definition>
 		<skos:note>A medicinal product may contain in the packaging one or more manufactured items and one or more pharmaceutical products. In certain regions, a medicinal product may also be defined as any substance or combination of substances which may be used to make a medical diagnosis.</skos:note>
 		<skos:note>The provisions in this document [ontology] apply to proprietary medicinal products for human use intended to be placed on the market and to industrially manufactured medicinal products, the marketing of which has been authorized by a medicines regulatory agency. However, the provisions do not apply to: i) medicinal products prepared according to prescription (e.g. prepared in a pharmacy from a prescription intended for a specific patient), ii) medicinal products prepared in accordance with an official formula (e.g. prepared in a pharmacy in accordance with the instructions in a pharmacopoeia and intended to be given direct to the patient by the pharmacy), iii) medicinal products intended for research and development trials, and to iv) intermediate products intended for subsequent processing by an authorized manufacturer.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.42</cmns-av:directSource>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.50</cmns-av:directSource>
 	</owl:Class>
@@ -3617,6 +3623,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>physical pharmaceutical product</rdfs:label>
 		<skos:definition>qualitative and quantitative composition of a medicinal product in the dose form approved for administration in line with the regulated product information</skos:definition>
 		<skos:note>In many instances, the pharmaceutical product is equal to the manufactured item. However, there are instances where the manufactured item shall undergo a transformation before being administered to the patient (as the pharmaceutical product) and the two are not equal.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:directSource>ISO 11238:2018 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.58</cmns-av:directSource>
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 3.1.60</cmns-av:directSource>
 	</owl:Class>
@@ -3631,6 +3638,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>physiological condition</rdfs:label>
 		<skos:definition>condition of the external or internal milieu for an organism</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;PhysiologicalConditionPopulationCharacteristic">
@@ -3642,7 +3650,10 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>physiological condition population characteristic</rdfs:label>
-		<skos:definition>classifier for a statistical population based on the physiological condition its members</skos:definition>
+		<skos:definition>classifier for a statistical population based on the physiological condition of its members</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause Figure 14</cmns-av:directSource>
+		<cmns-av:synonym>physiological condition</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Placebo">
@@ -3650,6 +3661,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:label>placebo</rdfs:label>
 		<dct:source>National Cancer Institute Thesaurus, see http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C753</dct:source>
 		<skos:definition>inactive substance, treatment or procedure that is intended to provide baseline measurements for the experimental protocol of a clinical trial</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:explanatoryNote>A placebo is essentially a medicinal product, with the same packaging, etc. from a patient perspective as the actual investigational or authorized product used in a clinical trial, but without the active ingredient studied in the trial.</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -3670,6 +3682,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>population characteristic</rdfs:label>
 		<skos:definition>classifier of a target population intended as the target of a therapeutic indication or contraindication</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
 	</owl:Class>
 	
@@ -3677,7 +3690,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Strength"/>
 		<rdfs:label>presentation strength</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.7.2.5.3</dct:source>
-		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) expressed in units of presentation ...</skos:definition>
+		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) expressed in units of presentation</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:synonym>strength (presentation)</cmns-av:synonym>
 	</owl:Class>
 	
@@ -3751,8 +3765,9 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>product classifier</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure 6</dct:source>
-		<skos:definition>classifier for a product using a categorization or grouping of Medicinal Products based on specific properties</skos:definition>
+		<skos:definition>classifier for a product using a categorization or grouping of medicinal products based on specific properties</skos:definition>
 		<skos:note>The Medicinal Product can be classified according to various classification systems, which may be regional or international.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:synonym>product classification</cmns-av:synonym>
 	</owl:Class>
 	
@@ -3790,6 +3805,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>product composition</rdfs:label>
 		<skos:definition>constituency that defines some product based on its relationship(s) to some other substance(s) (ingredient(s)), potentially with a given strength, in some context</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 		<cmns-av:usageNote>From an implementation (mapping) perspective, this product constituency class provides the basis for a (blank) node in the relationship &apos;product realizes ingredient role played by some substance&apos;, where the ingredient role may be that of an active ingredient which, in turn, may have some basis of strength in some context. The same product constituency could be used to link inactive ingredients to a product in which they are realized. A given product may include multiple active ingredients, each of which may have a different basis of strength.</cmns-av:usageNote>
 	</owl:Class>
 	
@@ -3812,6 +3828,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>product role</rdfs:label>
 		<skos:definition>functional role played by a product or specification for a product that is part of or used in the preparation of some manufactured item, or pharmaceutical product, medication, or drug, or in some investigation</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductSpecification">
@@ -3839,6 +3856,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>product specification</rdfs:label>
 		<skos:definition>specification for something that is produced by, results from, or obtained as a consequence of some process or transformation</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;QualitativeComposition">
@@ -3851,9 +3869,10 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>qualitative composition</rdfs:label>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.70</dct:source>
-		<skos:definition>composition of all the constituents of the investigational or authorized Medicinal Product), if applicable, before or after reconstitution and functioning of the constituents of:
+		<skos:definition>composition of all the constituents of the investigational or authorized medicinal product), if applicable, before or after reconstitution and functioning of the constituents of:
 - the substance (and specified substance description;
 - the excipients, whatever their nature or the quantity used, including colouring matter, preservatives, adjuvants, stabilizers, thickeners, emulsifiers, flavouring and aromatic substances, etc.</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;QuantitativeComposition">
@@ -3868,6 +3887,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.71</dct:source>
 		<skos:definition>amount of substance and specified substance constituents of the investigational or authorized medicinal product expressed in a ratio scale</skos:definition>
 		<skos:note>It is necessary for the quantitative composition of the substance(s) or the specified substance descriptions of the finished investigational or authorized Medicinal Products (depending on the pharmaceutical form concerned) to specify the mass, or the number of units of biological activity, either per dosage unit or per unit of mass or volume, of each substance or specified substance. Substance or specified substance descriptions present in the form of compounds or derivatives are always designated quantitatively by their total mass and, if necessary or relevant, by the mass of active entity, or entities, of the molecule. The term strength is a synonym of quantitative composition.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:usageNote>Note that quantitative composition is modeled as a kind of product composition in the ontology rather than as a quantity value, which is how the strength of a given ingredient is modeled.</cmns-av:usageNote>
 	</owl:Class>
 	
@@ -3880,7 +3900,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>race or ethnicity</rdfs:label>
-		<skos:definition>a subdivision of human population based on common culture or descent or a subspecies of animals</skos:definition>
+		<skos:definition>subdivision of human population based on common culture or descent or a subspecies of animals</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;RaceOrEthnicityPopulationCharacteristic">
@@ -3893,6 +3914,8 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>race or ethnicity population characteristic</rdfs:label>
 		<skos:definition>classifier for a statistical population based on the race or ethnicity of its members</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.9.2.5</cmns-av:adaptedFrom>
 		<cmns-av:usageNote>HL7 uses PHIN-VADS Race &amp; Ethnicity - CDC as vocabulary for this</cmns-av:usageNote>
 	</owl:Class>
 	
@@ -3927,6 +3950,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.72</dct:source>
 		<skos:definition>strength of an active substance(s) and/or specified substance(s) used as a reference from which the strength of an investigational or authorized medicinal product is described</skos:definition>
 		<skos:note>The strength of the active substance(s) and/or specified substance(s) shall be described as a quantity of the substance present in a given unit of the pharmaceutical product or manufactured item.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;RegistrationNumber">
@@ -3944,6 +3968,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>registration number</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 11.4.2.2</dct:source>
 		<skos:definition>identifier assigned to a clinical trial by a medicines regulatory agency in a region for tracking purposes</skos:definition>
 	</owl:Class>
 	
@@ -3955,10 +3980,13 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Scoring">
-		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
 		<rdfs:label>scoring</rdfs:label>
-		<skos:definition>rating based on a specific achievement or degree to which certain qualities are manifest</skos:definition>
+		<skos:definition>debossed line that runs across the planar surface of a tablet</skos:definition>
+		<skos:note>Scoring is the process of creating a groove or mark on a tablet to facilitate splitting it into equal parts. Scoring can help patients adjust their dosage, reduce costs, or improve swallowing of the tablet. However, scoring also requires careful evaluation and labeling to ensure the safety and efficacy of the drug product.</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.12</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>Nomenclature, Labeling, and Data for Evaluation, FDA Guidance for Industry, March 2013.</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;Shape">
@@ -3972,6 +4000,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		</rdfs:subClassOf>
 		<rdfs:label>shape</rdfs:label>
 		<skos:definition>morphological physical characteristic inhering in a bearer by virtue of the bearer&apos;s ratios of distances between its features (points, edges, surfaces and also holes etc).</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.6.2.21.8</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/PATO_0000052</cmns-av:adaptedFrom>
 	</owl:Class>
@@ -4059,9 +4088,10 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>small to medium enterprise</rdfs:label>
-		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.3.2.4</dct:source>
 		<skos:definition>classifier indicating that an entity has been certified based on its size in order to receive authorization for something under special rules</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NonConformant"/>
 		<cmns-av:abbreviation>SME</cmns-av:abbreviation>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.3.2.4</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;SpecialPrecautionsForStorage">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -120,7 +120,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230701/ISO11615-MedicinalProducts.rdf version of this ontology was modified to extend the definition of product role to relate to product specifications in addition to products (IDMP-633).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230801/ISO11615-MedicinalProducts.rdf version of this ontology was modified to add other therapy specifics (IDMP-639), and to (1) reflect the migration of some content in Commons from the Parties and Situations ontology to a new Roles and Compositions ontology at OMG (IDMP-642), to (1) rename cmns-doc;isSpecifiedBy to cmns-doc;isSpecifiedIn, (2) incorporate hasExpirationDate, which was simplified out of the OMG Commons ontology, and (3) rename concepts including Quantity, QuantityValue, and QuantityValueRange to ScalarQuantity, ScalarQuantityValue, and ScalarQuantityValueRange per the Commons 1.1 release (IDMP-655), and to restructure the inheritance hierarchy with respect to Batch and Lot definitions (IDMP-632).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230901/ISO11615-MedicinalProducts.rdf version of this ontology was modified to add package components, devices, and physical characteristics (IDMP-659), to eliminate default codes on Ingredient and InactiveIngredient (IDMP-634), and add characteristics for target populations (IDMP-640).</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20231001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to correct definitions to be compliant with IDMP-O policies (GitHub-501), and fill in gaps with respect to the top-level class definitions and relationships in the complete model figures for authorized and investigational medicinal product in Annex A and Annex B, respectively, in ISO 11615 (IDMP-677).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20231001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to correct definitions to be compliant with IDMP-O policies (GitHub-501), fill in gaps with respect to the top-level class definitions and relationships in the complete model figures for authorized and investigational medicinal product in Annex A and Annex B, respectively, in ISO 11615 (IDMP-677), and to update the conformance points to be current (IDMP-322).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2023 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -534,6 +534,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of a substance present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients, where the active moiety is basis of strength</skos:definition>
 		<skos:example>For example, 287 mg amoxicillin trihydrate equivalent to 250 mg anhydrous amoxicillin.</skos:example>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 		<cmns-av:explanatoryNote>Note that in the example case both substances can be use as a basis of strength (BOSS) because there is a stoichiometric relationship between them. In all cases where there is no stoichiometric relationship between the reference substance and salt forms, the base or the acid must be taken as the reference substance (BOSS).</cmns-av:explanatoryNote>
 	</owl:Class>
 	
@@ -572,6 +573,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of a substance present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients, where the entire substance is the basis of strength</skos:definition>
 		<skos:example>For example, propranolol hydrochloride quantified as the propranolol hydrochloride salt.</skos:example>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActiveIngredientReferenceSubstanceBasisOfStrength">
@@ -610,6 +612,7 @@
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of a substance present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients, where another reference substance is the basis of strength</skos:definition>
 		<skos:example>For example, metoprolol succinate quantified by amount of metoprolol tartrate with the equal amount of metoprolol active moiety.</skos:example>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActiveIngredientWithoutBasisOfStrength">
@@ -623,13 +626,14 @@
 		<rdfs:label>active ingredient without basis of strength</rdfs:label>
 		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, table D.1, clause D.2.1</dct:source>
 		<skos:definition>role of a substance present in a currently or previously marketed drug product indicating that it is or becomes pharmacologically active once delivered to patients whose basis of strength cannot be specified</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-NameAndAnnotationConformant"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;ActivityBasedStrength">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;Strength"/>
 		<rdfs:label>activity-based strength</rdfs:label>
-		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.7.2.5.3</dct:source>
-		<skos:definition>quantity or range of quantities of the substance/specified substance present per unitary volume (or mass) ...</skos:definition>
+		<skos:definition>quantity or range of quantities of the substance/specified substance (i.e., its potency) based on its biological or pharmacological activity, rather than its mass or concentration</skos:definition>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AdministrableDoseForm">
@@ -643,34 +647,33 @@
 		<cmns-av:synonym>pharmaceutical administrable dose form</cmns-av:synonym>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&idmp-mprd;Age">
-		<rdfs:subClassOf rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
-		<rdfs:subClassOf rdf:resource="&cmns-dt;Duration"/>
-		<rdfs:subClassOf rdf:resource="&cmns-qtu;ScalarQuantity"/>
-		<rdfs:label>age</rdfs:label>
-		<skos:definition>time (duration or quantity) since the creation or birth of something</skos:definition>
-		<cmns-av:usageNote>Age is both a duration and a quantity. Its magnitude value can be expressed as quantity value with a time unit or as an ISO 8601 duration expression, depending on the domain.</cmns-av:usageNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&idmp-mprd;AgeClassifier">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;Age"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;AgePopulationCharacteristic"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>age classifier</rdfs:label>
-		<skos:definition>qualitative classifier for ages</skos:definition>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 8.2.2.4 and Figure 14</dct:source>
+		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure F.1, clause F.2.7.1</dct:source>
+		<skos:definition>qualitative classifier for a range of ages, specified in terms of a controlled vocabulary</skos:definition>
 		<skos:example>adult</skos:example>
 		<skos:example>elderly</skos:example>
+		<skos:note>The age group of the specific population for an indication, undesirable effect, or a contraindication as authorized for the medicinal product in accordance with the regulated medicinal product information can be specified using an appropriate controlled terminology.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:synonym>age</cmns-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AgePopulationCharacteristic">
 		<rdfs:subClassOf rdf:resource="&idmp-mprd;PopulationCharacteristic"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasPopulationClassifiedBy"/>
 				<owl:onClass rdf:resource="&idmp-mprd;AgeClassifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -682,14 +685,14 @@
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-doc;specifies"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;Age"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>age population characteristic</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 8.2.2.4 and Figure 14</dct:source>
+		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure F.1, clause F.2.7.1</dct:source>
 		<skos:definition>classifier for a statistical population based on the age of its members</skos:definition>
+		<skos:note>Age is both a duration and a quantity. Its magnitude value can be expressed as quantity value with a time unit or as an ISO 8601 duration expression, depending on the domain.</skos:note>
+		<skos:note>The age group of the specific population for an indication, undesirable effect, or a contraindication as authorized for the medicinal product in accordance with the regulated medicinal product information can be specified using an appropriate controlled terminology.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
 		<cmns-av:usageNote>The age is either expressed as an explicit range of ages or by an age classifier from a controlled vocabulary.</cmns-av:usageNote>
 	</owl:Class>
 	
@@ -708,13 +711,23 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>age range value</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 8.2.2.4 and Figure 14</dct:source>
+		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure F.1, clause F.2.7.1</dct:source>
 		<skos:definition>time quantity value range expressing the upper and lower bounds amount of time passed since creation of something</skos:definition>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-DefinitionallyConformant"/>
+		<cmns-av:usageNote>Age is both a duration and a quantity. Its magnitude value can be expressed as quantity value with a time unit or as an ISO 8601 duration expression, depending on the domain.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AgeValue">
 		<rdfs:subClassOf rdf:resource="&idmp-uom;TimeQuantityValue"/>
 		<rdfs:label>age value</rdfs:label>
+		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 8.2.2.4 and Figure 14</dct:source>
+		<dct:source>ISO/TS 20443:2017(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, Figure F.1, clause F.2.7.1</dct:source>
 		<skos:definition>time quantity value expressing the amount of time passed since creation of something</skos:definition>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-PQ"/>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+		<cmns-av:usageNote>Age is both a duration and a quantity. Its magnitude value can be expressed as quantity value with a time unit or as an ISO 8601 duration expression, depending on the domain.</cmns-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-mprd;AttachedDocument">
@@ -952,7 +965,7 @@
 		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
 				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
@@ -967,7 +980,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onProperty rdf:resource="&cmns-dsg;denotes"/>
 				<owl:allValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">


### PR DESCRIPTION
Description: 
1. Cleaned up conformance level for ingredients in the substances ontology after review of ISO 11615; added conformance levels and regularized the modeling of age as a population characteristic, with conformance details in the medicinal products ontology
2. Additional refinement of annotations related to medicinal
 products, including elements related to administrable dose forms and authorized medicinal products
3. Added annotations for a number of additional concepts and cleaned up the model in a few cases, such as for batch, clinical trial, and gender related elements
4. Added notes regarding controlled vocabularies not specified in the IDMP standard and extensions to the definition of interaction
5. Extended definitions of medicinal product header, manufacturing authorization to cover pharma company usage examples