### PR TITLE
IDMP-779 - Augment the ISO 11615 ontology to include a property chain from manufacturer to the manufacturing site

### DIFF
--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -1696,6 +1696,13 @@
 	
 	<owl:Class rdf:about="&idmp-sub;Manufacturer">
 		<rdfs:subClassOf rdf:resource="&cmns-prd;Producer"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
+				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>manufacturer</rdfs:label>
 		<skos:definition>functional role of a party that produces finished products from raw materials or components using tools, machinery, labor, and chemical or physical transformation</skos:definition>
 		<skos:note>In the context of ISO 11238, the definition refers to a company responsible for the manufacturing of the substance. From a more general ISO IDMP perspective, a manufacturer refers to an organization that holds the authorization for the manufacturing process.</skos:note>

--- a/ISO/ISO11238-Substances.rdf
+++ b/ISO/ISO11238-Substances.rdf
@@ -102,7 +102,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240801/ISO11238-Substances/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240901/ISO11238-Substances/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221101/ISO11238-Substances.rdf version of this ontology was modified to relax the restriction on the property isStoichiometric with respect to chemical substances to optional from required (IDMP-380), and then reversed per the SME team and to conform with the IDMP standard.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11238-Substances.rdf version of this ontology was modified to relax the restriction on the property hasStructure with respect to substances, single substances, and moieties to optional from at most one value, to allow for cases where there may be multiples, especially if mapping content from multiple repositories (IDMP-GitHub-244) to add definitions for certain stereochemistry nominals where they were missing (IDMP-GitHub-243), and to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename substance constituency to substance composition, which is better understood by the user community. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11238-Substances.rdf version of this ontology was modified to integrate a revised manufactured item and packaging strategy for UC-2. (IDMP-465)</skos:changeNote>
@@ -115,7 +115,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20231001/ISO11238-Substances.rdf version of this ontology was augmented to build out the definition of mixture to complete the requirements specified in clause 7.8 of the ISO 11238 standard and related information in ISO/TS 19844 (IDMP-675), to assist in addressing gaps with respect to the top-level class definitions and relationships in the complete model figures for authorized and investigational medicinal product in Annex A and Annex B, respectively, in ISO 11615 (IDMP-677), and to update the conformance points to be current (IDMP-322).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20231201/ISO11238-Substances.rdf version of this ontology was augmented to build out the definition of source material (Figure 17 in the ISO standard) to support representation of biologics (IDMP-713) and to normalize the use of hasTextualName from MVF rather than from LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240301/ISO11238-Substances.rdf version of this ontology was augmented to add SKOS prefLabels for elements that have multiple labels (IDMP-734), to correct a wrong prefix for ReferenceSource, to make starting and resultant material roles disjoint, clean up URIs that had an erroneous final slash or were ill-formed, augment definitions with additional metadata from ISO 11238, and adjust the cardinality constraint on has quantity value range for amount to cover the case where there is both a quantity value range and reference range (GitHub-598).</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240601/ISO11238-Substances.rdf version of this ontology was augmented to integrate revisions to the content from the 1.2 revision of the OMG Commons Ontology Library (IDMP-774).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240601/ISO11238-Substances.rdf version of this ontology was augmented to integrate revisions to the content from the 1.2 revision of the OMG Commons Ontology Library (IDMP-774), and complete the linkage beween a manufacturer, a given business operation (facility), and the manufacturing site(s) at which a particular medicinal product (or component of a medicinal product) is manufactured (IDMP-779).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2024 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -1696,21 +1696,6 @@
 	
 	<owl:Class rdf:about="&idmp-sub;Manufacturer">
 		<rdfs:subClassOf rdf:resource="&cmns-prd;Producer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-prd;produces"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&idmp-sub;ManufacturedItem">
