### PR TITLE
IDMP-657 - add missing package item properties

### DIFF
--- a/EXT/Examples/AmlodipineExample.rdf
+++ b/EXT/Examples/AmlodipineExample.rdf
@@ -1179,14 +1179,14 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBlisterTabletComponent">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
 		<idmp-mprd:hasManufacturedItemQuantity>
 			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">10.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;Norvasc-ManufacturedItem-5mgTablet"/>
+		<idmp-mprd:isCharacterizedByManufacturedItem rdf:resource="&idmp-amp;Norvasc-ManufacturedItem-5mgTablet"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBox">
@@ -1206,7 +1206,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBoxBlisterComponent">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
 		<rdfs:label>Norvasc box blister component</rdfs:label>
 		<idmp-mprd:hasPackageItemQuantity>
 			<cmns-qtu:ScalarQuantityValue>
@@ -1214,7 +1214,7 @@
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">6.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasPackageItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-amp;NorvascBlister"/>
+		<idmp-mprd:isCharacterizedByPackageItem rdf:resource="&idmp-amp;NorvascBlister"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-amp;NorvascBoxComposition">

--- a/EXT/Examples/QlairaExample.rdf
+++ b/EXT/Examples/QlairaExample.rdf
@@ -925,18 +925,20 @@
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-1x28Box-Constituency">
 		<rdf:type rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:label>Qlaira, package item, 1 x 28 box, constituency</rdfs:label>
-		<cmns-col:hasConstituent>
-			<cmns-col:Constituent>
-				<idmp-mprd:hasPackageItemQuantity>
-					<cmns-qtu:ScalarQuantityValue>
-						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002109"/>
-						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:ScalarQuantityValue>
-				</idmp-mprd:hasPackageItemQuantity>
-				<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
-			</cmns-col:Constituent>
-		</cmns-col:hasConstituent>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-1x28Box-ContainerConstituent-1x28TabletBlister"/>
 		<cmns-dsg:defines rdf:resource="&idmp-qla;Qlaira-PackageItem-1x28Box"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-1x28Box-ContainerConstituent-1x28TabletBlister">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item 1 x 28 box, container constituent, 1 x 28 tablet blister</rdfs:label>
+		<idmp-mprd:hasPackageItemQuantity>
+			<cmns-qtu:ScalarQuantityValue>
+				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002109"/>
+				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">1.0</cmns-qtu:hasNumericValue>
+			</cmns-qtu:ScalarQuantityValue>
+		</idmp-mprd:hasPackageItemQuantity>
+		<idmp-mprd:isCharacterizedByPackageItem rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister">
@@ -964,72 +966,84 @@
 	
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituency">
 		<rdfs:label>Qlaira, package item, 28 tablet blister, constituency</rdfs:label>
-		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-1"/>
-		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-2"/>
-		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-3"/>
-		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-4"/>
-		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-5"/>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-17xLightYellowTablets"/>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-2xDarkRedTablets"/>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-2xDarkYellowTablets"/>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-2xWhiteTablets"/>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-5xMediumRedTablets"/>
 		<cmns-dsg:defines rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-1">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
-		<rdfs:label>Qlaira, package item, 28 tablet blister, constituent 1</rdfs:label>
-		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:ScalarQuantityValue>
-				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
-				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:ScalarQuantityValue>
-		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-DarkYellowTablets"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-2">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
-		<rdfs:label>Qlaira, package item, 28 tablet blister, constituent 2</rdfs:label>
-		<idmp-mprd:hasManufacturedItemQuantity>
-			<cmns-qtu:ScalarQuantityValue>
-				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
-				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">5.0</cmns-qtu:hasNumericValue>
-			</cmns-qtu:ScalarQuantityValue>
-		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-MediumRedTablets"/>
-	</owl:NamedIndividual>
-	
-	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-3">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
-		<rdfs:label>Qlaira, package item, 28 tablet blister, constituent 3</rdfs:label>
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-17xLightYellowTablets">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 28 tablet blister, container constituent, 17 x light yellow tablets</rdfs:label>
 		<idmp-mprd:hasManufacturedItemQuantity>
 			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">17.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-LightYellowTablets"/>
