### PR TITLE
IDMP-GitHub-571 - Simplify the licensing definitions in Commons to facilitate mapping to BFO

### DIFF
--- a/CMNS/ProductsAndServices.rdf
+++ b/CMNS/ProductsAndServices.rdf
@@ -60,10 +60,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/PartiesAndSituations/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230801/ProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20240801/ProductsAndServices/"/>
 		<skos:note>This ontology was originally designed for and has been adapted from the Financial Industry Business Ontology (FIBO) Products and Services Ontology.</skos:note>
-		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&cmns-prd;Capability">
@@ -523,6 +523,13 @@
 		<skos:definition>indicates a role played by a functional entity or party responsible for circulating, distributing, or publishing something</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&cmns-prd;isIssuedTo">
+		<rdfs:subPropertyOf rdf:resource="&cmns-prd;isProvidedTo"/>
+		<rdfs:label>is issued to</rdfs:label>
+		<rdfs:range rdf:resource="&cmns-pts;AgentRole"/>
+		<skos:definition>indicates a role played by a functional entity or party to the recipient of something, such as a license or authorization</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&cmns-prd;isProducedBy">
 		<rdfs:label>is produced by</rdfs:label>
 		<rdfs:range rdf:resource="&cmns-prd;Producer"/>
@@ -534,6 +541,11 @@
 		<rdfs:label>is provided by</rdfs:label>
 		<owl:inverseOf rdf:resource="&cmns-prd;provides"/>
 		<skos:definition>is made available by</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&cmns-prd;isProvidedTo">
+		<rdfs:label>is provided to</rdfs:label>
+		<skos:definition>is made available to</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&cmns-prd;isSituatedAt">

--- a/CMNS/RegulatoryAgencies.rdf
+++ b/CMNS/RegulatoryAgencies.rdf
@@ -54,9 +54,9 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/RolesAndCompositions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20230901/RegulatoryAgencies/"/>
-		<cmns-av:copyright>Copyright (c) 2022-2023 EDM Council, Inc.</cmns-av:copyright>
-		<cmns-av:copyright>Copyright (c) 2022-2023 Object Management Group, Inc.</cmns-av:copyright>
+		<owl:versionIRI rdf:resource="https://www.omg.org/spec/Commons/20240801/RegulatoryAgencies/"/>
+		<cmns-av:copyright>Copyright (c) 2022-2024 EDM Council, Inc.</cmns-av:copyright>
+		<cmns-av:copyright>Copyright (c) 2022-2024 Object Management Group, Inc.</cmns-av:copyright>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&cmns-org;LegalEntity">
@@ -109,15 +109,16 @@
 		<rdfs:subClassOf rdf:resource="&cmns-doc;LegalDocument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-pts;holdsDuring"/>
-				<owl:onClass rdf:resource="&cmns-dt;DatePeriod"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&cmns-prd;isIssuedTo"/>
+				<owl:onClass rdf:resource="&cmns-rga;Licensee"/>
+				<owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-pts;hasPartyRole"/>
-				<owl:someValuesFrom rdf:resource="&cmns-rga;Licensee"/>
+				<owl:onProperty rdf:resource="&cmns-pts;holdsDuring"/>
+				<owl:onClass rdf:resource="&cmns-dt;DatePeriod"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -148,17 +149,6 @@
 	<owl:Class rdf:about="&cmns-rga;Licensee">
 		<rdfs:subClassOf rdf:resource="&cmns-pts;PartyRole"/>
 		<rdfs:subClassOf rdf:resource="&cmns-pts;Undergoer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-pts;isAPartyTo"/>
-						<owl:someValuesFrom rdf:resource="&cmns-rga;License"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>licensee</rdfs:label>
 		<skos:definition>party to whom a license has been granted</skos:definition>
 		<cmns-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</cmns-av:adaptedFrom>
@@ -170,17 +160,6 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-prd;issues"/>
 				<owl:someValuesFrom rdf:resource="&cmns-rga;License"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
-				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&cmns-pts;isAPartyTo"/>
-						<owl:someValuesFrom rdf:resource="&cmns-rga;License"/>
-					</owl:Restriction>
-				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>licensor</rdfs:label>


### PR DESCRIPTION
 Added two properties, isProvidedTo and isIssuedTo in order to simplify restrictions in the regulatory agencies ontology and make it more amenable to mapping to BFO