-							</rdf:Description>
-							<rdf:Description rdf:about="&idmp-sub;Substance">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label>manufacturer</rdfs:label>
 		<skos:definition>functional role of a party that produces finished products from raw materials or components using tools, machinery, labor, and chemical or physical transformation</skos:definition>
 		<skos:note>In the context of ISO 11238, the definition refers to a company responsible for the manufacturing of the substance. From a more general ISO IDMP perspective, a manufacturer refers to an organization that holds the authorization for the manufacturing process.</skos:note>
@@ -6354,6 +6339,13 @@ For the description of nucleic acids, the following information can be used to a
 				<owl:onProperty rdf:resource="&idmp-sub;hasComment"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -322,6 +322,25 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;produces"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;ManufacturedItem">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;MedicinalProduct">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;PharmaceuticalProduct">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-sub;Substance">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&cmns-org;LegalEntity"/>
 			</owl:Restriction>
@@ -6732,6 +6751,30 @@ The convention applied for naming a medicinal product can differ between medicin
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, figure 11</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isProducedATManufacturingSite">
+		<rdfs:label>is produced at manufacturing site</rdfs:label>
+		<owl:propertyChainAxiom rdf:parseType="Collection">
+			<rdf:Description rdf:about="&cmns-prd;isProducedBy">
+			</rdf:Description>
+			<rdf:Description rdf:about="&cmns-org;manages">
+			</rdf:Description>
+			<rdf:Description rdf:about="&cmns-prd;isSituatedAt">
+			</rdf:Description>
+		</owl:propertyChainAxiom>
+		<skos:definition>relates a substance, manufactured item, medicinal product, or pharmaceutical product to a manufacturing site where it is produced</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isProducedByManufacturingOperation">
+		<rdfs:label>is produced by manufacturing operation</rdfs:label>
+		<owl:propertyChainAxiom rdf:parseType="Collection">
+			<rdf:Description rdf:about="&cmns-prd;isProducedBy">
+			</rdf:Description>
+			<rdf:Description rdf:about="&cmns-org;manages">
+			</rdf:Description>
+		</owl:propertyChainAxiom>
+		<skos:definition>relates a substance, manufactured item, medicinal product, or pharmaceutical product to a manufacturing operation that produces it</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;isTherapeuticIndicationFor">
 		<rdfs:subPropertyOf rdf:resource="&cmns-doc;specifies"/>
 		<rdfs:label>is therapeutic indication for</rdfs:label>
@@ -6752,6 +6795,28 @@ The convention applied for naming a medicinal product can differ between medicin
 		<rdfs:domain rdf:resource="&idmp-mprd;ClinicalTrial"/>
 		<rdfs:range rdf:resource="&idmp-mprd;InvestigationalMedicinalProduct"/>
 		<skos:definition>indicates an investigational medicinal product that is administered in the context of a clinical trial</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;manufacturesAtSite">
+		<rdfs:label>manufactures at site</rdfs:label>
+		<owl:propertyChainAxiom rdf:parseType="Collection">
+			<rdf:Description rdf:about="&cmns-org;manages">
+			</rdf:Description>
+			<rdf:Description rdf:about="&cmns-prd;isSituatedAt">
+			</rdf:Description>
+		</owl:propertyChainAxiom>
+		<skos:definition>relates a manufacturer to a site at which it, or a delegated third party, conducts manufacturing</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;manufacturesInRegion">
+		<rdfs:label>manufactures in region</rdfs:label>
+		<owl:propertyChainAxiom rdf:parseType="Collection">
+			<rdf:Description rdf:about="&idmp-mprd;isAuthorizedThrough">
+			</rdf:Description>
+			<rdf:Description rdf:about="&cmns-cxtdsg;isApplicableIn">
+			</rdf:Description>
+		</owl:propertyChainAxiom>
+		<skos:definition>relates a manufacturer to a region in which it is authorized to manufacture something</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;sponsors">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2516,6 +2516,13 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf rdf:resource="&cmns-prd;Facility"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasConfidentialityIndicator"/>
+				<owl:onClass rdf:resource="&idmp-mprd;ConfidentialityIndicator"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rga;isRegulatedBy"/>
 				<owl:onClass rdf:resource="&idmp-mprd;MedicinesRegulatoryAgency"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -265,6 +265,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasDoseForm"/>