+		<idmp-mprd:isCharacterizedByManufacturedItem rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-LightYellowTablets"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-4">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
-		<rdfs:label>Qlaira, package item, 28 tablet blister, constituent 4</rdfs:label>
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-2xDarkRedTablets">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 28 tablet blister, container constituent, 2 x dark red tablets</rdfs:label>
 		<idmp-mprd:hasManufacturedItemQuantity>
 			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-DarkRedTablets"/>
+		<idmp-mprd:isCharacterizedByManufacturedItem rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-DarkRedTablets"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-Constituent-5">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
-		<rdfs:label>Qlaira, package item, 28 tablet blister, constituent 5</rdfs:label>
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-2xDarkYellowTablets">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 28 tablet blister, constituent, 2 x dark yellow tablets</rdfs:label>
 		<idmp-mprd:hasManufacturedItemQuantity>
 			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasManufacturedItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-WhiteTablets"/>
+		<idmp-mprd:isCharacterizedByManufacturedItem rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-DarkYellowTablets"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-2xWhiteTablets">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 28 tablet blister, container constituent, 2 x white tablets</rdfs:label>
+		<idmp-mprd:hasManufacturedItemQuantity>
+			<cmns-qtu:ScalarQuantityValue>
+				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
+				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">2.0</cmns-qtu:hasNumericValue>
+			</cmns-qtu:ScalarQuantityValue>
+		</idmp-mprd:hasManufacturedItemQuantity>
+		<idmp-mprd:isCharacterizedByManufacturedItem rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-WhiteTablets"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-28TabletBlister-ContainerConstituent-5xMediumRedTablets">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 28 tablet blister, container constituent, 5 x medium red tablets</rdfs:label>
+		<idmp-mprd:hasManufacturedItemQuantity>
+			<cmns-qtu:ScalarQuantityValue>
+				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002152"/>
+				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">5.0</cmns-qtu:hasNumericValue>
+			</cmns-qtu:ScalarQuantityValue>
+		</idmp-mprd:hasManufacturedItemQuantity>
+		<idmp-mprd:isCharacterizedByManufacturedItem rdf:resource="&idmp-qla;Qlaira-ManufacturedItem-MediumRedTablets"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-3s28Box-ContainerConstituent-3x28TabletBlister">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 3 x 28 box, container constituent, 3 x 28 tablet blister</rdfs:label>
+		<idmp-mprd:hasPackageItemQuantity>
+			<cmns-qtu:ScalarQuantityValue>
+				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002109"/>
+				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">3.0</cmns-qtu:hasNumericValue>
+			</cmns-qtu:ScalarQuantityValue>
+		</idmp-mprd:hasPackageItemQuantity>
+		<idmp-mprd:isCharacterizedByPackageItem rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-3x28Box">
@@ -1051,17 +1065,7 @@
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-3x28Box-Constituency">
 		<rdf:type rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:label>Qlaira, package item, 3 x 28 box, constituency</rdfs:label>
-		<cmns-col:hasConstituent>
-			<cmns-col:Constituent>
-				<idmp-mprd:hasPackageItemQuantity>
-					<cmns-qtu:ScalarQuantityValue>
-						<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002109"/>
-						<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">3.0</cmns-qtu:hasNumericValue>
-					</cmns-qtu:ScalarQuantityValue>
-				</idmp-mprd:hasPackageItemQuantity>
-				<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
-			</cmns-col:Constituent>
-		</cmns-col:hasConstituent>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-3s28Box-ContainerConstituent-3x28TabletBlister"/>
 		<cmns-dsg:defines rdf:resource="&idmp-qla;Qlaira-PackageItem-3x28Box"/>
 	</owl:NamedIndividual>
 	
@@ -1084,20 +1088,20 @@
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-6x28Box-Constituency">
 		<rdf:type rdf:resource="&cmns-rlcmp;Composition"/>
 		<rdfs:label>Qlaira, package item, 6 x 28 box, constituency</rdfs:label>
