### PR TITLE
GitHub-580: add mvf-term:Term as parent class for MedDRA term

### DIFF
--- a/ISO/MedicalDictionaryForRegulatoryActivities.rdf
+++ b/ISO/MedicalDictionaryForRegulatoryActivities.rdf
@@ -262,6 +262,7 @@
 	
 	<owl:Class rdf:about="&idmp-meddra;MedDRATerm">
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualDesignation"/>
+		<rdfs:subClassOf rdf:resource="&mvf-term;Term"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>

--- a/ISO/MedicalDictionaryForRegulatoryActivities.rdf
+++ b/ISO/MedicalDictionaryForRegulatoryActivities.rdf
@@ -262,7 +262,7 @@
 	
 	<owl:Class rdf:about="&idmp-meddra;MedDRATerm">
 		<rdfs:subClassOf rdf:resource="&cmns-cxtdsg;ContextualDesignation"/>
-		<rdfs:subClassOf rdf:resource="&mvf-term;Term"/>
+		<rdfs:subClassOf rdf:resource="&mvf-trm;Term"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-ra;isRegisteredIn"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -75,7 +75,7 @@
     <uri id="08ecff33-fc40-4c1d-b4da-b61c7a9ac371" name="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/TerlipressinExample/" uri="./EXT/Examples/TerlipressinExample.rdf"/>
     <uri id="9c901a23-eb1b-4fc3-85ef-cd1f0de14c3c" name="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/EuropeanUnionClinicalTrialsRegister/" uri="./EXT/Examples/EuropeanUnionClinicalTrialsRegister.rdf"/>
     <uri id="4ed69cac-b562-4394-804c-fbb978d8cee5" name="https://spec.pistoiaalliance.org/idmp/ontology/EXT/Examples/QlairaExample/" uri="./EXT/Examples/QlairaExample.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.pistoiaalliance.org/idmp/ontology/SPAR/MetadataSPAR/" uri="./SPAR/MetadataSPAR.rdf"/>
+    <uri id="2c29ee60-2703-4710-901a-a9341dc286d5" name="https://spec.pistoiaalliance.org/idmp/ontology/SPAR/MetadataSPAR/" uri="./SPAR/MetadataSPAR.rdf"/>
     <uri id="38da13f0-4b2b-11ee-be56-0242ac120002" name="http://purl.org/spar/doco/" uri="./SPAR/doco.rdf"/>
     <uri id="05b3e1d0-6802-4994-a933-c93c598cae20" name="http://purl.org/spar/po/" uri="./SPAR/po.rdf"/>
     <uri id="62f48cd7-f6bd-4d45-aa93-8a56feee5647" name="http://purl.org/spar/deo/" uri="./SPAR/deo.rdf"/>


### PR DESCRIPTION
description:
Added mvf-trm:Term as parent class of MedDRA Term in addition to ContextualDesignation