+				<owl:onClass rdf:resource="&idmp-mprd;ManufacturedDoseForm"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasPhysicalCharacteristic"/>
 				<owl:onClass rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -289,13 +296,6 @@
 				<owl:onProperty rdf:resource="&cmns-dsg;isDefinedIn"/>
 				<owl:onClass rdf:resource="&idmp-mprd;ProductComposition"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&idmp-mprd;hasDoseForm"/>
-				<owl:onClass rdf:resource="&idmp-mprd;ManufacturedDoseForm"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2348,7 +2348,16 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;authorizesManufacturingOf"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-mprd;MedicinalProduct">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-sub;ManufacturedItem">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -114,7 +114,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-TerminologyScience/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/ISO1087-VocabularyForTermsAndDefinitions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/MVF/MultipleVocabularyFacility/"/>
-		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240801/ISO11615-MedicinalProducts/"/>
+		<owl:versionIRI rdf:resource="https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240901/ISO11615-MedicinalProducts/"/>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221001/ISO11615-MedicinalProducts.rdf version of this ontology was modified to rename &apos;ingredient role&apos;s to ingredients for clarification and refine the restrictions relating ingredients to pharmaceutical products and manufactured items per discussion at the Pistoia Alliance Conference Workshop on 3 November 2022 (IDMP-298). It was also extended to include concepts such as process, manufacturing process, process identifier, batch, batch identifier, lot, lot number, and others required in support of the regulatory to manufacturing bridge use case.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20221201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to refactor concepts including substance, moiety, and add physical substance in order to distinguish specifications for substances, which is the primary perspective of the IDMP standards from physical substances, and rename product constituency to product composition, which is better understood by the user community, and to move a couple of restrictions from ingredient to substance, including strength and whether or not that substance is potentially allergenic. (IDMP-405)</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20230201/ISO11615-MedicinalProducts.rdf version of this ontology was modified to integrate additional manufacturing and packaging details required for UC-2 (IDMP-465), to make manufactured item and pharmaceutical product disjoint, but both product specifications (IDMP-466), to change the status of this ontology to &apos;release&apos; (IDMP-525), to add content related to dose forms (IDMP-531, IDMP-538), and to complete the set of ingredient roles specified in the implementation guide for ISO 11615 (IDMP-304).</skos:changeNote>
@@ -128,7 +128,7 @@
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240301/ISO11615-MedicinalProducts.rdf version of this ontology was augmented to add SKOS prefLabels for elements that have multiple labels (IDMP-734), modified to clean up URIs that had an erroneous final slash or do not resolve reliably, and rephrased the definition of &apos;marketing status reason code&apos; to be grammatically correct.</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240501/ISO11615-MedicinalProducts.rdf version of this ontology was modified to correctly represent the notion of age as a population characteristic (IDMP-682) and simplify the representation of container roles (IDMP-748).</skos:changeNote>
 		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240601/ISO11615-MedicinalProducts.rdf version of this ontology was extended to complete the details for marketing authorization (IDMP-747) and marketing status (IDMP-750).</skos:changeNote>
-		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240701/ISO11615-MedicinalProducts.rdf version of this ontology was extended to complete the details for medicinal product name (IDMP-745) and integrate revisions to the content from the 1.2 revision of the OMG Commons Ontology Library (IDMP-774).</skos:changeNote>
+		<skos:changeNote>The https://spec.pistoiaalliance.org/idmp/ontology/ISO/20240701/ISO11615-MedicinalProducts.rdf version of this ontology was extended to complete the details for medicinal product name (IDMP-745), integrate revisions to the content from the 1.2 revision of the OMG Commons Ontology Library (IDMP-774), and complete the linkage beween a manufacturer, a given business operation (facility), and the manufacturing site(s) at which a particular medicinal product (or component of a medicinal product) is manufactured (IDMP-779).</skos:changeNote>
 		<idmp-chg:hasMaturityLevel rdf:resource="&idmp-chg;Release"/>
 		<cmns-av:copyright>Copyright (c) 2022-2024 EDM Council, Inc.</cmns-av:copyright>
 		<cmns-av:copyright>Copyright (c) 2022-2024 Pistoia Alliance, Inc.</cmns-av:copyright>