-		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-6x28Box-Constituent"/>
+		<cmns-col:hasConstituent rdf:resource="&idmp-qla;Qlaira-PackageItem-6x28Box-ContainerConstituent-6x28TabletBlister"/>
 		<cmns-dsg:defines rdf:resource="&idmp-qla;Qlaira-PackageItem-6x28Box"/>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-6x28Box-Constituent">
-		<rdf:type rdf:resource="&cmns-col;Constituent"/>
-		<rdfs:label>Qlaira, package item, 6 x 28 box, constituent</rdfs:label>
+	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackageItem-6x28Box-ContainerConstituent-6x28TabletBlister">
+		<rdf:type rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:label>Qlaira, package item, 6 x 28 box, container constituent, 6 x 28 tablet blister</rdfs:label>
 		<idmp-mprd:hasPackageItemQuantity>
 			<cmns-qtu:ScalarQuantityValue>
 				<cmns-qtu:hasMeasurementUnit rdf:resource="https://spor.ema.europa.eu/v1/lists/200000000014/terms/200000002109"/>
 				<cmns-qtu:hasNumericValue rdf:datatype="&xsd;decimal">6.0</cmns-qtu:hasNumericValue>
 			</cmns-qtu:ScalarQuantityValue>
 		</idmp-mprd:hasPackageItemQuantity>
-		<cmns-rlcmp:isPlayedBy rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
+		<idmp-mprd:isCharacterizedByPackageItem rdf:resource="&idmp-qla;Qlaira-PackageItem-28TabletBlister"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&idmp-qla;Qlaira-PackagedMedicinalProduct-1x28Box">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -5310,7 +5310,7 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 	<owl:ObjectProperty rdf:about="&idmp-mprd;isCharacterizedByManufacturedItem">
 		<rdfs:label>is characterized by manufactured item</rdfs:label>
 		<rdfs:domain rdf:resource="&idmp-mprd;ContainerConstituent"/>
-		<rdfs:range rdf:resource="&idmp-mprd;ManufacturedItem"/>
+		<rdfs:range rdf:resource="&idmp-sub;ManufacturedItem"/>
 		<rdfs:subProperyOf rdf:resource="&cmns-cls;isCharacterizedBy"/>
 		<skos:definition>relates the container constituent to its manufactured item</skos:definition>
 		<skos:example>A blister contains 20 tablets. One container constituent of the blister has the quantity of 10 tablets (units) chracterized by the tablet manufactured item.</skos:example>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -5307,6 +5307,24 @@ g) therapeutic indication(s) as authorized for the medicinal product.</skos:note
 		<skos:definition>indicates the situation that facilitates endorsement of the authorized party for some purpose</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isCharacterizedByManufacturedItem">
+		<rdfs:label>is characterized by manufactured item</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:range rdf:resource="&idmp-mprd;ManufacturedItem"/>
+		<rdfs:subProperyOf rdf:resource="&cmns-cls;isCharacterizedBy"/>
+		<skos:definition>relates the container constituent to its manufactured item</skos:definition>
+		<skos:example>A blister contains 20 tablets. One container constituent of the blister has the quantity of 10 tablets (units) chracterized by the tablet manufactured item.</skos:example>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isCharacterizedByPackageItem">
+		<rdfs:label>is characterized by package item</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;ContainerConstituent"/>
+		<rdfs:range rdf:resource="&idmp-mprd;PackageItem"/>
+		<rdfs:subProperyOf rdf:resource="&cmns-cls;isCharacterizedBy"/>
+		<skos:definition>relates the container constituent to its package item</skos:definition>
+		<skos:example>A box contains 5 blisters. One container constituent of the box has the quantity of 5 blisters (units) characterized by a blister package item.</skos:example>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;isContainedIn">
 		<rdf:type rdf:resource="&owl;TransitiveProperty"/>
 		<rdfs:subPropertyOf rdf:resource="&cmns-col;isPartOf"/>


### PR DESCRIPTION
summary: used 'is characterized by package item/manufactured item' instead of 'is played by' to link the package item constituent to the contained type