### PR TITLE
GitHub-601 - Modify the SPAR PO ontology to eliminate the SWRL Builtin statements which cannot be processed by certain reasoners

### DIFF
--- a/SPAR/po.rdf
+++ b/SPAR/po.rdf
@@ -934,15 +934,6 @@ Any entity belonging to this class is compliant with exactly one structural patt
 				<swrl:argument2 rdf:resource="&po;t"/>
 				<swrl:propertyPredicate rdf:resource="&po;hasName"/>
 			</swrl:DatavaluedPropertyAtom>
-			<swrl:BuiltinAtom>
-				<swrl:arguments rdf:parseType="Collection">
-					<rdf:Description rdf:about="&po;s">
-					</rdf:Description>
-					<rdf:Description rdf:about="&po;t">
-					</rdf:Description>
-				</swrl:arguments>
-				<swrl:builtin rdf:resource="&swrlb;notEqual"/>
-			</swrl:BuiltinAtom>
 		</swrl:body>
 		<swrl:head rdf:parseType="Collection">
 			<swrl:DatavaluedPropertyAtom>


### PR DESCRIPTION
Description: eliminated references to swrl:builtin, which not all reasoners handle properly