@@ -314,6 +314,12 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Manufacturer">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-org;manages"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ManufacturingOrBusinessOperation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-rlcmp;isPlayedBy"/>
@@ -2384,6 +2390,25 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<cmns-av:directSource>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.5.2.3.3</cmns-av:directSource>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;ManufacturingOperationType">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:allValuesFrom rdf:resource="&idmp-mprd;ManufacturingOrBusinessOperation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>manufacturing operation type</rdfs:label>
+		<skos:definition>sequence of characters denoting the nature of the manufacturing operation and classifying it accordingly</skos:definition>
+		<skos:note>The type of manufacturing operation shall be specified using a suitable controlled vocabulary. The controlled term and the controlled term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Mandatory"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.5.2.3.2</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause B.1</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;ManufacturingOrBusinessOperation">
 		<rdfs:subClassOf rdf:resource="&cmns-prd;Facility"/>
 		<rdfs:subClassOf>
@@ -2395,9 +2420,21 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&mvf-trm;isManagedBy"/>
-				<owl:onClass rdf:resource="&cmns-org;LegalEntity"/>
+				<owl:onProperty rdf:resource="&cmns-org;isManagedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ManufacturingOperationType"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;isSituatedAt"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ManufacturingSite"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">manufacturing or business operation</rdfs:label>
@@ -2413,6 +2450,14 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<dct:source>ISO 18629-11:2005(en) Industrial automation systems and integration — Process specification language — Part 11: PSL core - https://www.iso.org/obp/ui/#iso:std:iso:18629:-11:ed-1:v1:en, clause 3.1.15</dct:source>
 		<skos:definition>structured set of activities or operations performed upon material to convert it from the raw material or a semifinished state to a state of further completion</skos:definition>
 		<skos:editorialNote>This is a starting point that requires extension to include further axioms including relationships with input and output materials, derived from ANSI/ISA S88 and the ISO Process Specification Language (PSL).</skos:editorialNote>
+		<skos:note>Manufacturing processes may be arranged in process layout, product layout, cellular layout or fixed position layout. Manufacturing processes may be planned to support make-to-stock, make-to-order, assemble-to-order, etc., based on strategic use and placements of inventories. [SOURCE:ISO 15531-1]</skos:note>
+		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-mprd;ManufacturingSite">
+		<rdfs:subClassOf rdf:resource="&cmns-prd;Site"/>
+		<rdfs:label>manufacturing site</rdfs:label>
+		<skos:definition>structured set of activities or operations performed upon material to convert it from the raw material or a semifinished state to a state of further completion</skos:definition>
 		<skos:note>Manufacturing processes may be arranged in process layout, product layout, cellular layout or fixed position layout. Manufacturing processes may be planned to support make-to-stock, make-to-order, assemble-to-order, etc., based on strategic use and placements of inventories. [SOURCE:ISO 15531-1]</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -326,13 +326,13 @@
 				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&idmp-sub;ManufacturedItem">
+							<rdf:Description rdf:about="&idmp-sub;Matter">
 							</rdf:Description>
-							<rdf:Description rdf:about="&idmp-mprd;MedicinalProduct">
+							<rdf:Description rdf:about="&idmp-sub;MaterialSpecification">
 							</rdf:Description>
-							<rdf:Description rdf:about="&idmp-mprd;PharmaceuticalProduct">
+							<rdf:Description rdf:about="&idmp-mprd;ContainerSpecification">
 							</rdf:Description>
-							<rdf:Description rdf:about="&idmp-sub;Substance">
+							<rdf:Description rdf:about="&idmp-mprd;ProductSpecification">
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
@@ -376,6 +376,13 @@
 	<owl:Class rdf:about="&idmp-sub;MaterialSpecification">
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasPhysicalCharacteristic"/>
 				<owl:onClass rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -397,6 +404,16 @@
 		</rdfs:subClassOf>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.47</dct:source>
 		<skos:note>Material is more specifically defined in ISO 11615 to be a &apos;substance or specified substance of which a certain packaging or device is made. This definition applies to a medicinal product package item (container), package (component) and device.</skos:note>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&idmp-sub;Matter">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;MechanicalIngredient">
@@ -483,6 +500,13 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;SpecifiedSubstance">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasConfidentialityIndicator"/>
+				<owl:onClass rdf:resource="&idmp-mprd;ConfidentialityIndicator"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<dct:source>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 3.1.77</dct:source>
 	</owl:Class>
 	
@@ -514,6 +538,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&idmp-sub;Substance">
+		<rdfs:subClassOf rdf:resource="&idmp-mprd;ProductSpecification"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasDefiningStrength"/>
@@ -1261,6 +1286,37 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&idmp-mprd;ConfidentialityIndicator">
+		<rdfs:subClassOf rdf:resource="&idmp-dtp;ISO21090-ConceptDescriptor"/>
+		<rdfs:subClassOf rdf:resource="&cmns-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cls;classifies"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&idmp-sub;SpecifiedSubstance">
+							</rdf:Description>
+							<rdf:Description rdf:about="&cmns-org;Organization">
+							</rdf:Description>
+							<rdf:Description rdf:about="&idmp-mprd;ManufacturingOrBusinessOperation">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>confidentiality indicator</rdfs:label>
+		<skos:definition>classifier for information about a specified substance, an organization, a manufacturing or business operation, or a contact, describing the level of confidentiality associated with information about it</skos:definition>
+		<skos:note>The confidentiality level can be specified using an appropriate controlled vocabulary. The controlled term and a term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.4.2.2.5, 9.4.2.4.5, 9.5.2.3.5, and 9.7.2.2.4, and Figures 8, 10 and 12</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses D.2.5.3, G.2.4, G.2.6.4, and H.2.1.4</cmns-av:adaptedFrom>
+		<cmns-av:usageNote>No controlled vocabulary is defined in either ISO 11615 or the ISO/TS 20443 implementation guide.</cmns-av:usageNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&idmp-mprd;Container">
 		<rdfs:subClassOf rdf:resource="&idmp-sub;Material"/>
 		<rdfs:label>container</rdfs:label>
@@ -1382,6 +1438,13 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 	
 	<owl:Class rdf:about="&idmp-mprd;ContainerSpecification">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasPhysicalCharacteristic"/>
@@ -3090,13 +3153,6 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf rdf:resource="&idmp-sub;MaterialSpecification"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
-				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-dsg;isSignifiedBy"/>
 				<owl:onClass rdf:resource="&idmp-mprd;MedicalDeviceBatchIdentifier"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -3269,13 +3325,6 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&idmp-mprd;PediatricUseIndicator"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
-				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -4006,13 +4055,6 @@ The convention applied for naming a medicinal product can differ between medicin
 		<rdfs:subClassOf rdf:resource="&idmp-sub;MaterialComponentSpecification"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
-				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasPhysicalCharacteristic"/>
 				<owl:onClass rdf:resource="&idmp-sub;PhysicalCharacteristic"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -4088,13 +4130,6 @@ The convention applied for naming a medicinal product can differ between medicin
 						</owl:unionOf>
 					</owl:Class>
 				</owl:allValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
-				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -4764,6 +4799,13 @@ The convention applied for naming a medicinal product can differ between medicin
 	
 	<owl:Class rdf:about="&idmp-mprd;ProductSpecification">
 		<rdfs:subClassOf rdf:resource="&cmns-doc;Specification"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-prd;isProducedBy"/>
+				<owl:onClass rdf:resource="&idmp-sub;Manufacturer"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasPhysicalCharacteristic"/>
@@ -5740,6 +5782,17 @@ The convention applied for naming a medicinal product can differ between medicin
 		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
 		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-ST"/>
 	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;hasConfidentialityIndicator">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cls;isClassifiedBy"/>
+		<rdfs:label>has confidentiality indicator</rdfs:label>
+		<skos:definition>relates information about a specified substance, an organization, a manufacturing or business operation, or a contact to a classifier describing the level of confidentiality associated with information about it</skos:definition>
+		<skos:note>The confidentiality level can be specified using an appropriate controlled vocabulary. The controlled term and a term identifier shall be specified.</skos:note>
+		<idmp-sub:hasConformanceLevel rdf:resource="&idmp-sub;ConformanceLevel-Conditional"/>
+		<idmp-dtp:isEncodedAs rdf:resource="&idmp-dtp;DatatypeCode-CD"/>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses 9.4.2.2.5, 9.4.2.4.5, 9.5.2.3.5, and 9.7.2.2.4, and Figures 8, 10 and 12</cmns-av:adaptedFrom>
+		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clauses D.2.5.3, G.2.4, G.2.6.4, and H.2.1.4</cmns-av:adaptedFrom>
+	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&idmp-mprd;hasContainerPart">
 		<rdfs:subPropertyOf rdf:resource="&mvf;hasTextualName"/>
@@ -6751,7 +6804,7 @@ The convention applied for naming a medicinal product can differ between medicin
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, figure 11</cmns-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&idmp-mprd;isProducedATManufacturingSite">
+	<owl:ObjectProperty rdf:about="&idmp-mprd;isProducedAtManufacturingSite">
 		<rdfs:label>is produced at manufacturing site</rdfs:label>
 		<owl:propertyChainAxiom rdf:parseType="Collection">
 			<rdf:Description rdf:about="&cmns-prd;isProducedBy">
@@ -6831,11 +6884,20 @@ The convention applied for naming a medicinal product can differ between medicin
 	<owl:Class rdf:about="&cmns-org;LegalEntity">
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;hasConfidentialityIndicator"/>
+				<owl:onClass rdf:resource="&idmp-mprd;ConfidentialityIndicator"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cls;isClassifiedBy"/>
 				<owl:onClass rdf:resource="&idmp-mprd;SmallToMediumEnterprise"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<skos:note>The confidentiality level of the organization information can be specified using an appropriate controlled vocabulary. The controlled term and a term identifier shall be specified.</skos:note>
+		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated medicinal product information, clause 9.4.2.2.5</cmns-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&mvf-tsc;TerminologyWork">

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2354,6 +2354,12 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ManufacturingOrBusinessOperation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -2361,6 +2367,12 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&cmns-cxtdsg;isApplicableIn"/>
 				<owl:someValuesFrom rdf:resource="&cmns-loc;GeographicRegion"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&cmns-pts;holdsDuring"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ValidityPeriod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-GB">manufacturing authorisation</rdfs:label>
@@ -2438,7 +2450,8 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">manufacturing or business operation</rdfs:label>
-		<skos:definition>facility (operation) managed by a given entity that provides some operational capability</skos:definition>
+		<skos:definition>facility (operation) managed by a given manufacturer that provides some operational capability</skos:definition>
+		<skos:note>The manufacturing/business operation being undertaken by the particular manufacturer/establishment (organisation) shall be specified.</skos:note>
 		<cmns-av:adaptedFrom>ISO 11615:2017 Health informatics - Identification of medicinal products (IDMP) - Data elements and structures for the unique identification and exchange of regulated information on substances, clause 9.5.2.3</cmns-av:adaptedFrom>
 		<cmns-av:adaptedFrom>ISO/TS 20443:2018(E) Health informatics - Identification of medicinal products (IDMP) - Implementation guidelines for ISO 11615 data elements and structures for the unique identification and exchange of regulated medicinal product information, clause B.1</cmns-av:adaptedFrom>
 		<cmns-av:synonym xml:lang="en">manufacturing / business operation</cmns-av:synonym>
@@ -2457,8 +2470,8 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 	<owl:Class rdf:about="&idmp-mprd;ManufacturingSite">
 		<rdfs:subClassOf rdf:resource="&cmns-prd;Site"/>
 		<rdfs:label>manufacturing site</rdfs:label>
-		<skos:definition>structured set of activities or operations performed upon material to convert it from the raw material or a semifinished state to a state of further completion</skos:definition>
-		<skos:note>Manufacturing processes may be arranged in process layout, product layout, cellular layout or fixed position layout. Manufacturing processes may be planned to support make-to-stock, make-to-order, assemble-to-order, etc., based on strategic use and placements of inventories. [SOURCE:ISO 15531-1]</skos:note>
+		<skos:definition>place, setting, or context in which a manufacturing or business operation is situated</skos:definition>
+		<skos:note>A given manufacturing site may be associated with one or more manufacturing or business operations (facilities). A given facility (manufacturing or business operation) may span multiple manufacturing sites.</skos:note>
 		<idmp-cmpl:hasConformanceToISOLevel rdf:resource="&idmp-cmpl;ConformanceToISOLevel-Extension"/>
 	</owl:Class>
 	

--- a/ISO/ISO11615-MedicinalProducts.rdf
+++ b/ISO/ISO11615-MedicinalProducts.rdf
@@ -2341,6 +2341,18 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;authorizesManufacturingAt"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;ManufacturingOrBusinessOperation"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&idmp-mprd;authorizesManufacturingOf"/>
+				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasAuthorizedParty"/>
 				<owl:someValuesFrom rdf:resource="&idmp-sub;Manufacturer"/>
 			</owl:Restriction>
@@ -2349,18 +2361,6 @@ d) the assignment of a unique medicinal product batch identifier (BAID2) to reli
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&idmp-mprd;hasAuthorizingParty"/>
 				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinesRegulatoryAgency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;ManufacturingOrBusinessOperation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&cmns-cxtdsg;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&idmp-mprd;MedicinalProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -5527,6 +5527,22 @@ The convention applied for naming a medicinal product can differ between medicin
 		<rdfs:range rdf:resource="&idmp-mprd;AuthorizedParty"/>
 		<owl:inverseOf rdf:resource="&idmp-mprd;isAuthorizedBy"/>
 		<skos:definition>endorses, enables, empowers, or gives permission to</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;authorizesManufacturingAt">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;appliesTo"/>
+		<rdfs:label>authorizes manufacturing at</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;ManufacturingAuthorization"/>
+		<rdfs:range rdf:resource="&idmp-mprd;ManufacturingOrBusinessOperation"/>
+		<skos:definition>gives permission to manufacture at</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&idmp-mprd;authorizesManufacturingOf">
+		<rdfs:subPropertyOf rdf:resource="&cmns-cxtdsg;appliesTo"/>
+		<rdfs:label>authorizes manufacturing of</rdfs:label>
+		<rdfs:domain rdf:resource="&idmp-mprd;ManufacturingAuthorization"/>
+		<rdfs:range rdf:resource="&idmp-mprd;MedicinalProduct"/>
+		<skos:definition>gives permission to manufacture</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&idmp-mprd;authorizesThrough">


### PR DESCRIPTION
Description:
1. Augmented the definition of manufacturing or business operation to include the classifier for type of operation
2. Added connections between the manufacturing authorization and the manufacturing or business operation as well as to the medicinal product
3. Expanded the notion of a manufacturing authorization to allow for parts of a medicinal product (i.e., manufactured items)
4. Added several property chains connecting manufacturers , facilities (manufacturing or business operations), sites, connecting products to the sites and facilities that produce them, and so forth
5. cleaned up certain restrictions related to manufacturers, linked them to the legal entities (organizations) that play them, added the notion of a confidentiality indicator, including the classifier, property and restrictions to connect them appropriately, and simplified the class hierarchy related to the things that manufacturers produce for ease in query development
6. corrected a restriction on manufactured item related to dose form